### PR TITLE
refactor: migrate from @extrachill/api-client to wp-native-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
 		"@wordpress/scripts": "^30.15.0"
 	},
 	"dependencies": {
-		"@extrachill/api-client": "^0.2.0",
 		"@wordpress/api-fetch": "^7.0.0",
 		"@wordpress/components": "^28.0.0",
 		"@wordpress/element": "^6.0.0",
-		"@wordpress/i18n": "^5.0.0"
+		"@wordpress/i18n": "^5.0.0",
+		"wp-native-client": "^0.0.1"
 	},
 	"private": true
 }

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,23 +1,92 @@
 /**
  * Analytics API Client
  *
- * Delegates all calls to @extrachill/api-client via WpApiFetchTransport.
- * Exports match the original function names so dashboard components need zero changes.
+ * Uses wp-native-client (WPNativeClient + WpApiFetchTransport) for
+ * ability-backed calls, and falls back to direct apiFetch for REST
+ * endpoints that do not yet have ability equivalents.
+ *
+ * Exports match the original function names so dashboard components
+ * need zero changes.
+ *
+ * Abilities used:
+ *   - extrachill/get-analytics-summary
+ *
+ * Direct REST (no ability registered — see PR for gap documentation):
+ *   - GET extrachill/v1/analytics/events   → getEvents()
+ *   - GET extrachill/v1/analytics/meta     → getAnalyticsMeta()
  */
 
 import apiFetch from '@wordpress/api-fetch';
-import { ExtraChillClient } from '@extrachill/api-client';
-import { WpApiFetchTransport } from '@extrachill/api-client/wordpress';
+import { WPNativeClient } from 'wp-native-client';
+import { WpApiFetchTransport } from 'wp-native-client/wordpress';
+
+/** @typedef {import('../types/analytics').AnalyticsEventsParams} AnalyticsEventsParams */
+/** @typedef {import('../types/analytics').AnalyticsEventsResponse} AnalyticsEventsResponse */
+/** @typedef {import('../types/analytics').AnalyticsSummaryResponse} AnalyticsSummaryResponse */
+/** @typedef {import('../types/analytics').AnalyticsMetaResponse} AnalyticsMetaResponse */
 
 const transport = new WpApiFetchTransport( apiFetch );
-const client = new ExtraChillClient( transport );
+const client = new WPNativeClient( transport, { validateAbilityNames: false } );
 
 export const getConfig = () => window.extraChillAnalytics || {};
 
-export const getEvents = ( params ) => client.analytics.getEvents( params );
-export const getAnalyticsMeta = () => client.analytics.getMeta();
-export const getEventsSummary = ( eventType, days, blogId ) =>
-	client.analytics.getSummary( eventType, days, blogId );
+/**
+ * Build a query string from params (filters out falsy values).
+ *
+ * @param {Record<string, string|number|boolean|undefined>} params
+ * @return {string}
+ */
+function buildQuery( params ) {
+	const parts = Object.entries( params )
+		.filter( ( [ , v ] ) => v !== undefined && v !== '' && v !== null )
+		.map(
+			( [ k, v ] ) =>
+				`${ encodeURIComponent( k ) }=${ encodeURIComponent(
+					String( v )
+				) }`
+		);
+	return parts.length ? `?${ parts.join( '&' ) }` : '';
+}
+
+/**
+ * Fetch paginated analytics events.
+ *
+ * No ability equivalent registered — uses direct REST endpoint.
+ *
+ * @param {AnalyticsEventsParams} params
+ * @return {Promise<AnalyticsEventsResponse>}
+ */
+export const getEvents = ( params = {} ) =>
+	apiFetch( {
+		path: `extrachill/v1/analytics/events${ buildQuery( params ) }`,
+	} );
+
+/**
+ * Fetch analytics metadata (event types, blog list).
+ *
+ * No ability equivalent registered — uses direct REST endpoint.
+ *
+ * @return {Promise<AnalyticsMetaResponse>}
+ */
+export const getAnalyticsMeta = () =>
+	apiFetch( { path: 'extrachill/v1/analytics/meta' } );
+
+/**
+ * Fetch analytics summary via the Abilities API.
+ *
+ * Uses: extrachill/get-analytics-summary
+ *
+ * @param {string}  eventType
+ * @param {number}  [days=30]
+ * @param {number}  [blogId]
+ * @return {Promise<AnalyticsSummaryResponse>}
+ */
+export const getEventsSummary = ( eventType, days = 30, blogId ) =>
+	client.execute( 'extrachill/get-analytics-summary', {
+		event_type: eventType,
+		days,
+		...( blogId !== undefined && { blog_id: blogId } ),
+	} );
 
 export default {
 	getConfig,

--- a/src/types/analytics.js
+++ b/src/types/analytics.js
@@ -1,0 +1,52 @@
+/**
+ * Analytics type definitions.
+ *
+ * Relocated from @extrachill/api-client during M8 migration.
+ * These are JSDoc-only types for editor tooling — no runtime cost.
+ */
+
+/**
+ * @typedef {Object} AnalyticsEvent
+ * @property {number}                   id
+ * @property {string}                   event_type
+ * @property {string}                   source_url
+ * @property {Record<string, unknown>}  event_data
+ * @property {string}                   created_at
+ * @property {number}                   [user_id]
+ * @property {number}                   [blog_id]
+ */
+
+/**
+ * @typedef {Object} AnalyticsEventsParams
+ * @property {string} [event_type]
+ * @property {number} [blog_id]
+ * @property {string} [date_from]
+ * @property {string} [date_to]
+ * @property {string} [search]
+ * @property {number} [limit]
+ * @property {number} [offset]
+ * @property {number} [page]
+ * @property {number} [per_page]
+ */
+
+/**
+ * @typedef {Object} AnalyticsEventsResponse
+ * @property {AnalyticsEvent[]} events
+ * @property {number}           total
+ * @property {number}           page
+ * @property {number}           per_page
+ */
+
+/**
+ * @typedef {Object} AnalyticsSummaryResponse
+ * @property {Record<string, number>} summary
+ * @property {string}                 period
+ */
+
+/**
+ * @typedef {Object} AnalyticsMetaResponse
+ * @property {string[]} event_types
+ * @property {number}   total_events
+ */
+
+export {};


### PR DESCRIPTION
## Summary

Replaces `@extrachill/api-client` with `wp-native-client` in the analytics dashboard plugin. All ability-backed calls now flow through `client.execute()`. REST endpoints without ability equivalents fall back to direct `apiFetch`.

Closes #18. Part of M8 umbrella retirement (extrachill-app#38).

## Callsite inventory

| Export | Old call | New call | Transport |
|---|---|---|---|
| `getEventsSummary` | `client.analytics.getSummary()` | `client.execute('extrachill/get-analytics-summary', ...)` | Abilities API ✅ |
| `getEvents` | `client.analytics.getEvents()` | `apiFetch({ path: 'extrachill/v1/analytics/events...' })` | Direct REST ⚠️ |
| `getAnalyticsMeta` | `client.analytics.getMeta()` | `apiFetch({ path: 'extrachill/v1/analytics/meta' })` | Direct REST ⚠️ |
| `getConfig` | `window.extraChillAnalytics` | `window.extraChillAnalytics` | Local (unchanged) |

## Abilities used (all registered server-side)

- `extrachill/get-analytics-summary`

## Server-side gaps

Two REST endpoints used by the dashboard have **no ability equivalent** registered:

| REST endpoint | Used by | Gap |
|---|---|---|
| `GET extrachill/v1/analytics/events` | `getEvents()` — main events table | No `extrachill/list-analytics-events` ability |
| `GET extrachill/v1/analytics/meta` | `getAnalyticsMeta()` — filter dropdowns | No `extrachill/get-analytics-meta` ability |

These continue working via direct `apiFetch` calls. Registering abilities for them is a separate issue.

## Dep changes

- **Removed:** `@extrachill/api-client` (`^0.2.0`)
- **Added:** `wp-native-client` (`^0.0.1`, npm)

## Other changes

- Created `src/types/analytics.js` with JSDoc type definitions relocated from `@extrachill/api-client`
- `src/api/client.js` fully rewritten with documented JSDoc types
- No changes to dashboard components (`App.jsx`, `EventsTable.jsx`, etc.) — exports are API-compatible

## Verification

- [x] `npm run build` succeeds (webpack compiled successfully)
- [x] No `@extrachill/api-client` imports remain in source
- [x] All three exported functions (`getEvents`, `getAnalyticsMeta`, `getEventsSummary`) preserved with identical signatures