### PR TITLE
feat: 404 analysis abilities — closes #13

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -29,6 +29,14 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/gtm.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-analytics-summary.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-summary.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-top-urls.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-patterns.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/drill-404-category.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/list-404-events.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/purge-404-events.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-top-ips.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-categorizer.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-tracking.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/email-tracking.php';
 

--- a/inc/core/404-categorizer.php
+++ b/inc/core/404-categorizer.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * 404 URL Categorizer
+ *
+ * Shared helper functions for categorizing and analyzing 404 URLs.
+ * Extracted from CLI command logic into reusable functions that
+ * abilities, CLI, and REST endpoints can all consume.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Categorize a 404 URL into a named pattern category.
+ *
+ * Order matters — specific patterns are checked before general ones.
+ *
+ * @param string $url The requested URL path.
+ * @return string Category name.
+ */
+function extrachill_analytics_categorize_404_url( $url ) {
+	$url_lower = strtolower( $url );
+
+	// SQL injection attempts.
+	if ( preg_match( '/select\(|sleep\(|union\+select|1\'"/i', $url ) ) {
+		return 'sql-injection';
+	}
+
+	// Ad/sponsor/media-kit probe — multilingual about/contact/advertising pages.
+	$ad_sponsor_paths = array(
+		'/mediakit',
+		'/media-kit',
+		'/publicite',
+		'/publicidad',
+		'/werbung',
+		'/rate-card',
+		'/advertise',
+		'/advertise-with-us',
+		'/sponsors',
+		'/sponsorship',
+		'/partnerships',
+		'/partner-with-us',
+		'/about-us',
+		'/aboutus',
+		'/our-team',
+		'/team',
+		'/kontakt',
+		'/impressum',
+		'/chi-siamo',
+		'/over-ons',
+		'/ueber-uns',
+		'/uber-uns',
+		'/get-in-touch',
+		'/contactus',
+		'/reach-us',
+		'/inquiry',
+		'/a-propos',
+		'/sobre',
+		'/sobre-nosotros',
+		'/contato',
+		'/anuncie',
+		'/pubblicita',
+		'/mediadaten',
+		'/contatti',
+		'/fale-conosco',
+		'/neem-contact-op',
+		'/expediente',
+		'/ficha-tecnica',
+		'/institucional',
+		'/instituicao',
+		'/nosotros',
+		'/contacto',
+		'/nous-contacter',
+		'/qui-sommes-nous',
+		'/enquiry',
+		'/publicidade',
+	);
+
+	$path_no_trailing = rtrim( $url_lower, '/' );
+	foreach ( $ad_sponsor_paths as $ad_path ) {
+		if ( $path_no_trailing === $ad_path ) {
+			return 'ad-sponsor-probe';
+		}
+	}
+
+	// Legacy HTML pages.
+	if ( false !== strpos( $url_lower, '.html' ) ) {
+		return 'legacy-html';
+	}
+
+	// Missing uploads.
+	if ( 0 === strpos( $url, '/wp-content/uploads/' ) ) {
+		return 'missing-upload';
+	}
+
+	// Plugin probes.
+	if ( 0 === strpos( $url, '/wp-content/plugins/' ) ) {
+		return 'plugin-probe';
+	}
+
+	// wp-includes probes.
+	if ( 0 === strpos( $url, '/wp-includes/' ) ) {
+		return 'wp-includes-probe';
+	}
+
+	// PHP file probes (case-insensitive, optional digit suffix).
+	if ( preg_match( '/\.ph[pP]\d?/i', $url ) ) {
+		return 'php-probe';
+	}
+
+	// Ad/txt standard files.
+	$ad_txt_paths = array( '/ads.txt', '/app-ads.txt', '/sellers.json', '/security.txt' );
+	if ( in_array( $url_lower, $ad_txt_paths, true ) ) {
+		return 'ad-txt';
+	}
+
+	// Bot probes — common attack/scan paths.
+	$bot_paths = array( '/login/', '/admin/', '/cgi-bin/', '/getcmd/', '/ip', '/xmlrpc/' );
+	if ( in_array( $url_lower, $bot_paths, true ) ) {
+		return 'bot-probe';
+	}
+
+	// Author enumeration.
+	if ( preg_match( '#^/?\?author=#', $url ) ) {
+		return 'author-enum';
+	}
+
+	// Old sitemap URLs.
+	if ( 0 === strpos( $url_lower, '/sitemap' ) ) {
+		return 'old-sitemap';
+	}
+
+	// Community thread URLs.
+	if ( 0 === strpos( $url, '/t/' ) ) {
+		return 'community-thread';
+	}
+
+	// Events URLs.
+	if ( 0 === strpos( $url, '/events/' ) ) {
+		return 'events';
+	}
+
+	// Festival URLs.
+	if ( 0 === strpos( $url_lower, '/festival' ) ) {
+		return 'festival';
+	}
+
+	// Date-prefixed content (e.g. /2023/04/post-slug).
+	if ( preg_match( '#^/\d{4}/\d{2}/#', $url ) ) {
+		return 'date-prefix';
+	}
+
+	// Join page.
+	if ( '/join' === $path_no_trailing ) {
+		return 'join-page';
+	}
+
+	// Everything else is content.
+	return 'content';
+}
+
+/**
+ * Check if a 404 category is actionable (could potentially be fixed with redirects, etc.).
+ *
+ * @param string $category The category name from extrachill_analytics_categorize_404_url().
+ * @return bool True if the category is actionable.
+ */
+function extrachill_analytics_is_actionable_404_category( $category ) {
+	$actionable = array(
+		'legacy-html',
+		'content',
+		'date-prefix',
+		'missing-upload',
+		'ad-txt',
+		'community-thread',
+		'events',
+		'festival',
+		'old-sitemap',
+		'join-page',
+	);
+
+	return in_array( $category, $actionable, true );
+}
+
+/**
+ * Extract a post slug from a 404 URL.
+ *
+ * Strips query strings, .html suffixes, date prefixes (/YYYY/MM/),
+ * and takes the last path segment.
+ *
+ * @param string $url The requested URL path.
+ * @return string Sanitized slug.
+ */
+function extrachill_analytics_extract_404_slug( $url ) {
+	// Remove query string.
+	$path = strtok( $url, '?' );
+
+	// Remove .html suffix.
+	$path = preg_replace( '/\.html$/i', '', $path );
+
+	// Remove date prefix /YYYY/MM/.
+	$path = preg_replace( '#^/\d{4}/\d{2}/#', '/', $path );
+
+	// Take the last non-empty segment.
+	$segments = array_filter( explode( '/', $path ) );
+	$slug     = ! empty( $segments ) ? end( $segments ) : '';
+
+	return sanitize_title( $slug );
+}
+
+/**
+ * Find a published post by slug.
+ *
+ * @param string $slug The post slug to search for.
+ * @return int|false Post ID on success, false if not found.
+ */
+function extrachill_analytics_find_post_by_slug( $slug ) {
+	if ( empty( $slug ) ) {
+		return false;
+	}
+
+	$posts = get_posts(
+		array(
+			'name'           => $slug,
+			'post_type'      => array( 'post', 'page' ),
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+		)
+	);
+
+	return ! empty( $posts ) ? $posts[0] : false;
+}

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -13,6 +13,13 @@ defined( 'ABSPATH' ) || exit;
 add_action( 'wp_abilities_api_categories_init', 'extrachill_analytics_register_category' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_abilities' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_summary_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_404_summary_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_404_top_urls_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_404_patterns_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_drill_404_category_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_list_404_events_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_purge_404_events_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_404_top_ips_ability' );
 
 /**
  * Register analytics ability category.

--- a/inc/core/abilities/drill-404-category.php
+++ b/inc/core/abilities/drill-404-category.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Drill 404 Category Ability
+ *
+ * Read-side ability that drills into a specific 404 category,
+ * showing individual URLs and optional redirect suggestions.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the drill-404-category ability.
+ */
+function extrachill_analytics_register_drill_404_category_ability() {
+	wp_register_ability(
+		'extrachill/drill-404-category',
+		array(
+			'label'       => __( 'Drill 404 Category', 'extrachill-analytics' ),
+			'description' => __( 'Drills into a specific 404 category showing individual URLs with optional redirect suggestions.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'category' => array(
+						'type'        => 'string',
+						'description' => __( 'Category name to drill into (e.g. legacy-html, content, bot-probe).', 'extrachill-analytics' ),
+					),
+					'days'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back.', 'extrachill-analytics' ),
+						'default'     => 7,
+					),
+					'blog_id'  => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for all sites.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Maximum number of URLs to return.', 'extrachill-analytics' ),
+						'default'     => 20,
+					),
+				),
+				'required' => array( 'category' ),
+			),
+			'output_schema' => array(
+				'type'        => 'array',
+				'description' => __( 'Array of URLs in the category with hits, last_seen, and optional slug/post_id/fixable fields.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_drill_404_category',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for drill-404-category ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Array of URL objects within the requested category.
+ */
+function extrachill_analytics_ability_drill_404_category( $input ) {
+	global $wpdb;
+
+	$category = isset( $input['category'] ) ? sanitize_key( $input['category'] ) : '';
+	$days     = isset( $input['days'] ) ? (int) $input['days'] : 7;
+	$blog_id  = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+	$limit    = isset( $input['limit'] ) ? (int) $input['limit'] : 20;
+
+	if ( empty( $category ) ) {
+		return array();
+	}
+
+	$table  = extrachill_analytics_events_table();
+	$where  = array( "event_type = '404_error'" );
+	$values = array();
+
+	if ( $days > 0 ) {
+		$where[]  = 'created_at >= %s';
+		$values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+	}
+
+	if ( $blog_id > 0 ) {
+		$where[]  = 'blog_id = %d';
+		$values[] = $blog_id;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$sql = "SELECT
+		JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.requested_url')) AS url,
+		COUNT(*) AS hits,
+		MAX(created_at) AS last_seen
+		FROM {$table}
+		WHERE {$where_clause}
+		GROUP BY url
+		ORDER BY hits DESC";
+
+	if ( ! empty( $values ) ) {
+		$rows = $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+	} else {
+		$rows = $wpdb->get_results( $sql );
+	}
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	// Categories that are candidates for redirect suggestions.
+	$redirect_categories = array( 'legacy-html', 'content', 'date-prefix' );
+	$is_redirect_candidate = in_array( $category, $redirect_categories, true );
+
+	// Filter by category and slice to limit.
+	$results = array();
+	foreach ( $rows as $row ) {
+		$row_category = extrachill_analytics_categorize_404_url( $row->url );
+		if ( $row_category !== $category ) {
+			continue;
+		}
+
+		$item = array(
+			'url'       => $row->url,
+			'hits'      => (int) $row->hits,
+			'last_seen' => $row->last_seen,
+		);
+
+		if ( $is_redirect_candidate ) {
+			$slug    = extrachill_analytics_extract_404_slug( $row->url );
+			$post_id = extrachill_analytics_find_post_by_slug( $slug );
+
+			$item['slug']    = $slug;
+			$item['post_id'] = $post_id ? $post_id : null;
+			$item['fixable'] = false !== $post_id;
+		}
+
+		$results[] = $item;
+
+		if ( count( $results ) >= $limit ) {
+			break;
+		}
+	}
+
+	return $results;
+}

--- a/inc/core/abilities/get-404-patterns.php
+++ b/inc/core/abilities/get-404-patterns.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Get 404 Patterns Ability
+ *
+ * Read-side ability that aggregates 404 URLs by pattern category,
+ * showing the distribution of error types.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-404-patterns ability.
+ */
+function extrachill_analytics_register_404_patterns_ability() {
+	wp_register_ability(
+		'extrachill/get-404-patterns',
+		array(
+			'label'       => __( 'Get 404 Patterns', 'extrachill-analytics' ),
+			'description' => __( 'Aggregates 404 URLs by pattern category with hit counts and percentages.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back.', 'extrachill-analytics' ),
+						'default'     => 7,
+					),
+					'blog_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for all sites.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+				),
+			),
+			'output_schema' => array(
+				'type'        => 'array',
+				'description' => __( 'Array of pattern categories with hits, unique_urls, pct, and actionable flag.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_404_patterns',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-404-patterns ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Array of category aggregation objects.
+ */
+function extrachill_analytics_ability_get_404_patterns( $input ) {
+	global $wpdb;
+
+	$days    = isset( $input['days'] ) ? (int) $input['days'] : 7;
+	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+
+	$table  = extrachill_analytics_events_table();
+	$where  = array( "event_type = '404_error'" );
+	$values = array();
+
+	if ( $days > 0 ) {
+		$where[]  = 'created_at >= %s';
+		$values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+	}
+
+	if ( $blog_id > 0 ) {
+		$where[]  = 'blog_id = %d';
+		$values[] = $blog_id;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$sql = "SELECT
+		JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.requested_url')) AS url,
+		COUNT(*) AS hits
+		FROM {$table}
+		WHERE {$where_clause}
+		GROUP BY url
+		ORDER BY hits DESC";
+
+	if ( ! empty( $values ) ) {
+		$rows = $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+	} else {
+		$rows = $wpdb->get_results( $sql );
+	}
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	// Aggregate by category.
+	$categories  = array();
+	$total_hits  = 0;
+
+	foreach ( $rows as $row ) {
+		$category = extrachill_analytics_categorize_404_url( $row->url );
+		$hits     = (int) $row->hits;
+		$total_hits += $hits;
+
+		if ( ! isset( $categories[ $category ] ) ) {
+			$categories[ $category ] = array(
+				'hits'        => 0,
+				'unique_urls' => 0,
+			);
+		}
+
+		$categories[ $category ]['hits']        += $hits;
+		$categories[ $category ]['unique_urls'] += 1;
+	}
+
+	// Build output sorted by hits descending.
+	$results = array();
+	foreach ( $categories as $category => $data ) {
+		$results[] = array(
+			'category'    => $category,
+			'hits'        => $data['hits'],
+			'unique_urls' => $data['unique_urls'],
+			'pct'         => $total_hits > 0 ? round( ( $data['hits'] / $total_hits ) * 100, 1 ) : 0.0,
+			'actionable'  => extrachill_analytics_is_actionable_404_category( $category ),
+		);
+	}
+
+	usort(
+		$results,
+		function ( $a, $b ) {
+			return $b['hits'] - $a['hits'];
+		}
+	);
+
+	return $results;
+}

--- a/inc/core/abilities/get-404-summary.php
+++ b/inc/core/abilities/get-404-summary.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Get 404 Summary Ability
+ *
+ * Read-side ability that returns 404 error summary statistics
+ * including totals, unique counts, and daily breakdown.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-404-summary ability.
+ */
+function extrachill_analytics_register_404_summary_ability() {
+	wp_register_ability(
+		'extrachill/get-404-summary',
+		array(
+			'label'       => __( 'Get 404 Summary', 'extrachill-analytics' ),
+			'description' => __( 'Returns 404 error summary statistics with totals, unique counts, and daily breakdown.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back.', 'extrachill-analytics' ),
+						'default'     => 7,
+					),
+					'blog_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for all sites.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+				),
+			),
+			'output_schema' => array(
+				'type'        => 'object',
+				'description' => __( 'Summary with total, unique URLs/IPs, daily average, and daily breakdown.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_404_summary',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-404-summary ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Summary data.
+ */
+function extrachill_analytics_ability_get_404_summary( $input ) {
+	global $wpdb;
+
+	$days    = isset( $input['days'] ) ? (int) $input['days'] : 7;
+	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+
+	$table  = extrachill_analytics_events_table();
+	$where  = array( "event_type = '404_error'" );
+	$values = array();
+
+	if ( $days > 0 ) {
+		$where[]  = 'created_at >= %s';
+		$values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+	}
+
+	if ( $blog_id > 0 ) {
+		$where[]  = 'blog_id = %d';
+		$values[] = $blog_id;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+
+	// Total count.
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$total_sql = "SELECT COUNT(*) FROM {$table} WHERE {$where_clause}";
+	if ( ! empty( $values ) ) {
+		$total = (int) $wpdb->get_var( $wpdb->prepare( $total_sql, $values ) );
+	} else {
+		$total = (int) $wpdb->get_var( $total_sql );
+	}
+
+	// Unique URLs.
+	$unique_urls_sql = "SELECT COUNT(DISTINCT JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.requested_url'))) FROM {$table} WHERE {$where_clause}";
+	if ( ! empty( $values ) ) {
+		$unique_urls = (int) $wpdb->get_var( $wpdb->prepare( $unique_urls_sql, $values ) );
+	} else {
+		$unique_urls = (int) $wpdb->get_var( $unique_urls_sql );
+	}
+
+	// Unique IPs.
+	$unique_ips_sql = "SELECT COUNT(DISTINCT JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.ip_hash'))) FROM {$table} WHERE {$where_clause}";
+	if ( ! empty( $values ) ) {
+		$unique_ips = (int) $wpdb->get_var( $wpdb->prepare( $unique_ips_sql, $values ) );
+	} else {
+		$unique_ips = (int) $wpdb->get_var( $unique_ips_sql );
+	}
+
+	// Daily breakdown.
+	$daily_sql = "SELECT DATE(created_at) as date, COUNT(*) as hits FROM {$table} WHERE {$where_clause} GROUP BY DATE(created_at) ORDER BY date DESC";
+	if ( ! empty( $values ) ) {
+		$daily_rows = $wpdb->get_results( $wpdb->prepare( $daily_sql, $values ) );
+	} else {
+		$daily_rows = $wpdb->get_results( $daily_sql );
+	}
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	$daily = array();
+	foreach ( $daily_rows as $row ) {
+		$daily[] = array(
+			'date' => $row->date,
+			'hits'  => (int) $row->hits,
+		);
+	}
+
+	$per_day_avg = $days > 0 ? round( $total / $days, 2 ) : (float) $total;
+
+	return array(
+		'total'       => $total,
+		'unique_urls' => $unique_urls,
+		'unique_ips'  => $unique_ips,
+		'per_day_avg' => $per_day_avg,
+		'days'        => $days,
+		'period'      => $days > 0
+			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
+			: 'all time',
+		'daily'       => $daily,
+	);
+}

--- a/inc/core/abilities/get-404-top-ips.php
+++ b/inc/core/abilities/get-404-top-ips.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Get 404 Top IPs Ability
+ *
+ * Read-side ability that returns the top IP addresses (hashed)
+ * generating 404 errors with hit counts and metadata.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-404-top-ips ability.
+ */
+function extrachill_analytics_register_404_top_ips_ability() {
+	wp_register_ability(
+		'extrachill/get-404-top-ips',
+		array(
+			'label'       => __( 'Get 404 Top IPs', 'extrachill-analytics' ),
+			'description' => __( 'Returns the top IP addresses (hashed) generating 404 errors with hit counts and metadata.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back.', 'extrachill-analytics' ),
+						'default'     => 7,
+					),
+					'blog_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for all sites.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'limit'   => array(
+						'type'        => 'integer',
+						'description' => __( 'Maximum number of IPs to return.', 'extrachill-analytics' ),
+						'default'     => 15,
+					),
+				),
+			),
+			'output_schema' => array(
+				'type'        => 'array',
+				'description' => __( 'Array of top IP hashes with hits, unique_urls, first_seen, last_seen, and top_ua.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_404_top_ips',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-404-top-ips ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Array of top IP objects.
+ */
+function extrachill_analytics_ability_get_404_top_ips( $input ) {
+	global $wpdb;
+
+	$days    = isset( $input['days'] ) ? (int) $input['days'] : 7;
+	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+	$limit   = isset( $input['limit'] ) ? (int) $input['limit'] : 15;
+
+	$table  = extrachill_analytics_events_table();
+	$where  = array( "event_type = '404_error'" );
+	$values = array();
+
+	if ( $days > 0 ) {
+		$where[]  = 'created_at >= %s';
+		$values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+	}
+
+	if ( $blog_id > 0 ) {
+		$where[]  = 'blog_id = %d';
+		$values[] = $blog_id;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+
+	$values[] = $limit;
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$sql = "SELECT
+		JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.ip_hash')) AS ip_hash,
+		COUNT(*) AS hits,
+		COUNT(DISTINCT JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.requested_url'))) AS unique_urls,
+		MIN(created_at) AS first_seen,
+		MAX(created_at) AS last_seen
+		FROM {$table}
+		WHERE {$where_clause}
+		GROUP BY ip_hash
+		ORDER BY hits DESC
+		LIMIT %d";
+
+	$rows = $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	$results = array();
+	foreach ( $rows as $row ) {
+		// Second pass: find the most common user agent for this IP.
+		$ua_values = array();
+		$ua_where  = array( "event_type = '404_error'" );
+
+		$ua_where[]  = "JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.ip_hash')) = %s";
+		$ua_values[] = $row->ip_hash;
+
+		if ( $days > 0 ) {
+			$ua_where[]  = 'created_at >= %s';
+			$ua_values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+		}
+
+		if ( $blog_id > 0 ) {
+			$ua_where[]  = 'blog_id = %d';
+			$ua_values[] = $blog_id;
+		}
+
+		$ua_where_clause = implode( ' AND ', $ua_where );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$ua_sql = "SELECT
+			JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.user_agent')) AS ua,
+			COUNT(*) AS cnt
+			FROM {$table}
+			WHERE {$ua_where_clause}
+			GROUP BY ua
+			ORDER BY cnt DESC
+			LIMIT 1";
+
+		$top_ua_row = $wpdb->get_row( $wpdb->prepare( $ua_sql, $ua_values ) );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$results[] = array(
+			'ip_hash'     => $row->ip_hash,
+			'hits'        => (int) $row->hits,
+			'unique_urls' => (int) $row->unique_urls,
+			'first_seen'  => $row->first_seen,
+			'last_seen'   => $row->last_seen,
+			'top_ua'      => $top_ua_row ? $top_ua_row->ua : '',
+		);
+	}
+
+	return $results;
+}

--- a/inc/core/abilities/get-404-top-urls.php
+++ b/inc/core/abilities/get-404-top-urls.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Get 404 Top URLs Ability
+ *
+ * Read-side ability that returns the most frequently hit 404 URLs
+ * with hit counts, last-seen timestamps, and category classification.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-404-top-urls ability.
+ */
+function extrachill_analytics_register_404_top_urls_ability() {
+	wp_register_ability(
+		'extrachill/get-404-top-urls',
+		array(
+			'label'       => __( 'Get 404 Top URLs', 'extrachill-analytics' ),
+			'description' => __( 'Returns the most frequently hit 404 URLs with counts and categories.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back.', 'extrachill-analytics' ),
+						'default'     => 7,
+					),
+					'blog_id'  => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for all sites.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Maximum number of URLs to return.', 'extrachill-analytics' ),
+						'default'     => 30,
+					),
+					'min_hits' => array(
+						'type'        => 'integer',
+						'description' => __( 'Minimum number of hits to include a URL.', 'extrachill-analytics' ),
+						'default'     => 2,
+					),
+				),
+			),
+			'output_schema' => array(
+				'type'        => 'array',
+				'description' => __( 'Array of top 404 URLs with url, hits, last_seen, and category.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_404_top_urls',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-404-top-urls ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Array of top URL objects.
+ */
+function extrachill_analytics_ability_get_404_top_urls( $input ) {
+	global $wpdb;
+
+	$days     = isset( $input['days'] ) ? (int) $input['days'] : 7;
+	$blog_id  = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+	$limit    = isset( $input['limit'] ) ? (int) $input['limit'] : 30;
+	$min_hits = isset( $input['min_hits'] ) ? (int) $input['min_hits'] : 2;
+
+	$table  = extrachill_analytics_events_table();
+	$where  = array( "event_type = '404_error'" );
+	$values = array();
+
+	if ( $days > 0 ) {
+		$where[]  = 'created_at >= %s';
+		$values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+	}
+
+	if ( $blog_id > 0 ) {
+		$where[]  = 'blog_id = %d';
+		$values[] = $blog_id;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+
+	$values[] = $min_hits;
+	$values[] = $limit;
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$sql = "SELECT
+		JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.requested_url')) AS url,
+		COUNT(*) AS hits,
+		MAX(created_at) AS last_seen
+		FROM {$table}
+		WHERE {$where_clause}
+		GROUP BY url
+		HAVING hits >= %d
+		ORDER BY hits DESC
+		LIMIT %d";
+
+	$rows = $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	$results = array();
+	foreach ( $rows as $row ) {
+		$results[] = array(
+			'url'       => $row->url,
+			'hits'      => (int) $row->hits,
+			'last_seen' => $row->last_seen,
+			'category'  => extrachill_analytics_categorize_404_url( $row->url ),
+		);
+	}
+
+	return $results;
+}

--- a/inc/core/abilities/list-404-events.php
+++ b/inc/core/abilities/list-404-events.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * List 404 Events Ability
+ *
+ * Read-side ability that returns raw 404 event records
+ * with full event data fields.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the list-404-events ability.
+ */
+function extrachill_analytics_register_list_404_events_ability() {
+	wp_register_ability(
+		'extrachill/list-404-events',
+		array(
+			'label'       => __( 'List 404 Events', 'extrachill-analytics' ),
+			'description' => __( 'Returns raw 404 event records with URL, referer, user agent, IP hash, and date.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back.', 'extrachill-analytics' ),
+						'default'     => 7,
+					),
+					'blog_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for all sites.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'limit'   => array(
+						'type'        => 'integer',
+						'description' => __( 'Maximum number of events to return.', 'extrachill-analytics' ),
+						'default'     => 50,
+					),
+				),
+			),
+			'output_schema' => array(
+				'type'        => 'array',
+				'description' => __( 'Array of 404 event records.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_list_404_events',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for list-404-events ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Array of event records.
+ */
+function extrachill_analytics_ability_list_404_events( $input ) {
+	$days    = isset( $input['days'] ) ? (int) $input['days'] : 7;
+	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+	$limit   = isset( $input['limit'] ) ? (int) $input['limit'] : 50;
+
+	$args = array(
+		'event_type' => '404_error',
+		'limit'      => $limit,
+		'orderby'    => 'created_at',
+		'order'      => 'DESC',
+	);
+
+	if ( $days > 0 ) {
+		$args['date_from'] = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+	}
+
+	if ( $blog_id > 0 ) {
+		$args['blog_id'] = $blog_id;
+	}
+
+	$events  = extrachill_get_analytics_events( $args );
+	$results = array();
+
+	foreach ( $events as $event ) {
+		$data = is_array( $event->event_data ) ? $event->event_data : array();
+
+		$results[] = array(
+			'url'        => isset( $data['requested_url'] ) ? $data['requested_url'] : '',
+			'referer'    => isset( $data['referer'] ) ? $data['referer'] : '',
+			'user_agent' => isset( $data['user_agent'] ) ? $data['user_agent'] : '',
+			'ip_hash'    => isset( $data['ip_hash'] ) ? $data['ip_hash'] : '',
+			'date'       => $event->created_at,
+			'blog_id'    => (int) $event->blog_id,
+		);
+	}
+
+	return $results;
+}

--- a/inc/core/abilities/purge-404-events.php
+++ b/inc/core/abilities/purge-404-events.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Purge 404 Events Ability
+ *
+ * Write-side ability that deletes old 404 error events
+ * from the analytics database. Supports dry-run mode.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the purge-404-events ability.
+ */
+function extrachill_analytics_register_purge_404_events_ability() {
+	wp_register_ability(
+		'extrachill/purge-404-events',
+		array(
+			'label'       => __( 'Purge 404 Events', 'extrachill-analytics' ),
+			'description' => __( 'Deletes old 404 error events from the analytics database. Supports dry-run mode.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Delete events older than this many days.', 'extrachill-analytics' ),
+						'default'     => 30,
+					),
+					'blog_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for all sites.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'dry_run' => array(
+						'type'        => 'boolean',
+						'description' => __( 'If true, only count without deleting.', 'extrachill-analytics' ),
+						'default'     => true,
+					),
+				),
+			),
+			'output_schema' => array(
+				'type'        => 'object',
+				'description' => __( 'Object with count of affected events and whether deletion occurred.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_purge_404_events',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => false,
+					'destructive' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for purge-404-events ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Result with count and deleted flag.
+ */
+function extrachill_analytics_ability_purge_404_events( $input ) {
+	global $wpdb;
+
+	$days    = isset( $input['days'] ) ? (int) $input['days'] : 30;
+	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+	$dry_run = isset( $input['dry_run'] ) ? (bool) $input['dry_run'] : true;
+
+	$table  = extrachill_analytics_events_table();
+	$where  = array( "event_type = '404_error'" );
+	$values = array();
+
+	if ( $days > 0 ) {
+		$where[]  = 'created_at < %s';
+		$values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+	}
+
+	if ( $blog_id > 0 ) {
+		$where[]  = 'blog_id = %d';
+		$values[] = $blog_id;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+
+	// Count matching events.
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$count_sql = "SELECT COUNT(*) FROM {$table} WHERE {$where_clause}";
+	if ( ! empty( $values ) ) {
+		$count = (int) $wpdb->get_var( $wpdb->prepare( $count_sql, $values ) );
+	} else {
+		$count = (int) $wpdb->get_var( $count_sql );
+	}
+
+	if ( $dry_run || 0 === $count ) {
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return array(
+			'count'   => $count,
+			'deleted' => false,
+		);
+	}
+
+	// Perform deletion.
+	$delete_sql = "DELETE FROM {$table} WHERE {$where_clause}";
+	if ( ! empty( $values ) ) {
+		$wpdb->query( $wpdb->prepare( $delete_sql, $values ) );
+	} else {
+		$wpdb->query( $delete_sql );
+	}
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	return array(
+		'count'   => $count,
+		'deleted' => true,
+	);
+}


### PR DESCRIPTION
## Summary

- **7 new abilities** registered via the WordPress Abilities API for 404 error analysis
- **Shared categorizer** extracted into `inc/core/404-categorizer.php` with 18 URL pattern categories
- **New primitive**: `extrachill/get-404-top-ips` for identifying concentrated attack sources (e.g., the Apr 15 spike was 1 IP doing 7,064 requests)
- **New categories**: `sql-injection` and `ad-sponsor-probe` (multilingual about/contact/ad page scanner)

## Abilities Added

| Ability | Type | Purpose |
|---|---|---|
| `extrachill/get-404-summary` | read | Totals, unique URLs/IPs, daily breakdown |
| `extrachill/get-404-top-urls` | read | Top URLs by hit count with category |
| `extrachill/get-404-patterns` | read | Category aggregation with actionable flag |
| `extrachill/drill-404-category` | read | Drill into category with redirect candidates |
| `extrachill/list-404-events` | read | Raw event stream |
| `extrachill/purge-404-events` | write | Cleanup old events (destructive) |
| `extrachill/get-404-top-ips` | read | Top IPs with hit count, unique URLs, UA |

## Architecture

All query logic lives in the ability execute callbacks. CLI (`extrachill-cli`) and future REST routes (`extrachill-api`) are thin wrappers that call `wp_get_ability()->execute()`.

Follows the existing `get-analytics-summary` pattern exactly.

## Companion PR

- **extrachill-cli**: CLI refactor to wrap these abilities (separate PR)

Closes #13