### PR TITLE
Classify SQLi/XSS scanner probes as search_attack event_type

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -37,6 +37,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/drill-404-cat
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/list-404-events.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/purge-404-events.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-top-ips.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-attack-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-categorizer.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-tracking.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/email-tracking.php';

--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -24,6 +24,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/events-db.php';
 
 // Core functionality (network-wide).
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/events.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/security-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/gtm.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -97,6 +97,27 @@ function extrachill_analytics_ability_track_event( $input ) {
 	$event_data = isset( $input['event_data'] ) ? $input['event_data'] : array();
 	$source_url = isset( $input['source_url'] ) ? $input['source_url'] : '';
 
+	// Defense-in-depth: if a 'search' event arrives with a payload-shaped term,
+	// reclassify it as 'search_attack' so real search metrics stay clean while
+	// the attack stays visible. This catches any caller (current or future)
+	// that forgets to pre-classify, including community/forum/artist search.
+	if ( $event_type === 'search' && is_array( $event_data ) && ! empty( $event_data['search_term'] ) ) {
+		$classification = extrachill_analytics_classify_search_payload( (string) $event_data['search_term'] );
+		if ( null !== $classification ) {
+			$event_type = 'search_attack';
+			$event_data = array_merge(
+				$event_data,
+				array(
+					'classification'  => $classification['pattern_name'],
+					'pattern_family'  => $classification['pattern_family'],
+					'matched_token'   => $classification['matched_token'],
+					'ip'              => extrachill_analytics_get_client_ip(),
+					'user_agent'      => extrachill_analytics_get_user_agent(),
+				)
+			);
+		}
+	}
+
 	/**
 	 * Filter whether to track an analytics event.
 	 *

--- a/inc/core/abilities/get-attack-summary.php
+++ b/inc/core/abilities/get-attack-summary.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Get Attack Summary Ability
+ *
+ * Read-side ability that summarizes search_attack events. Supports grouping by
+ * pattern family, calendar day, source IP, or source URL.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_attack_summary_ability' );
+
+/**
+ * Register the get-attack-summary ability.
+ */
+function extrachill_analytics_register_attack_summary_ability() {
+	wp_register_ability(
+		'extrachill/get-attack-summary',
+		array(
+			'label'       => __( 'Get Attack Summary', 'extrachill-analytics' ),
+			'description' => __( 'Summarizes search_attack events by pattern, day, IP, or URL.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back. 0 for all time.', 'extrachill-analytics' ),
+						'default'     => 28,
+					),
+					'group_by' => array(
+						'type'        => 'string',
+						'description' => __( 'Grouping dimension: pattern, day, ip, or url.', 'extrachill-analytics' ),
+						'enum'        => array( 'pattern', 'day', 'ip', 'url' ),
+						'default'     => 'pattern',
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Maximum rows to return. 0 for unlimited.', 'extrachill-analytics' ),
+						'default'     => 25,
+					),
+					'blog_id'  => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for all sites.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+				),
+			),
+			'output_schema' => array(
+				'type'        => 'object',
+				'description' => __( 'Summary with rows array, totals, and period metadata.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_attack_summary',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-attack-summary ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Summary data with shape:
+ *   [
+ *     'rows'      => [ ['key' => ..., 'count' => N, ...], ... ],
+ *     'total'     => int,
+ *     'group_by'  => string,
+ *     'days'      => int,
+ *     'period'    => string,
+ *     'distinct'  => int,  // Number of distinct keys (rows before limit truncation)
+ *   ]
+ */
+function extrachill_analytics_ability_get_attack_summary( $input ) {
+	global $wpdb;
+
+	$days     = isset( $input['days'] ) ? max( 0, (int) $input['days'] ) : 28;
+	$group_by = isset( $input['group_by'] ) ? (string) $input['group_by'] : 'pattern';
+	$limit    = isset( $input['limit'] ) ? max( 0, (int) $input['limit'] ) : 25;
+	$blog_id  = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+
+	$valid_groups = array( 'pattern', 'day', 'ip', 'url' );
+	if ( ! in_array( $group_by, $valid_groups, true ) ) {
+		$group_by = 'pattern';
+	}
+
+	$table  = extrachill_analytics_events_table();
+	$where  = array( "event_type = 'search_attack'" );
+	$values = array();
+
+	if ( $days > 0 ) {
+		$where[]  = 'created_at >= %s';
+		$values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+	}
+
+	if ( $blog_id > 0 ) {
+		$where[]  = 'blog_id = %d';
+		$values[] = $blog_id;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+	// Snapshot the WHERE-only values before we append a LIMIT placeholder for the
+	// grouped query — count/distinct queries need just the WHERE values.
+	$where_values = $values;
+
+	// Build the GROUP BY expression depending on dimension. Uses MySQL JSON
+	// functions for fields stored inside event_data.
+	switch ( $group_by ) {
+		case 'day':
+			$select = 'DATE(created_at) AS grp_key, COUNT(*) AS cnt';
+			$group  = 'DATE(created_at)';
+			$order  = 'grp_key DESC';
+			break;
+		case 'ip':
+			$select = "JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.ip')) AS grp_key, COUNT(*) AS cnt";
+			$group  = "JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.ip'))";
+			$order  = 'cnt DESC';
+			break;
+		case 'url':
+			$select = 'source_url AS grp_key, COUNT(*) AS cnt';
+			$group  = 'source_url';
+			$order  = 'cnt DESC';
+			break;
+		case 'pattern':
+		default:
+			$select = "JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.classification')) AS grp_key, COUNT(*) AS cnt";
+			$group  = "JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.classification'))";
+			$order  = 'cnt DESC';
+			break;
+	}
+
+	$sql           = "SELECT {$select} FROM {$table} WHERE {$where_clause} GROUP BY {$group} ORDER BY {$order}";
+	$query_values  = $values;
+	$fetch_limit   = 0;
+	if ( $limit > 0 ) {
+		$sql           .= ' LIMIT %d';
+		$fetch_limit    = $limit + 1; // Fetch one extra so we know if more exist.
+		$query_values[] = $fetch_limit;
+	}
+
+	$results = empty( $query_values )
+		? $wpdb->get_results( $sql ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		: $wpdb->get_results( $wpdb->prepare( $sql, $query_values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+	$rows = array();
+	foreach ( $results as $row ) {
+		$rows[] = array(
+			'key'   => $row->grp_key !== null ? (string) $row->grp_key : '(null)',
+			'count' => (int) $row->cnt,
+		);
+	}
+
+	$truncated = false;
+	if ( $limit > 0 && count( $rows ) > $limit ) {
+		$rows      = array_slice( $rows, 0, $limit );
+		$truncated = true;
+	}
+
+	// Total + distinct across the entire filtered set (not just returned rows).
+	$count_sql   = "SELECT COUNT(*) FROM {$table} WHERE {$where_clause}";
+	$grand_total = empty( $where_values )
+		? (int) $wpdb->get_var( $count_sql ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		: (int) $wpdb->get_var( $wpdb->prepare( $count_sql, $where_values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+	$distinct_sql = "SELECT COUNT(DISTINCT {$group}) FROM {$table} WHERE {$where_clause}";
+	$distinct     = empty( $where_values )
+		? (int) $wpdb->get_var( $distinct_sql ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		: (int) $wpdb->get_var( $wpdb->prepare( $distinct_sql, $where_values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+	return array(
+		'rows'      => $rows,
+		'total'     => $grand_total,
+		'distinct'  => $distinct,
+		'group_by'  => $group_by,
+		'days'      => $days,
+		'period'    => $days > 0
+			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
+			: 'all time',
+		'truncated' => $truncated,
+	);
+}

--- a/inc/core/security-classifier.php
+++ b/inc/core/security-classifier.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Security Classifier
+ *
+ * Detects scanner / injection probe payloads in user-supplied strings so they
+ * can be partitioned away from real user-behavior metrics. Used at analytics
+ * insert time by callers like extrachill-search.
+ *
+ * Design intent: never silently drop attacks. Classify them and route to a
+ * distinct event_type so the canary stays loud while real metrics stay clean.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Classify a user-supplied search/query string against a catalog of known
+ * scanner payload shapes.
+ *
+ * Returns the FIRST matching pattern, or null if the string looks benign.
+ * Order is important: higher-confidence patterns fire first.
+ *
+ * @param string $term The raw search term.
+ * @return array|null Classification array on match, null if benign.
+ *                    Shape: [
+ *                      'pattern_name'    => 'time_based_sqli',
+ *                      'pattern_family'  => 'sqli',
+ *                      'matched_token'   => 'sleep(',
+ *                    ]
+ */
+function extrachill_analytics_classify_search_payload( $term ) {
+	if ( ! is_string( $term ) || $term === '' ) {
+		return null;
+	}
+
+	// Normalize once: HTML-entity decode (attackers double-encode), strip slashes.
+	$normalized = wp_unslash( $term );
+	$normalized = html_entity_decode( $normalized, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+	$normalized = rawurldecode( $normalized );
+
+	$catalog = array(
+		// Time-based blind SQLi — highest signal, near-zero false positives.
+		array(
+			'pattern_name'   => 'time_based_sqli',
+			'pattern_family' => 'sqli',
+			'regex'          => '/\bsleep\s*\(\s*\d+\s*\)/i',
+		),
+		array(
+			'pattern_name'   => 'time_based_sqli',
+			'pattern_family' => 'sqli',
+			'regex'          => '/\bwaitfor\s+delay\b/i',
+		),
+		array(
+			'pattern_name'   => 'time_based_sqli',
+			'pattern_family' => 'sqli',
+			'regex'          => '/\bDBMS_PIPE\.RECEIVE_MESSAGE\b/i',
+		),
+		array(
+			'pattern_name'   => 'time_based_sqli',
+			'pattern_family' => 'sqli',
+			'regex'          => '/\bbenchmark\s*\(\s*\d+/i',
+		),
+		array(
+			'pattern_name'   => 'time_based_sqli',
+			'pattern_family' => 'sqli',
+			'regex'          => '/\bpg_sleep\s*\(/i',
+		),
+		// Boolean / union SQLi.
+		array(
+			'pattern_name'   => 'boolean_sqli',
+			'pattern_family' => 'sqli',
+			'regex'          => '/\bunion\s+(?:all\s+)?select\b/i',
+		),
+		array(
+			'pattern_name'   => 'boolean_sqli',
+			'pattern_family' => 'sqli',
+			// e.g. (select(0)from(select(sleep ...))) family — sqlmap fingerprint.
+			'regex'          => '/\bselect\s*\(\s*\d+\s*\)\s*from\s*\(\s*select\b/i',
+		),
+		array(
+			'pattern_name'   => 'boolean_sqli',
+			'pattern_family' => 'sqli',
+			// XOR(1*if(...)) family.
+			'regex'          => "/\bxor\s*\(\s*\d+\s*\*\s*if\s*\(/i",
+		),
+		// XSS probes.
+		array(
+			'pattern_name'   => 'xss_script_tag',
+			'pattern_family' => 'xss',
+			'regex'          => '/<script\b/i',
+		),
+		array(
+			'pattern_name'   => 'xss_event_handler',
+			'pattern_family' => 'xss',
+			'regex'          => '/\bon(?:error|load|click|mouseover)\s*=/i',
+		),
+		array(
+			'pattern_name'   => 'xss_javascript_uri',
+			'pattern_family' => 'xss',
+			'regex'          => '/javascript\s*:/i',
+		),
+		// Path traversal.
+		array(
+			'pattern_name'   => 'path_traversal',
+			'pattern_family' => 'lfi',
+			'regex'          => '/\.\.\/\.\./',
+		),
+		array(
+			'pattern_name'   => 'path_traversal',
+			'pattern_family' => 'lfi',
+			'regex'          => '/\/etc\/passwd\b/i',
+		),
+		// Excessive length — legitimate searches are rarely > 200 chars.
+		array(
+			'pattern_name'   => 'length_abuse',
+			'pattern_family' => 'abuse',
+			'regex'          => '/^.{300,}$/s',
+		),
+	);
+
+	/**
+	 * Filter the security classifier pattern catalog.
+	 *
+	 * Allows other plugins to add or remove detection patterns. Each entry must
+	 * have keys: pattern_name (string), pattern_family (string), regex (string).
+	 *
+	 * @param array $catalog Array of pattern definitions.
+	 */
+	$catalog = apply_filters( 'extrachill_analytics_search_attack_patterns', $catalog );
+
+	foreach ( $catalog as $entry ) {
+		if ( empty( $entry['regex'] ) ) {
+			continue;
+		}
+		if ( @preg_match( $entry['regex'], $normalized, $matches ) === 1 ) {
+			return array(
+				'pattern_name'   => isset( $entry['pattern_name'] ) ? (string) $entry['pattern_name'] : 'unknown',
+				'pattern_family' => isset( $entry['pattern_family'] ) ? (string) $entry['pattern_family'] : 'unknown',
+				'matched_token'  => isset( $matches[0] ) ? substr( (string) $matches[0], 0, 120 ) : '',
+			);
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Get the real client IP for the current request.
+ *
+ * Honors Cloudflare's CF-Connecting-IP header when present (set when the
+ * nginx Cloudflare real-ip config is active), otherwise falls back to
+ * REMOTE_ADDR. Always returns a sanitized string, possibly empty.
+ *
+ * @return string IP address or empty string.
+ */
+function extrachill_analytics_get_client_ip() {
+	$candidates = array();
+
+	if ( ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
+		$candidates[] = wp_unslash( $_SERVER['HTTP_CF_CONNECTING_IP'] );
+	}
+	if ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+		$candidates[] = wp_unslash( $_SERVER['REMOTE_ADDR'] );
+	}
+
+	foreach ( $candidates as $candidate ) {
+		$ip = trim( (string) $candidate );
+		if ( $ip !== '' && filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return $ip;
+		}
+	}
+
+	return '';
+}
+
+/**
+ * Get a sanitized truncated User-Agent string for the current request.
+ *
+ * @param int $max_length Maximum length to keep.
+ * @return string
+ */
+function extrachill_analytics_get_user_agent( $max_length = 255 ) {
+	if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		return '';
+	}
+	$ua = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+	if ( strlen( $ua ) > $max_length ) {
+		$ua = substr( $ua, 0, $max_length );
+	}
+	return $ua;
+}

--- a/inc/core/security-classifier.php
+++ b/inc/core/security-classifier.php
@@ -35,8 +35,12 @@ function extrachill_analytics_classify_search_payload( $term ) {
 		return null;
 	}
 
-	// Normalize once: HTML-entity decode (attackers double-encode), strip slashes.
-	$normalized = wp_unslash( $term );
+	// Build two views of the input: the raw term (for patterns that target
+	// URL-encoded markers like %25%27) and a fully-decoded form (for patterns
+	// that target literal characters even when attackers double-encode them).
+	// Each catalog entry can opt into 'raw' matching via the 'match_raw' key.
+	$raw        = wp_unslash( $term );
+	$normalized = $raw;
 	$normalized = html_entity_decode( $normalized, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 	$normalized = rawurldecode( $normalized );
 
@@ -112,7 +116,59 @@ function extrachill_analytics_classify_search_payload( $term ) {
 			'pattern_family' => 'lfi',
 			'regex'          => '/\/etc\/passwd\b/i',
 		),
-		// Excessive length — legitimate searches are rarely > 200 chars.
+		// Scanner session markers — sqlmap / AcuneticX-style fingerprints.
+		array(
+			'pattern_name'   => 'scanner_marker',
+			'pattern_family' => 'scanner',
+			// e.g. @@OZOin @@z5T3X @@3IOVO — sqlmap uses @@ prefix for unique session ids.
+			'regex'          => '/^@@[A-Za-z0-9]{4,8}$/',
+		),
+		array(
+			'pattern_name'   => 'scanner_quote_probe',
+			'pattern_family' => 'scanner',
+			// e.g. 1'", the'", 1&#039;&quot;1000 — quote-injection probes.
+			// Match a short token followed by quote(s) (raw or HTML-encoded) optionally trailed by digits.
+			'regex'          => '/^[a-z0-9\/]{0,40}(?:\'|&#039;|&apos;)+(?:"|&quot;)+(?:\d{1,4})?$/i',
+		),
+		array(
+			'pattern_name'   => 'scanner_path_enum',
+			'pattern_family' => 'scanner',
+			// e.g. the/page/page/3/0qah8bhh2pp4.jsp — random-token file probes.
+			// Token + /page/ chain + optional numeric segment + random alphanumeric token + extension.
+			// Allows arbitrary path segments between /page/ and the random token.
+			'regex'          => '/\/page(?:\/[a-z0-9]+)+\.(?:html|jsp|asp|aspx|php)$/i',
+		),
+		array(
+			'pattern_name'   => 'scanner_path_enum',
+			'pattern_family' => 'scanner',
+			// Repeated /page chains — humans don't type "/page/page" twice.
+			// Two or more "/page" segments in sequence.
+			'regex'          => '/\/page\/page/i',
+		),
+		array(
+			'pattern_name'   => 'scanner_quote_probe',
+			'pattern_family' => 'scanner',
+			// Bare quote+backslash escape probes: '\", "\\\\'\\\\\\".
+			'regex'          => '/(?:\\\\\\\\\'|\\\\\\\\")|^[\'"]+\\\\+[\'"]+$/',
+		),
+		array(
+			'pattern_name'   => 'scanner_encoded_gibberish',
+			'pattern_family' => 'scanner',
+			// e.g. 1????%2527%2522\\'\\\" — literal ???? markers + URL-encoded quotes.
+			// Match against the RAW (un-decoded) input so the %25 prefix survives.
+			'regex'          => '/\?{3,}%25/',
+			'match_raw'      => true,
+		),
+		array(
+			'pattern_name'   => 'scanner_encoded_gibberish',
+			'pattern_family' => 'scanner',
+			// Double-URL-encoded quote pairs: %2527%2522 anywhere.
+			// %2527 is double-encoded ' (apostrophe), %2522 is double-encoded ".
+			// No legitimate human search contains this shape. Match raw.
+			'regex'          => '/%25(?:27|22)%25(?:27|22)/i',
+			'match_raw'      => true,
+		),
+		// Excessive length — legitimate searches are rarely > 300 chars.
 		array(
 			'pattern_name'   => 'length_abuse',
 			'pattern_family' => 'abuse',
@@ -134,7 +190,8 @@ function extrachill_analytics_classify_search_payload( $term ) {
 		if ( empty( $entry['regex'] ) ) {
 			continue;
 		}
-		if ( @preg_match( $entry['regex'], $normalized, $matches ) === 1 ) {
+		$haystack = ! empty( $entry['match_raw'] ) ? $raw : $normalized;
+		if ( @preg_match( $entry['regex'], $haystack, $matches ) === 1 ) {
 			return array(
 				'pattern_name'   => isset( $entry['pattern_name'] ) ? (string) $entry['pattern_name'] : 'unknown',
 				'pattern_family' => isset( $entry['pattern_family'] ) ? (string) $entry['pattern_family'] : 'unknown',


### PR DESCRIPTION
## Why

Sustained scanner attacks against \`/?s=\` are polluting search analytics. Three discrete attack runs in the current 28-day window:

- **Apr 27**: 19,676 events between 10:00–15:00 UTC (sqlmap-style fuzzing)
- **Apr 15**: 1,815 events
- **Apr 2**: 7,457 events

This drove the 28-day search-event rate from a normal ~380/day baseline to 1,079/day, and was visible in the slow query log too:

\`\`\`
MATCH(...) AGAINST('+10\\\\'XOR(1*if(now()=sysdate(),sleep(15),0))XOR\\\\'Z*' IN BOOLEAN MODE)
Rows_examined: 59,287
\`\`\`

WordPress's \`WP_Query\` handles these safely (no actual SQLi succeeded), but the analytics tracker dutifully logged every probe as \`event_type='search'\`, masking real user search behavior in PROGRESS.md and the analytics summary CLI.

## Approach

Don't silently drop scanner traffic — that would blind us at exactly the layer that detected the attack. **Classify and route.**

Real user searches still land in \`event_type='search'\`. Scanner probes land in a new \`event_type='search_attack'\` with enriched data:

\`\`\`json
{
  "search_term": "1*if(now()=sysdate(),sleep(15),0)",
  "result_count": 825,
  "classification": "time_based_sqli",
  "pattern_family": "sqli",
  "matched_token": "sleep(15)",
  "ip": "203.0.113.42",
  "user_agent": "Mozilla/5.0 ... Chrome/126.0.0.0 ..."
}
\`\`\`

Future fail2ban or Cloudflare WAF rules can consume \`event_type='search_attack'\` directly.

## Implementation

- **\`inc/core/security-classifier.php\`** (new) — regex catalog for time-based SQLi (\`sleep\`, \`waitfor\`, \`DBMS_PIPE\`, \`benchmark\`, \`pg_sleep\`), boolean SQLi (\`UNION SELECT\`, sqlmap \`(select(0)from(...))\` family, \`XOR(N*if(...))\` family), XSS (script tags, \`javascript:\`, \`on*=\`), path traversal, and length abuse. Catalog is filterable via \`extrachill_analytics_search_attack_patterns\`. Also exposes \`extrachill_analytics_get_client_ip()\` (honors \`CF-Connecting-IP\`) and \`extrachill_analytics_get_user_agent()\`.

- **\`inc/core/abilities.php\`** — defense-in-depth in \`extrachill_analytics_ability_track_event()\`: when \`event_type='search'\` arrives with a payload-shaped \`search_term\`, reroute to \`search_attack\` and enrich. Applies to every caller of the ability, not just \`extrachill-search\` — future search surfaces (community, artist directory) get the same protection automatically.

- No changes needed in \`extrachill-search\` because the routing happens inside the ability.

## Test

23-case test suite (in commit message) verifies:
- 13 real attack payloads pulled from \`c8c_extrachill_analytics_events\` Apr 27 all classify correctly
- 10 benign head queries (\`alice fredenham\`, \`the\`, \`grateful dead\`, \`1\`, \`extra chill\`, etc.) all return \`null\`
- Zero false positives, zero false negatives

## Pairs with

\`/etc/nginx/conf.d/cloudflare-real-ip.conf\` (deployed live on the server in the same session) which adds Cloudflare's IP ranges to \`set_real_ip_from\` and uses \`real_ip_header CF-Connecting-IP\`. Without that, \`extrachill_analytics_get_client_ip()\` would still see Cloudflare edge IPs. Verified post-reload that nginx access logs now show real client IPs (residential, datacenter, IPv6) instead of \`172.68.x.x\` / \`162.158.x.x\` edges.

## Followups (not in this PR)

- \`wp extrachill analytics attacks\` CLI subcommand for daily / by-IP / by-pattern attack summaries
- Cloudflare WAF rule blocking \`?s=\` requests containing \`sleep(\`, \`waitfor\`, \`DBMS_PIPE\`, etc. — kills the attack class at the edge
- Backfill: SQL migration to retroactively reclassify the 28K+ historic \`search\` rows that match the classifier, so PROGRESS.md baselines stop being polluted