### PR TITLE
feat(abilities): register tracking + link-page analytics abilities

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -38,6 +38,8 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/list-404-even
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/purge-404-events.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-top-ips.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-attack-summary.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/track-page-view.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-link-page-analytics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-categorizer.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-tracking.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/email-tracking.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -20,6 +20,8 @@ add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_drill_404_ca
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_list_404_events_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_purge_404_events_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_404_top_ips_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_track_page_view_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_get_link_page_analytics_ability' );
 
 /**
  * Register analytics ability category.

--- a/inc/core/abilities/get-link-page-analytics.php
+++ b/inc/core/abilities/get-link-page-analytics.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+/**
+ * Get Link Page Analytics Ability
+ *
+ * Read-side ability that returns aggregated analytics
+ * for an artist link page over a configurable date range.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.8.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-link-page-analytics ability.
+ */
+function extrachill_analytics_register_get_link_page_analytics_ability(): void {
+	wp_register_ability(
+		'extrachill/get-link-page-analytics',
+		array(
+			'label'       => __( 'Get Link Page Analytics', 'extrachill-analytics' ),
+			'description' => __( 'Returns aggregated analytics data for an artist link page.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'link_page_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The link page post ID.', 'extrachill-analytics' ),
+					),
+					'date_range' => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to query. Defaults to 30.', 'extrachill-analytics' ),
+						'default'     => 30,
+					),
+				),
+				'required' => array( 'link_page_id' ),
+			),
+			'output_schema' => array(
+				'type'        => 'object',
+				'description' => __( 'Aggregated analytics data for the link page.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_link_page_analytics',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-link-page-analytics ability.
+ *
+ * Validates the link page, checks ownership via ec_can_manage_artist(),
+ * then delegates to the extrachill_get_link_page_analytics filter.
+ *
+ * @param array $input Input parameters.
+ * @return array|WP_Error Analytics data or error.
+ */
+function extrachill_analytics_ability_get_link_page_analytics( array $input ) {
+	$link_page_id = isset( $input['link_page_id'] ) ? (int) $input['link_page_id'] : 0;
+	$date_range   = isset( $input['date_range'] ) ? (int) $input['date_range'] : 30;
+
+	if ( $link_page_id <= 0 ) {
+		return new \WP_Error(
+			'invalid_link_page_id',
+			__( 'A valid link_page_id is required.', 'extrachill-analytics' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	// Validate post type.
+	if ( get_post_type( $link_page_id ) !== 'artist_link_page' ) {
+		return new \WP_Error(
+			'invalid_link_page',
+			__( 'Invalid link page specified.', 'extrachill-analytics' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	// Resolve artist ownership.
+	$artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
+	if ( ! $artist_id ) {
+		return new \WP_Error(
+			'artist_not_found',
+			__( 'Could not determine associated artist.', 'extrachill-analytics' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	// Permission: caller must be able to manage the artist.
+	if ( ! function_exists( 'ec_can_manage_artist' ) || ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
+		return new \WP_Error(
+			'permission_denied',
+			__( 'You do not have permission to view analytics for this link page.', 'extrachill-analytics' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	/** @var array|WP_Error|null $result */
+	$result = apply_filters( 'extrachill_get_link_page_analytics', null, $link_page_id, $date_range );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	if ( ! is_array( $result ) ) {
+		return new \WP_Error(
+			'analytics_unavailable',
+			__( 'Analytics data could not be retrieved.', 'extrachill-analytics' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	return $result;
+}

--- a/inc/core/abilities/track-page-view.php
+++ b/inc/core/abilities/track-page-view.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+/**
+ * Track Page View Ability
+ *
+ * Write-side ability that increments post view counts.
+ * High-frequency hot-path — keeps logic minimal.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.8.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the track-page-view ability.
+ */
+function extrachill_analytics_register_track_page_view_ability(): void {
+	wp_register_ability(
+		'extrachill/track-page-view',
+		array(
+			'label'       => __( 'Track Page View', 'extrachill-analytics' ),
+			'description' => __( 'Increment the view counter for a post. High-frequency endpoint called async after page load.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'post_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The post ID to record a view for.', 'extrachill-analytics' ),
+					),
+				),
+				'required' => array( 'post_id' ),
+			),
+			'output_schema' => array(
+				'type'        => 'object',
+				'description' => __( 'Confirmation object with recorded flag.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_track_page_view',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => false,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for track-page-view ability.
+ *
+ * Mirrors the existing REST handler: quick post-meta increment,
+ * plus link-page daily-table action when applicable.
+ *
+ * @param array $input Input parameters.
+ * @return array{recorded: bool}|WP_Error Confirmation or error.
+ */
+function extrachill_analytics_ability_track_page_view( array $input ) {
+	$post_id = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
+
+	if ( $post_id <= 0 ) {
+		return new \WP_Error(
+			'invalid_post_id',
+			__( 'A valid post_id is required.', 'extrachill-analytics' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	if ( ! function_exists( 'ec_track_post_views' ) ) {
+		return new \WP_Error(
+			'function_missing',
+			__( 'View tracking function not available.', 'extrachill-analytics' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	// All-time view increment (post meta).
+	ec_track_post_views( $post_id );
+
+	// Link pages also fire the 90-day daily-table action.
+	if ( get_post_type( $post_id ) === 'artist_link_page' ) {
+		do_action( 'extrachill_link_page_view_recorded', $post_id );
+	}
+
+	return array( 'recorded' => true );
+}


### PR DESCRIPTION
## Summary

Registers two new abilities in extrachill-analytics that mirror the existing REST routes in extrachill-api:

- **`extrachill/track-page-view`** — public write ability for async view counting (hot-path, minimal logic)
- **`extrachill/get-link-page-analytics`** — authenticated read ability for aggregated link-page analytics

## Details

| Ability | Permission | `meta.readonly` | `show_in_rest` |
|---|---|---|---|
| `extrachill/track-page-view` | `__return_true` | `false` | `true` |
| `extrachill/get-link-page-analytics` | `is_user_logged_in` + `ec_can_manage_artist()` | `true` | `true` |

### Files changed

- `inc/core/abilities/track-page-view.php` — new ability file
- `inc/core/abilities/get-link-page-analytics.php` — new ability file
- `inc/core/abilities.php` — added `add_action` hooks for both
- `extrachill-analytics.php` — added `require_once` for both ability files

### Design notes

- **track-page-view** stays lean for hot-path performance: post-meta increment + optional link-page action fire. No heavy joins or full result-set returns.
- **get-link-page-analytics** preserves the full permission model from the REST route: `is_user_logged_in` at the ability level, plus `ec_can_manage_artist()` ownership check inside `execute_callback`.
- Both files use `declare(strict_types=1)` (PHP 8.1+).
- `php -l` passes on all files.

### Related routes (in extrachill-api)

- `POST /wp-json/extrachill/v1/analytics/view` → `extrachill/track-page-view`
- `GET /wp-json/extrachill/v1/analytics/link-page` → `extrachill/get-link-page-analytics`