### PR TITLE
feat: add extrachill/get-analytics-meta ability

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -30,6 +30,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/gtm.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-analytics-summary.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-analytics-meta.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-top-urls.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-patterns.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
 add_action( 'wp_abilities_api_categories_init', 'extrachill_analytics_register_category' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_abilities' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_summary_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_meta_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_404_summary_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_404_top_urls_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_404_patterns_ability' );

--- a/inc/core/abilities/get-analytics-meta.php
+++ b/inc/core/abilities/get-analytics-meta.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Get Analytics Meta Ability
+ *
+ * Read-side ability that returns the filter options for the analytics
+ * dashboard: the distinct event types and the blogs that have events.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.8.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-analytics-meta ability.
+ */
+function extrachill_analytics_register_meta_ability() {
+	wp_register_ability(
+		'extrachill/get-analytics-meta',
+		array(
+			'label'        => __( 'Get Analytics Meta', 'extrachill-analytics' ),
+			'description'  => __( 'Returns analytics filter options: distinct event types and the blogs that have events.', 'extrachill-analytics' ),
+			'category'     => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(),
+			),
+			'output_schema' => array(
+				'type'        => 'object',
+				'description' => __( 'Object with event_types (string array) and blogs (array of {id, name}).', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_meta',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_network_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-analytics-meta ability.
+ *
+ * @return array Meta data with event_types and blogs.
+ */
+function extrachill_analytics_ability_get_meta() {
+	$event_types = function_exists( 'extrachill_get_analytics_event_types' )
+		? extrachill_get_analytics_event_types()
+		: array();
+
+	$blog_ids = function_exists( 'extrachill_get_analytics_blog_ids' )
+		? extrachill_get_analytics_blog_ids()
+		: array();
+
+	$blogs = array();
+	foreach ( $blog_ids as $blog_id ) {
+		$blog_id   = absint( $blog_id );
+		$blog_name = get_blog_option( $blog_id, 'blogname' );
+		$blogs[]   = array(
+			'id'   => $blog_id,
+			'name' => $blog_name ? $blog_name : "Blog {$blog_id}",
+		);
+	}
+
+	return array(
+		'event_types' => $event_types,
+		'blogs'       => $blogs,
+	);
+}

--- a/inc/core/events.php
+++ b/inc/core/events.php
@@ -301,3 +301,37 @@ function extrachill_get_analytics_event_stats( $event_type, $days = 30, $blog_id
 		'by_context' => $by_context,
 	);
 }
+
+/**
+ * Get the distinct event types present in the events table.
+ *
+ * @return string[] Event type identifiers ordered ascending.
+ */
+function extrachill_get_analytics_event_types() {
+	global $wpdb;
+
+	$table_name = extrachill_analytics_events_table();
+
+	$event_types = $wpdb->get_col(
+		"SELECT DISTINCT event_type FROM {$table_name} ORDER BY event_type ASC"
+	);
+
+	return array_map( 'strval', (array) $event_types );
+}
+
+/**
+ * Get the distinct blog IDs that have recorded events.
+ *
+ * @return int[] Blog IDs ordered ascending.
+ */
+function extrachill_get_analytics_blog_ids() {
+	global $wpdb;
+
+	$table_name = extrachill_analytics_events_table();
+
+	$blog_ids = $wpdb->get_col(
+		"SELECT DISTINCT blog_id FROM {$table_name} ORDER BY blog_id ASC"
+	);
+
+	return array_map( 'absint', (array) $blog_ids );
+}


### PR DESCRIPTION
## Summary

Adds the `extrachill/get-analytics-meta` read-side ability — the analytics home for the raw SQL that `extrachill-api` previously inlined in its `analytics/meta` REST handler. Paired with **Extra-Chill/extrachill-api#69**.

This mirrors the existing `extrachill/get-analytics-summary` ability: thin ability that delegates to data functions in `inc/core/events.php`.

## Changes

- **`inc/core/events.php`** — two new data functions:
  - `extrachill_get_analytics_event_types()` → distinct `event_type` values, ordered ASC, as a string array.
  - `extrachill_get_analytics_blog_ids()` → distinct `blog_id` values, ordered ASC, as an int array.
- **`inc/core/abilities/get-analytics-meta.php`** — new `extrachill/get-analytics-meta` ability that wraps those data functions and resolves blog names (`get_blog_option`), returning `{ event_types: [...], blogs: [{id, name}] }`. Permission: `manage_network_options` (or WP-CLI). Marked `readonly`/`idempotent`, `show_in_rest => false` (consumed via the API wrapper).
- **`extrachill-analytics.php`** — `require_once` the new ability file.
- **`inc/core/abilities.php`** — register the ability on `wp_abilities_api_init`.

## Why an ability (not just data functions)

The issue's acceptance criteria explicitly want the meta lookup to be an ability alongside `get-analytics-summary`, and the `extrachill-api` `analytics/events/summary` handler already establishes the `wp_get_ability(...)->execute(...)` consumption pattern. The ability still delegates to data functions (no raw `$wpdb` in the ability beyond the simple `SELECT DISTINCT` wrappers, which now live in `events.php` with the rest of the analytics data layer).

## Verification

Ran the data-function SQL against the live network table — output shape matches the original raw-SQL handler exactly: 8 distinct event types, 10 blogs as `{id, name}`.

## Pairing / merge order

Must ship together with **Extra-Chill/extrachill-api#69**. The API handler now calls this ability; merging the API PR without this one would resolve a non-existent ability and return a 500. Merge this first (or simultaneously).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)