### PR TITLE
fix(security): add scanner-404 counter for the URL/path attack storm

### DIFF
--- a/inc/core/404-categorizer.php
+++ b/inc/core/404-categorizer.php
@@ -28,6 +28,33 @@ function extrachill_analytics_categorize_404_url( $url ) {
 		return 'sql-injection';
 	}
 
+	// Secret / credential / VCS file probes — scanners hunting for leaked
+	// secrets and source control metadata. These are unambiguously hostile;
+	// no legitimate visitor requests an .env, .git internals, or cloud creds.
+	// Matched before the generic content catch-all so the scanner storm is
+	// counted instead of being buried in 'content'.
+	if ( preg_match(
+		'#(?:^|/)(?:\.env|\.env\.|\.git/|\.gitignore$|\.svn/|\.hg/|\.bzr/|\.aws/|\.ssh/|\.npmrc$|\.htpasswd$|\.htaccess$|\.vscode/|\.idea/|\.well-known/[^/]*\.bak)#i',
+		$url
+	) ) {
+		return 'secret-probe';
+	}
+
+	// Config / backup / dump file probes — looking for credentials.json,
+	// config.json, wp-config backups, database dumps, archive backups, log
+	// files, and PHP info/debug endpoints.
+	if ( preg_match(
+		'#(?:^|/)(?:wp-config\.php\.[a-z0-9]+|credentials\.[a-z]+|config\.(?:json|php\.bak|yml|yaml)|secrets?\.[a-z]+|backup\.(?:zip|sql|tar|tar\.gz|tgz)|db\.sql|database\.sql|dump\.sql|.*\.sql\.gz|robots\.txt\.bak|sftp\.json|laravel\.log|telescope/|actuator/|phpinfo\.php|info\.php|server\.php)#i',
+		$url
+	) ) {
+		return 'config-probe';
+	}
+
+	// REST API user enumeration — /wp-json/wp/v2/users harvesting.
+	if ( preg_match( '#/wp-json/wp/v2/users#i', $url ) ) {
+		return 'wpjson-user-enum';
+	}
+
 	// Ad/sponsor/media-kit probe — multilingual about/contact/advertising pages.
 	$ad_sponsor_paths = array(
 		'/mediakit',
@@ -182,6 +209,48 @@ function extrachill_analytics_is_actionable_404_category( $category ) {
 	);
 
 	return in_array( $category, $actionable, true );
+}
+
+/**
+ * Check if a 404 category represents scanner / attack traffic.
+ *
+ * These categories indicate automated probing for vulnerabilities, leaked
+ * secrets, admin endpoints, or injection points — never legitimate visitor
+ * navigation. Used by the scanner-404 counter to partition the attack-shaped
+ * slice of the 404 storm away from benign content 404s, giving a trustworthy
+ * attack-volume signal for scoping a WAF rule.
+ *
+ * This is the complement of the on-site search_attack classifier: that one
+ * measures injection attempts submitted through the SITE SEARCH form, while
+ * this one measures the URL/PATH scanner storm that 404s without ever touching
+ * the search box. Two distinct attack surfaces, two distinct counters.
+ *
+ * @param string $category The category name from extrachill_analytics_categorize_404_url().
+ * @return bool True if the category is scanner/attack traffic.
+ */
+function extrachill_analytics_is_scanner_404_category( $category ) {
+	$scanner = array(
+		'sql-injection',
+		'secret-probe',
+		'config-probe',
+		'wpjson-user-enum',
+		'php-probe',
+		'plugin-probe',
+		'wp-includes-probe',
+		'bot-probe',
+		'author-enum',
+		'ad-sponsor-probe',
+	);
+
+	/**
+	 * Filter the set of 404 categories treated as scanner / attack traffic.
+	 *
+	 * @param string[] $scanner  Category names considered scanner traffic.
+	 * @param string   $category The category being checked.
+	 */
+	$scanner = apply_filters( 'extrachill_analytics_scanner_404_categories', $scanner, $category );
+
+	return in_array( $category, $scanner, true );
 }
 
 /**

--- a/inc/core/abilities/get-attack-summary.php
+++ b/inc/core/abilities/get-attack-summary.php
@@ -5,6 +5,15 @@
  * Read-side ability that summarizes search_attack events. Supports grouping by
  * pattern family, calendar day, source IP, or source URL.
  *
+ * SCOPE: this counter measures injection probes submitted through the ON-SITE
+ * SEARCH form (event_type='search_attack', written by the search-term
+ * classifier in security-classifier.php). It does NOT measure the URL/path
+ * scanner storm — those requests 404 without ever touching the search box and
+ * are counted by the companion get-scanner-404-summary ability. Two distinct
+ * attack surfaces, two distinct counters. A low/flat search_attack number means
+ * on-site search injection is quiet, NOT that scanning has stopped — check
+ * get-scanner-404-summary for the path-scanner volume.
+ *
  * @package ExtraChill\Analytics
  * @since 0.7.0
  */

--- a/inc/core/abilities/get-scanner-404-summary.php
+++ b/inc/core/abilities/get-scanner-404-summary.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Get Scanner 404 Summary Ability
+ *
+ * Read-side ability that surfaces the URL/path scanner storm — the slice of
+ * 404_error events whose categorized URL is scanner/attack-shaped (secret
+ * probes, config/backup hunting, plugin/wp-includes probing, user enumeration,
+ * SQLi-in-URL, etc.).
+ *
+ * This is a deliberate companion to get-attack-summary. The search_attack
+ * counter (get-attack-summary) measures injection submitted through the ON-SITE
+ * SEARCH form. This counter measures the URL/PATH scanner storm that 404s
+ * without ever touching the search box. Two distinct attack surfaces.
+ *
+ * Categorization happens at QUERY TIME via extrachill_analytics_categorize_404_url()
+ * — no new columns or tables are added. The stored requested_url lives in the
+ * event_data JSON under '$.requested_url'.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.7.5
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_scanner_404_summary_ability' );
+
+/**
+ * Register the get-scanner-404-summary ability.
+ */
+function extrachill_analytics_register_scanner_404_summary_ability() {
+	wp_register_ability(
+		'extrachill/get-scanner-404-summary',
+		array(
+			'label'       => __( 'Get Scanner 404 Summary', 'extrachill-analytics' ),
+			'description' => __( 'Summarizes scanner/attack-shaped 404 events (secret/config probes, plugin/wp-includes probing, user enumeration, SQLi-in-URL) by category, day, IP, or URL. Companion to get-attack-summary, which covers on-site search injection.', 'extrachill-analytics' ),
+			'category'    => 'extrachill-analytics',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back. 0 for all time.', 'extrachill-analytics' ),
+						'default'     => 28,
+					),
+					'group_by' => array(
+						'type'        => 'string',
+						'description' => __( 'Grouping dimension: category, day, ip, or url.', 'extrachill-analytics' ),
+						'enum'        => array( 'category', 'day', 'ip', 'url' ),
+						'default'     => 'category',
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Maximum rows to return. 0 for unlimited.', 'extrachill-analytics' ),
+						'default'     => 25,
+					),
+					'blog_id'  => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for all sites.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+				),
+			),
+			'output_schema' => array(
+				'type'        => 'object',
+				'description' => __( 'Summary with rows array, scanner total, benign total, and period metadata.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_scanner_404_summary',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-scanner-404-summary ability.
+ *
+ * Pulls every distinct 404 URL in the window, categorizes each at read time,
+ * keeps only scanner/attack-shaped categories, then aggregates by the requested
+ * dimension. The 'ip' dimension regroups by the hashed IP stored in event_data
+ * (404 tracking stores 'ip_hash', not a raw IP).
+ *
+ * @param array $input Input parameters.
+ * @return array Summary data:
+ *   [
+ *     'rows'          => [ ['key' => ..., 'count' => N], ... ],
+ *     'scanner_total' => int,  // total scanner-shaped 404 hits in window
+ *     'benign_total'  => int,  // total non-scanner 404 hits in window
+ *     'total'         => int,  // all 404 hits in window
+ *     'scanner_pct'   => float,
+ *     'distinct'      => int,  // distinct keys for the chosen dimension
+ *     'group_by'      => string,
+ *     'days'          => int,
+ *     'period'        => string,
+ *     'truncated'     => bool,
+ *   ]
+ */
+function extrachill_analytics_ability_get_scanner_404_summary( $input ) {
+	global $wpdb;
+
+	$days     = isset( $input['days'] ) ? max( 0, (int) $input['days'] ) : 28;
+	$group_by = isset( $input['group_by'] ) ? (string) $input['group_by'] : 'category';
+	$limit    = isset( $input['limit'] ) ? max( 0, (int) $input['limit'] ) : 25;
+	$blog_id  = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+
+	$valid_groups = array( 'category', 'day', 'ip', 'url' );
+	if ( ! in_array( $group_by, $valid_groups, true ) ) {
+		$group_by = 'category';
+	}
+
+	$table  = extrachill_analytics_events_table();
+	$where  = array( "event_type = '404_error'" );
+	$values = array();
+
+	if ( $days > 0 ) {
+		$where[]  = 'created_at >= %s';
+		$values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+	}
+
+	if ( $blog_id > 0 ) {
+		$where[]  = 'blog_id = %d';
+		$values[] = $blog_id;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+
+	// Pull every 404 row in the window with the fields needed to categorize and
+	// group. Categorization can't be expressed in SQL (it mirrors the PHP
+	// categorizer), so we aggregate in PHP. Rows are grouped by URL first to
+	// keep the working set small even on a multi-hundred-thousand-row window.
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$sql = "SELECT
+		JSON_UNQUOTE(JSON_EXTRACT(event_data, '\$.requested_url')) AS url,
+		JSON_UNQUOTE(JSON_EXTRACT(event_data, '\$.ip_hash')) AS ip_hash,
+		DATE(created_at) AS day,
+		COUNT(*) AS hits
+		FROM {$table}
+		WHERE {$where_clause}
+		GROUP BY url, ip_hash, day";
+
+	if ( ! empty( $values ) ) {
+		$rows = $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+	} else {
+		$rows = $wpdb->get_results( $sql );
+	}
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	$scanner_total = 0;
+	$benign_total  = 0;
+	$agg           = array();
+
+	foreach ( $rows as $row ) {
+		$url      = (string) $row->url;
+		$hits     = (int) $row->hits;
+		$category = extrachill_analytics_categorize_404_url( $url );
+
+		if ( ! extrachill_analytics_is_scanner_404_category( $category ) ) {
+			$benign_total += $hits;
+			continue;
+		}
+
+		$scanner_total += $hits;
+
+		switch ( $group_by ) {
+			case 'day':
+				$key = (string) $row->day;
+				break;
+			case 'ip':
+				$key = ( null === $row->ip_hash || '' === $row->ip_hash ) ? '(unknown)' : (string) $row->ip_hash;
+				break;
+			case 'url':
+				$key = $url;
+				break;
+			case 'category':
+			default:
+				$key = $category;
+				break;
+		}
+
+		if ( ! isset( $agg[ $key ] ) ) {
+			$agg[ $key ] = 0;
+		}
+		$agg[ $key ] += $hits;
+	}
+
+	if ( 'day' === $group_by ) {
+		krsort( $agg );
+	} else {
+		arsort( $agg );
+	}
+
+	$distinct = count( $agg );
+
+	$rows_out = array();
+	foreach ( $agg as $key => $count ) {
+		$rows_out[] = array(
+			'key'   => $key,
+			'count' => (int) $count,
+		);
+	}
+
+	$truncated = false;
+	if ( $limit > 0 && count( $rows_out ) > $limit ) {
+		$rows_out  = array_slice( $rows_out, 0, $limit );
+		$truncated = true;
+	}
+
+	$total = $scanner_total + $benign_total;
+
+	return array(
+		'rows'          => $rows_out,
+		'scanner_total' => $scanner_total,
+		'benign_total'  => $benign_total,
+		'total'         => $total,
+		'scanner_pct'   => $total > 0 ? round( ( $scanner_total / $total ) * 100, 1 ) : 0.0,
+		'distinct'      => $distinct,
+		'group_by'      => $group_by,
+		'days'          => $days,
+		'period'        => $days > 0
+			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
+			: 'all time',
+		'truncated'     => $truncated,
+	);
+}


### PR DESCRIPTION
## Root cause

`search_attack` was frozen at **exactly 109** for the full 28d window (and across 3 agent sessions) while 404s ran ~8,850/day. It is **not** a dead pipeline — it is a **classification/partition gap**.

`search_attack` is only ever written in one place: `extrachill_analytics_ability_track_event()` reclassifies an event to `search_attack` when `event_type === 'search'` **and** the submitted `search_term` matches `extrachill_analytics_classify_search_payload()`. That classifier only sees terms submitted through the **on-site search form**.

The live attack volume today is a **URL/path scanner storm** — requests for `/.env`, `/credentials.json`, `/wp-content/plugins/...`, `/wp-json/wp/v2/users`, `/actuator/env`, etc. Those **404 without ever touching the search box**, so they never reach the search-term classifier. `search_attack` is a stale residual count from the old on-site-probe era; the pipeline is healthy (the `search` counter moves freely).

## DB evidence (live, `c8c_extrachill_analytics_events`)

**1. Counts by event type (28d):**

| event_type | count (28d) | first_seen | last_seen |
|---|---|---|---|
| `404_error` | 246,194 | 2026-05-03 | **2026-05-31 (live)** |
| `search` | 10,873 | 2026-05-03 | 2026-05-31 (live) |
| `search_attack` | **109** | 2026-05-04 | **2026-05-07 (stale, ~24d old)** |

**2. `search_attack` monthly histogram — it stopped growing in early May:**

| month | count |
|---|---|
| 2026-05 | 109 |
| 2026-04 | 15,570 |
| 2026-03 | 2,936 |
| 2026-02 | 15 |

Most-recent `search_attack` row: **2026-05-07 23:31:54** — frozen since. All-time total 18,630.

**3. Current 404 scanner shape (top 7d):** `/login/`, `/ip`, `/?author=2`, `/wp-includes/wlwmanifest.xml`, `/ALFA_DATA/alfacgiapi/perl.alfa`, `/wp-content/plugins/apikey/apikey.php.suspected`, `/credentials.json`, `/google-credentials.json`, `/service-account.json`, `/firebase-adminsdk.json`, `/actuator/env`, `/secrets.json`, `/sa-key.json`, … — overwhelmingly **secret/credential/config probes, plugin/wp-includes probing, user enumeration, and admin/bot path probes**. None are on-site search terms. Many were previously buried in the `content` catch-all.

**4. Scanner-shaped vs benign:** see verification below.

## Chosen option: (b) — separate 404-scanner counter

The evidence is decisive: `search_attack` rows are stale and the storm is all 404-path scanning, which is a **distinct attack surface** from on-site search injection. Forcing path-scanning through the search classifier would be wrong (it never submits a search term). So:

- **Keep `search_attack` as-is** — it correctly measures on-site search-form injection; it's simply quiet now.
- **Add a separate, trustworthy 404-scanner counter** for the URL/path storm.

## What was added

**`inc/core/404-categorizer.php`:**
- New categories that were previously swallowed by the `content` catch-all: `secret-probe` (`.env`, `.git/`, `.aws/`, `.ssh/`, `.svn/`, `.htpasswd`, `.npmrc`…), `config-probe` (wp-config backups, db dumps, `credentials.json`, service-account/firebase/gcp keys, `phpinfo.php`, `actuator/`, `telescope/`, laravel logs…), and `wpjson-user-enum` (`/wp-json/wp/v2/users`).
- New helper `extrachill_analytics_is_scanner_404_category()` returning true for `sql-injection`, `secret-probe`, `config-probe`, `wpjson-user-enum`, `php-probe`, `plugin-probe`, `wp-includes-probe`, `bot-probe`, `author-enum`, `ad-sponsor-probe`. Filterable via `extrachill_analytics_scanner_404_categories`.

**`inc/core/abilities/get-scanner-404-summary.php` (new ability `extrachill/get-scanner-404-summary`):**
- Counts `404_error` events whose URL is scanner-shaped, **categorized at query time** via `extrachill_analytics_categorize_404_url()` on the stored `requested_url` (in `event_data` JSON). Grouped by `category` / `day` / `ip` / `url` over a window.
- Returns `scanner_total`, `benign_total`, `total`, `scanner_pct`, `distinct`, `rows`, period metadata — a direct WAF-scoping signal.
- Mirrors existing ability conventions: self-registers on `wp_abilities_api_init`, `manage_options || WP_CLI` permission, `show_in_rest => false`, readonly/idempotent annotations, `days`/`group_by`/`limit`/`blog_id` inputs. **No new DB columns/tables. No AJAX.** Registered in both `inc/core/abilities.php` and the plugin bootstrap `require_once` list.

**`inc/core/abilities/get-attack-summary.php`:** documented the two-surface split — `search_attack` = on-site search injection; scanner-404 = URL/path scanner storm. A low/flat `search_attack` means on-site search injection is quiet, **not** that scanning stopped.

## Verification (run against live DB on the install)

Per-URL categorization confirmed correct:
```
/credentials.json            -> config-probe       [SCANNER]
/.env                        -> secret-probe       [SCANNER]
/.git/config                 -> secret-probe       [SCANNER]
/wp-json/wp/v2/users         -> wpjson-user-enum   [SCANNER]
/actuator/env                -> config-probe       [SCANNER]
/?author=2                   -> author-enum        [SCANNER]
/login/                      -> bot-probe          [SCANNER]
/wp-includes/wlwmanifest.xml -> wp-includes-probe  [SCANNER]
/jerry-garcia-ties           -> content            (benign)
/2016/02/foo.html            -> legacy-html        (benign)
```

`get-scanner-404-summary` (group_by=category, 28d) against live data:
```
bot-probe            5641
plugin-probe         2912
config-probe         1184
wp-includes-probe     445
php-probe             419
author-enum           149
wpjson-user-enum        6
secret-probe            2

scanner_total = 10,758   (~384/day)
benign_total  = 235,061
total         = 245,819
```

**The new counter reports 10,758 scanner-shaped 404s/28d vs the frozen 109 `search_attack` — a realistic, trustworthy attack-volume signal for scoping a Cloudflare WAF rule.** `php -l` clean on all changed files.

## Tests
No PHPUnit tests exist in the repo (`composer.json` declares a `test` script but there is no `tests/` suite); the `phpcs`/`lint:php` scripts require dev deps not installed in this environment. Verification was done via live-DB execution of the new logic (above).

Closes #25