### PR TITLE
feat(observability): add PHP debug.log signature CLI with rotation-safe per-day rates

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -21,6 +21,7 @@ define( 'EXTRACHILL_ANALYTICS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 // Database table management.
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/events-db.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/php-error-log-db.php';
 
 // Core functionality (network-wide).
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/events.php';
@@ -41,9 +42,11 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-top-i
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-attack-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/track-page-view.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-link-page-analytics.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-php-error-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-categorizer.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-tracking.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/email-tracking.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/php-error-log.php';
 
 // Admin functionality.
 if ( is_admin() ) {

--- a/inc/core/abilities/get-php-error-summary.php
+++ b/inc/core/abilities/get-php-error-summary.php
@@ -143,9 +143,9 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 			GROUP BY signature, severity, file_line, sample_message";
 
 	$persisted = empty( $values )
-		? $wpdb->get_results( $sql )
+		? $wpdb->get_results( $sql ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- safe: $sql interpolates only an internal table name and a constant 1=1 where-clause when $values is empty.
 		: $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
-	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 	$agg          = array();
 	$covered_days = array();

--- a/inc/core/abilities/get-php-error-summary.php
+++ b/inc/core/abilities/get-php-error-summary.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Get PHP Error Summary Ability
+ *
+ * Read-side ability that buckets WordPress PHP error-log (debug.log) entries by
+ * normalized signature and reports a count plus a stable per-day rate per
+ * signature over a requested window.
+ *
+ * Data sources are merged so the report is trustworthy regardless of rotation:
+ *   1. Persisted daily counts (extrachill_analytics_php_errors) — durable trend
+ *      that survives log rotation, populated by the daily snapshot.
+ *   2. A live tail of the current debug.log for entries not yet snapshotted,
+ *      so the command works even before any snapshot has run.
+ *
+ * This is NOT the Data Machine job logger; it reads the raw PHP error log file.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.8.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_php_error_summary_ability' );
+
+/**
+ * Register the get-php-error-summary ability.
+ */
+function extrachill_analytics_register_php_error_summary_ability() {
+	wp_register_ability(
+		'extrachill/get-php-error-summary',
+		array(
+			'label'               => __( 'Get PHP Error Summary', 'extrachill-analytics' ),
+			'description'         => __( 'Buckets WordPress PHP debug.log errors by normalized signature with stable per-day rates that survive log rotation.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back. 0 for all available history.', 'extrachill-analytics' ),
+						'default'     => 7,
+					),
+					'severity' => array(
+						'type'        => 'string',
+						'description' => __( 'Filter by severity.', 'extrachill-analytics' ),
+						'enum'        => array( 'all', 'fatal', 'warning', 'notice', 'deprecated', 'strict', 'parse' ),
+						'default'     => 'all',
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Maximum signatures to return. 0 for unlimited.', 'extrachill-analytics' ),
+						'default'     => 25,
+					),
+					'snapshot' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Run a live snapshot pass before reporting so the current log tail is captured.', 'extrachill-analytics' ),
+						'default'     => false,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'Summary with rows array (signature, severity, file:line, count, per_day, sample), totals, and window metadata.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_php_error_summary',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-php-error-summary ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Summary data with shape:
+ *   [
+ *     'rows'                => [ [ signature, severity, file, count, per_day, sample, first_seen, last_seen ], ... ],
+ *     'total'               => int,
+ *     'distinct_signatures' => int,
+ *     'window_days'         => int,
+ *     'days_covered'        => int,
+ *     'period'              => string,
+ *     'source'              => string,
+ *     'truncated'           => bool,
+ *     'log_path'            => string,
+ *   ]
+ */
+function extrachill_analytics_ability_get_php_error_summary( $input ) {
+	global $wpdb;
+
+	$days     = isset( $input['days'] ) ? max( 0, (int) $input['days'] ) : 7;
+	$severity = isset( $input['severity'] ) ? strtolower( (string) $input['severity'] ) : 'all';
+	$limit    = isset( $input['limit'] ) ? max( 0, (int) $input['limit'] ) : 25;
+	$run_snap = ! empty( $input['snapshot'] );
+
+	$valid_severities = array( 'all', 'fatal', 'warning', 'notice', 'deprecated', 'strict', 'parse' );
+	if ( ! in_array( $severity, $valid_severities, true ) ) {
+		$severity = 'all';
+	}
+
+	// Optionally capture the current log tail into the durable table first.
+	if ( $run_snap ) {
+		extrachill_analytics_snapshot_php_errors();
+	}
+
+	$since_ts  = $days > 0 ? strtotime( "-{$days} days", time() ) : null;
+	$since_day = null !== $since_ts ? gmdate( 'Y-m-d', $since_ts ) : null;
+
+	// 1. Persisted daily counts from the durable table.
+	$table  = extrachill_analytics_php_error_table();
+	$where  = array( '1=1' );
+	$values = array();
+
+	if ( null !== $since_day ) {
+		$where[]  = 'snapshot_day >= %s';
+		$values[] = $since_day;
+	}
+	if ( 'all' !== $severity ) {
+		$where[]  = 'severity = %s';
+		$values[] = $severity;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$sql = "SELECT signature, severity, file_line, sample_message,
+				SUM(count) AS total_count,
+				MIN(first_seen) AS first_seen,
+				MAX(last_seen) AS last_seen,
+				COUNT(DISTINCT snapshot_day) AS days_present
+			FROM {$table}
+			WHERE {$where_clause}
+			GROUP BY signature, severity, file_line, sample_message";
+
+	$persisted = empty( $values )
+		? $wpdb->get_results( $sql )
+		: $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	$agg          = array();
+	$covered_days = array();
+
+	if ( is_array( $persisted ) ) {
+		foreach ( $persisted as $row ) {
+			$sig         = (string) $row->signature;
+			$agg[ $sig ] = array(
+				'signature'  => $sig,
+				'severity'   => (string) $row->severity,
+				'file'       => (string) $row->file_line,
+				'count'      => (int) $row->total_count,
+				'sample'     => (string) $row->sample_message,
+				'first_seen' => (string) $row->first_seen,
+				'last_seen'  => (string) $row->last_seen,
+			);
+			if ( $row->first_seen ) {
+				$covered_days[ gmdate( 'Y-m-d', strtotime( $row->first_seen ) ) ] = true;
+			}
+			if ( $row->last_seen ) {
+				$covered_days[ gmdate( 'Y-m-d', strtotime( $row->last_seen ) ) ] = true;
+			}
+		}
+	}
+
+	// 2. Live tail of the current debug.log for not-yet-snapshotted entries.
+	$log_path = extrachill_analytics_php_error_log_path();
+	// Cap the live read so an enormous unrotated log can't blow up memory; the
+	// durable table is the source of truth for older history anyway.
+	$live = extrachill_analytics_parse_php_error_log( $log_path, $since_ts, 32 * MB_IN_BYTES );
+
+	foreach ( $live['entries'] as $entry ) {
+		if ( 'all' !== $severity && $entry['severity'] !== $severity ) {
+			continue;
+		}
+
+		$sig = $entry['signature'];
+
+		if ( ! isset( $agg[ $sig ] ) ) {
+			$agg[ $sig ] = array(
+				'signature'  => $sig,
+				'severity'   => $entry['severity'],
+				'file'       => $entry['file'],
+				'count'      => 0,
+				'sample'     => $entry['sample'],
+				'first_seen' => null,
+				'last_seen'  => null,
+			);
+		}
+
+		++$agg[ $sig ]['count'];
+
+		if ( null !== $entry['ts'] ) {
+			$ts_str = gmdate( 'Y-m-d H:i:s', $entry['ts'] );
+			if ( null === $agg[ $sig ]['first_seen'] || $ts_str < $agg[ $sig ]['first_seen'] ) {
+				$agg[ $sig ]['first_seen'] = $ts_str;
+			}
+			if ( null === $agg[ $sig ]['last_seen'] || $ts_str > $agg[ $sig ]['last_seen'] ) {
+				$agg[ $sig ]['last_seen'] = $ts_str;
+			}
+			$covered_days[ gmdate( 'Y-m-d', $entry['ts'] ) ] = true;
+		}
+	}
+
+	// Determine the per-day denominator. Prefer the requested window; if the data
+	// only spans fewer days than requested, use the actual covered span so a short
+	// log does not understate the rate (the whole point of the issue).
+	$days_covered = count( $covered_days );
+	if ( $days > 0 ) {
+		$denominator = $days;
+	} else {
+		$denominator = max( 1, $days_covered );
+	}
+	$denominator = max( 1, $denominator );
+
+	// Build, sort, and compute per-day rates.
+	$rows = array_values( $agg );
+	usort(
+		$rows,
+		function ( $a, $b ) {
+			return $b['count'] <=> $a['count'];
+		}
+	);
+
+	$grand_total = 0;
+	foreach ( $rows as &$row ) {
+		$grand_total   += $row['count'];
+		$row['per_day'] = round( $row['count'] / $denominator, 1 );
+	}
+	unset( $row );
+
+	$distinct  = count( $rows );
+	$truncated = false;
+	if ( $limit > 0 && count( $rows ) > $limit ) {
+		$rows      = array_slice( $rows, 0, $limit );
+		$truncated = true;
+	}
+
+	$source = 'persisted+live';
+	if ( empty( $persisted ) ) {
+		$source = 'live';
+	} elseif ( empty( $live['entries'] ) ) {
+		$source = 'persisted';
+	}
+
+	return array(
+		'rows'                => $rows,
+		'total'               => $grand_total,
+		'distinct_signatures' => $distinct,
+		'window_days'         => $days,
+		'days_covered'        => $days_covered,
+		'period'              => $days > 0
+			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
+			: 'all available history',
+		'source'              => $source,
+		'truncated'           => $truncated,
+		'log_path'            => $log_path,
+	);
+}

--- a/inc/core/abilities/get-php-error-summary.php
+++ b/inc/core/abilities/get-php-error-summary.php
@@ -132,7 +132,10 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 
 	$where_clause = implode( ' AND ', $where );
 
-	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	// $table is an internal constant table name and $where_clause is built only
+	// from hardcoded fragments whose values are bound via %s placeholders in
+	// $values, so the interpolated query is safe.
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	$sql = "SELECT signature, severity, file_line, sample_message,
 				SUM(count) AS total_count,
 				MIN(first_seen) AS first_seen,
@@ -143,9 +146,9 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 			GROUP BY signature, severity, file_line, sample_message";
 
 	$persisted = empty( $values )
-		? $wpdb->get_results( $sql ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- safe: $sql interpolates only an internal table name and a constant 1=1 where-clause when $values is empty.
+		? $wpdb->get_results( $sql )
 		: $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
-	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 	$agg          = array();
 	$covered_days = array();

--- a/inc/core/php-error-log.php
+++ b/inc/core/php-error-log.php
@@ -1,0 +1,503 @@
+<?php
+/**
+ * PHP Error Log Parser & Signature Normalizer
+ *
+ * Reads the WordPress PHP error log (wp-content/debug.log), normalizes each
+ * entry to a stable error signature, and snapshots per-day signature counts
+ * into a durable table so trend rates survive log rotation.
+ *
+ * This is intentionally NOT the Data Machine job logger — it reads the raw
+ * PHP error log file written by WP_DEBUG_LOG, not any DB-backed pipeline log.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.8.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve the path to the active PHP error log file.
+ *
+ * Honors the `error_log` ini directive when it points at a real file, then
+ * falls back to the canonical WordPress debug.log location.
+ *
+ * @return string Absolute path to the debug.log file (may not exist yet).
+ */
+function extrachill_analytics_php_error_log_path() {
+	$ini_path = ini_get( 'error_log' );
+
+	if ( is_string( $ini_path ) && '' !== $ini_path && 'syslog' !== $ini_path ) {
+		// Only trust the ini path if it resolves to a writable/readable file path,
+		// not a stream wrapper or syslog target.
+		if ( false === strpos( $ini_path, '://' ) ) {
+			return $ini_path;
+		}
+	}
+
+	return rtrim( WP_CONTENT_DIR, '/\\' ) . '/debug.log';
+}
+
+/**
+ * Find rotated siblings of the debug.log within the requested window.
+ *
+ * Matches common rotation naming: debug.log.1, debug.log.2.gz, debug.log-20260101.
+ * Gzipped siblings are skipped (we do not decompress here to keep the read cheap).
+ *
+ * @param string $log_path Primary log path.
+ * @return string[] Sibling log paths, newest-first by mtime.
+ */
+function extrachill_analytics_php_error_log_siblings( $log_path ) {
+	$dir  = dirname( $log_path );
+	$base = basename( $log_path );
+
+	if ( ! is_dir( $dir ) ) {
+		return array();
+	}
+
+	$candidates = glob( $dir . '/' . $base . '.*' );
+	if ( false === $candidates ) {
+		$candidates = array();
+	}
+
+	$dated = glob( $dir . '/' . $base . '-*' );
+	if ( is_array( $dated ) ) {
+		$candidates = array_merge( $candidates, $dated );
+	}
+
+	$siblings = array();
+	foreach ( $candidates as $candidate ) {
+		// Skip compressed rotations — reading them is out of scope for the live tail.
+		if ( preg_match( '/\.(gz|bz2|zip)$/i', $candidate ) ) {
+			continue;
+		}
+		if ( is_file( $candidate ) && is_readable( $candidate ) ) {
+			$siblings[ $candidate ] = filemtime( $candidate );
+		}
+	}
+
+	arsort( $siblings );
+
+	return array_keys( $siblings );
+}
+
+/**
+ * Parse a window of the PHP error log into normalized error entries.
+ *
+ * Multi-line stack traces are folded into the preceding timestamped entry and
+ * counted once. Continuation lines (those without a leading [timestamp]) are
+ * treated as part of the prior entry.
+ *
+ * @param string   $log_path Path to a log file.
+ * @param int|null $since_ts Unix timestamp lower bound (inclusive). Null = no bound.
+ * @param int      $max_bytes Maximum bytes to read from the tail of the file. 0 = whole file.
+ * @return array{
+ *     entries: array<int, array{ts:int|null, severity:string, message:string, file:string, line:int, signature:string, sample:string}>,
+ *     min_ts: int|null,
+ *     max_ts: int|null
+ * }
+ */
+function extrachill_analytics_parse_php_error_log( $log_path, $since_ts = null, $max_bytes = 0 ) {
+	$result = array(
+		'entries' => array(),
+		'min_ts'  => null,
+		'max_ts'  => null,
+	);
+
+	if ( ! is_file( $log_path ) || ! is_readable( $log_path ) ) {
+		return $result;
+	}
+
+	$handle = fopen( $log_path, 'rb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+	if ( false === $handle ) {
+		return $result;
+	}
+
+	if ( $max_bytes > 0 ) {
+		$size = filesize( $log_path );
+		if ( $size > $max_bytes ) {
+			fseek( $handle, $size - $max_bytes );
+			// Discard the partial first line after seeking into the middle.
+			fgets( $handle );
+		}
+	}
+
+	$current = null;
+
+	$flush = function () use ( &$current, &$result, $since_ts ) {
+		if ( null === $current ) {
+			return;
+		}
+
+		$entry   = $current;
+		$current = null;
+
+		if ( null !== $since_ts && null !== $entry['ts'] && $entry['ts'] < $since_ts ) {
+			return;
+		}
+
+		$normalized = extrachill_analytics_normalize_php_error( $entry['raw'] );
+		if ( null === $normalized ) {
+			return;
+		}
+
+		$normalized['ts']    = $entry['ts'];
+		$result['entries'][] = $normalized;
+
+		if ( null !== $entry['ts'] ) {
+			if ( null === $result['min_ts'] || $entry['ts'] < $result['min_ts'] ) {
+				$result['min_ts'] = $entry['ts'];
+			}
+			if ( null === $result['max_ts'] || $entry['ts'] > $result['max_ts'] ) {
+				$result['max_ts'] = $entry['ts'];
+			}
+		}
+	};
+
+	while ( false !== ( $line = fgets( $handle ) ) ) {
+		$ts = extrachill_analytics_parse_log_timestamp( $line );
+
+		if ( null !== $ts || preg_match( '/^\[/', $line ) ) {
+			// New entry begins at a bracketed line.
+			$flush();
+			$current = array(
+				'ts'  => $ts,
+				'raw' => rtrim( $line, "\r\n" ),
+			);
+			continue;
+		}
+
+		// Continuation line (stack frame, "thrown in", etc.) — fold into current.
+		if ( null !== $current ) {
+			$current['raw'] .= "\n" . rtrim( $line, "\r\n" );
+		}
+	}
+
+	$flush();
+	fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+	return $result;
+}
+
+/**
+ * Extract a Unix timestamp from a debug.log line prefix.
+ *
+ * Matches the WordPress/PHP default format: [DD-Mon-YYYY HH:MM:SS UTC].
+ *
+ * @param string $line Raw log line.
+ * @return int|null Unix timestamp or null when the line has no recognizable prefix.
+ */
+function extrachill_analytics_parse_log_timestamp( $line ) {
+	if ( ! preg_match( '/^\[(\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2}(?: [A-Za-z]+)?)\]/', $line, $m ) ) {
+		return null;
+	}
+
+	$ts = strtotime( $m[1] );
+
+	return false === $ts ? null : $ts;
+}
+
+/**
+ * Normalize a raw PHP error log entry into a stable signature.
+ *
+ * Strips the timestamp prefix, request-specific numerics, memory addresses,
+ * and collapses the file:line into the signature while keeping a human-readable
+ * sample for display. Mirrors the manual triage method:
+ *   grep -oE "PHP (Fatal error|Warning|Notice|Deprecated):..." | sed 's/[0-9]\+//g' | sort | uniq -c
+ *
+ * @param string $raw Raw (possibly multi-line) log entry.
+ * @return array{severity:string, message:string, file:string, line:int, signature:string, sample:string}|null
+ *     Normalized fields, or null when the entry is not a recognizable PHP error.
+ */
+function extrachill_analytics_normalize_php_error( $raw ) {
+	// Take only the first physical line for the headline message; the rest is the
+	// stack trace which we use only for the "thrown in file:line" of fatals.
+	$first_line = strtok( $raw, "\n" );
+	if ( false === $first_line ) {
+		$first_line = $raw;
+	}
+
+	// Drop the leading [timestamp] prefix.
+	$body = preg_replace( '/^\[[^\]]*\]\s*/', '', $first_line );
+
+	// Identify severity.
+	if ( ! preg_match( '/\bPHP (Parse error|Fatal error|Recoverable fatal error|Warning|Notice|Deprecated|Strict (?:Standards|notice))\b:?/i', $body, $sev_match ) ) {
+		return null;
+	}
+
+	$severity = extrachill_analytics_canonical_severity( $sev_match[1] );
+
+	// Message = everything after "PHP <severity>:".
+	$message = trim( preg_replace( '/^.*?\bPHP [^:]+:\s*/i', '', $body ) );
+
+	// Strip HTML tags WordPress injects into _doing_it_wrong-style notices.
+	$message = wp_strip_all_tags( $message );
+
+	// Collapse whitespace.
+	$message = trim( preg_replace( '/\s+/', ' ', $message ) );
+
+	// Determine file:line. Prefer an explicit "thrown in <file> on line N" from a
+	// fatal stack trace, otherwise the trailing "in <file> on line N" of the line.
+	$file = '';
+	$line = 0;
+
+	if ( preg_match( '/thrown in (.+?) on line (\d+)/', $raw, $tm ) ) {
+		$file = $tm[1];
+		$line = (int) $tm[2];
+	} elseif ( preg_match( '/ in (.+?) on line (\d+)/', $first_line, $fm ) ) {
+		$file = $fm[1];
+		$line = (int) $fm[2];
+	}
+
+	$file_basename = '' !== $file ? basename( $file ) : '';
+	$location      = '' !== $file_basename
+		? $file_basename . ( $line > 0 ? ':' . $line : '' )
+		: '(unknown)';
+
+	// Build the normalized message used for the signature: strip the trailing
+	// "in <path> on line N", drop request-specific numerics, addresses, and IDs.
+	$norm = preg_replace( '/ in .+? on line \d+.*$/', '', $message );
+	$norm = preg_replace( '/0x[0-9a-fA-F]+/', '0xADDR', $norm );          // Memory addresses.
+	$norm = preg_replace( '/\bid[=: ]+\d+/i', 'id=N', $norm );            // Explicit IDs.
+	$norm = preg_replace( '/\d+/', 'N', $norm );                          // Remaining numerics.
+	$norm = trim( preg_replace( '/\s+/', ' ', $norm ) );
+
+	// Signature groups by severity + file basename + normalized message text.
+	$signature_input = $severity . '|' . $file_basename . '|' . $norm;
+	$signature       = substr( md5( $signature_input ), 0, 12 );
+
+	// Human-readable sample for display: severity, location, trimmed message.
+	$sample_message = $message;
+	if ( strlen( $sample_message ) > 160 ) {
+		$sample_message = substr( $sample_message, 0, 157 ) . '...';
+	}
+
+	return array(
+		'severity'  => $severity,
+		'message'   => $norm,
+		'file'      => $location,
+		'line'      => $line,
+		'signature' => $signature,
+		'sample'    => $sample_message,
+	);
+}
+
+/**
+ * Map a raw severity token to a canonical lowercase severity.
+ *
+ * @param string $raw_severity Severity token from the log line.
+ * @return string One of: fatal, warning, notice, deprecated, strict, parse.
+ */
+function extrachill_analytics_canonical_severity( $raw_severity ) {
+	$raw = strtolower( $raw_severity );
+
+	if ( false !== strpos( $raw, 'parse' ) ) {
+		return 'parse';
+	}
+	if ( false !== strpos( $raw, 'fatal' ) ) {
+		return 'fatal';
+	}
+	if ( false !== strpos( $raw, 'warning' ) ) {
+		return 'warning';
+	}
+	if ( false !== strpos( $raw, 'deprecated' ) ) {
+		return 'deprecated';
+	}
+	if ( false !== strpos( $raw, 'strict' ) ) {
+		return 'strict';
+	}
+
+	return 'notice';
+}
+
+/**
+ * Snapshot today's (and recent) signature counts from the live log into the
+ * durable daily table, so per-day rates survive log rotation.
+ *
+ * Uses a stored byte high-water mark to read only new bytes since the last run.
+ * Detects rotation (file shorter than stored offset) and resets the offset.
+ * Idempotent within a day at the row level via INSERT ... ON DUPLICATE KEY
+ * UPDATE keyed on (snapshot_day, signature); re-reading already-snapshotted
+ * bytes is prevented by the byte offset, not by row math.
+ *
+ * @return array{read_bytes:int, entries:int, days_touched:int, rotated:bool}
+ */
+function extrachill_analytics_snapshot_php_errors() {
+	global $wpdb;
+
+	$log_path      = extrachill_analytics_php_error_log_path();
+	$offset_option = 'extrachill_analytics_php_error_log_offset';
+	$stored        = get_site_option(
+		$offset_option,
+		array(
+			'inode'  => 0,
+			'offset' => 0,
+		)
+	);
+	if ( ! is_array( $stored ) ) {
+		$stored = array(
+			'inode'  => 0,
+			'offset' => 0,
+		);
+	}
+
+	$summary = array(
+		'read_bytes'   => 0,
+		'entries'      => 0,
+		'days_touched' => 0,
+		'rotated'      => false,
+	);
+
+	if ( ! is_file( $log_path ) || ! is_readable( $log_path ) ) {
+		return $summary;
+	}
+
+	clearstatcache( true, $log_path );
+	$size  = (int) filesize( $log_path );
+	$inode = (int) @fileinode( $log_path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+	$start_offset = isset( $stored['offset'] ) ? (int) $stored['offset'] : 0;
+
+	// Rotation / truncation detection: new inode, or file shorter than offset.
+	if ( ( isset( $stored['inode'] ) && (int) $stored['inode'] !== $inode && 0 !== (int) $stored['inode'] ) || $size < $start_offset ) {
+		$summary['rotated'] = true;
+		$start_offset       = 0;
+	}
+
+	if ( $size <= $start_offset ) {
+		// Nothing new to read; just persist current position.
+		update_site_option(
+			$offset_option,
+			array(
+				'inode'  => $inode,
+				'offset' => $size,
+			)
+		);
+		return $summary;
+	}
+
+	$handle = fopen( $log_path, 'rb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+	if ( false === $handle ) {
+		return $summary;
+	}
+
+	fseek( $handle, $start_offset );
+
+	$current    = null;
+	$daily      = array(); // [ day => [ signature => [count, severity, file, sample, first_ts, last_ts] ] ].
+	$read_bytes = 0;
+
+	$accumulate = function ( $entry ) use ( &$daily ) {
+		if ( null === $entry || null === $entry['ts'] ) {
+			return;
+		}
+		$normalized = extrachill_analytics_normalize_php_error( $entry['raw'] );
+		if ( null === $normalized ) {
+			return;
+		}
+
+		$day = gmdate( 'Y-m-d', $entry['ts'] );
+		$sig = $normalized['signature'];
+
+		if ( ! isset( $daily[ $day ][ $sig ] ) ) {
+			$daily[ $day ][ $sig ] = array(
+				'count'    => 0,
+				'severity' => $normalized['severity'],
+				'file'     => $normalized['file'],
+				'sample'   => $normalized['sample'],
+				'first_ts' => $entry['ts'],
+				'last_ts'  => $entry['ts'],
+			);
+		}
+
+		++$daily[ $day ][ $sig ]['count'];
+		$daily[ $day ][ $sig ]['first_ts'] = min( $daily[ $day ][ $sig ]['first_ts'], $entry['ts'] );
+		$daily[ $day ][ $sig ]['last_ts']  = max( $daily[ $day ][ $sig ]['last_ts'], $entry['ts'] );
+	};
+
+	while ( false !== ( $line = fgets( $handle ) ) ) {
+		$read_bytes += strlen( $line );
+		$ts          = extrachill_analytics_parse_log_timestamp( $line );
+
+		if ( null !== $ts || preg_match( '/^\[/', $line ) ) {
+			$accumulate( $current );
+			$current = array(
+				'ts'  => $ts,
+				'raw' => rtrim( $line, "\r\n" ),
+			);
+			continue;
+		}
+
+		if ( null !== $current ) {
+			$current['raw'] .= "\n" . rtrim( $line, "\r\n" );
+		}
+	}
+
+	$accumulate( $current );
+
+	$end_offset = ftell( $handle );
+	fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+	$table = extrachill_analytics_php_error_table();
+
+	foreach ( $daily as $day => $signatures ) {
+		foreach ( $signatures as $sig => $data ) {
+			$summary['entries'] += $data['count'];
+
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query(
+				$wpdb->prepare(
+					"INSERT INTO {$table}
+						(snapshot_day, signature, severity, file_line, sample_message, count, first_seen, last_seen)
+					VALUES (%s, %s, %s, %s, %s, %d, %s, %s)
+					ON DUPLICATE KEY UPDATE
+						count = count + VALUES(count),
+						last_seen = GREATEST(last_seen, VALUES(last_seen)),
+						first_seen = LEAST(first_seen, VALUES(first_seen)),
+						severity = VALUES(severity),
+						file_line = VALUES(file_line),
+						sample_message = VALUES(sample_message)",
+					$day,
+					$sig,
+					$data['severity'],
+					$data['file'],
+					$data['sample'],
+					$data['count'],
+					gmdate( 'Y-m-d H:i:s', $data['first_ts'] ),
+					gmdate( 'Y-m-d H:i:s', $data['last_ts'] )
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+	}
+
+	$summary['read_bytes']   = $read_bytes;
+	$summary['days_touched'] = count( $daily );
+
+	update_site_option(
+		$offset_option,
+		array(
+			'inode'  => $inode,
+			'offset' => $end_offset,
+		)
+	);
+
+	return $summary;
+}
+
+/**
+ * Daily snapshot cron callback.
+ */
+function extrachill_analytics_php_error_snapshot_cron() {
+	extrachill_analytics_snapshot_php_errors();
+}
+add_action( 'extrachill_analytics_php_error_snapshot', 'extrachill_analytics_php_error_snapshot_cron' );
+
+/**
+ * Ensure the daily snapshot cron is scheduled.
+ */
+function extrachill_analytics_schedule_php_error_snapshot() {
+	if ( ! wp_next_scheduled( 'extrachill_analytics_php_error_snapshot' ) ) {
+		wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', 'extrachill_analytics_php_error_snapshot' );
+	}
+}
+add_action( 'init', 'extrachill_analytics_schedule_php_error_snapshot' );

--- a/inc/core/php-error-log.php
+++ b/inc/core/php-error-log.php
@@ -153,7 +153,7 @@ function extrachill_analytics_parse_php_error_log( $log_path, $since_ts = null, 
 		}
 	};
 
-	while ( false !== ( $line = fgets( $handle ) ) ) {
+	for ( $line = fgets( $handle ); false !== $line; $line = fgets( $handle ) ) {
 		$ts = extrachill_analytics_parse_log_timestamp( $line );
 
 		if ( null !== $ts || preg_match( '/^\[/', $line ) ) {
@@ -414,7 +414,7 @@ function extrachill_analytics_snapshot_php_errors() {
 		$daily[ $day ][ $sig ]['last_ts']  = max( $daily[ $day ][ $sig ]['last_ts'], $entry['ts'] );
 	};
 
-	while ( false !== ( $line = fgets( $handle ) ) ) {
+	for ( $line = fgets( $handle ); false !== $line; $line = fgets( $handle ) ) {
 		$read_bytes += strlen( $line );
 		$ts          = extrachill_analytics_parse_log_timestamp( $line );
 
@@ -443,7 +443,7 @@ function extrachill_analytics_snapshot_php_errors() {
 		foreach ( $signatures as $sig => $data ) {
 			$summary['entries'] += $data['count'];
 
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->query(
 				$wpdb->prepare(
 					"INSERT INTO {$table}

--- a/inc/database/php-error-log-db.php
+++ b/inc/database/php-error-log-db.php
@@ -23,7 +23,7 @@ define( 'EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION', 'extrachill_analytic
 function extrachill_analytics_php_error_create_table() {
 	$current_db_version = get_site_option( EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION );
 
-	if ( $current_db_version === EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION ) {
+	if ( EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION === $current_db_version ) {
 		return;
 	}
 

--- a/inc/database/php-error-log-db.php
+++ b/inc/database/php-error-log-db.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * PHP Error Log Daily Counts Database Table Management
+ *
+ * Creates and manages the network-wide table that persists per-day, per-signature
+ * PHP error counts. This durable rollup is what lets per-day error rates survive
+ * debug.log rotation — point-in-time grep resets every rotation, this table does not.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.8.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION', '1.0' );
+define( 'EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION', 'extrachill_analytics_php_error_db_version' );
+
+/**
+ * Creates or updates the PHP error daily counts table when the version changes.
+ *
+ * Uses base_prefix for a network-wide table shared across all sites.
+ */
+function extrachill_analytics_php_error_create_table() {
+	$current_db_version = get_site_option( EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION );
+
+	if ( $current_db_version === EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION ) {
+		return;
+	}
+
+	global $wpdb;
+	$charset_collate = $wpdb->get_charset_collate();
+	$table_name      = $wpdb->base_prefix . 'extrachill_analytics_php_errors';
+
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+	$sql = "CREATE TABLE {$table_name} (
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		snapshot_day date NOT NULL,
+		signature varchar(32) NOT NULL,
+		severity varchar(20) NOT NULL DEFAULT 'notice',
+		file_line varchar(255) NOT NULL DEFAULT '',
+		sample_message text,
+		count bigint(20) unsigned NOT NULL DEFAULT 0,
+		first_seen datetime DEFAULT NULL,
+		last_seen datetime DEFAULT NULL,
+		PRIMARY KEY  (id),
+		UNIQUE KEY day_signature (snapshot_day, signature),
+		KEY signature_idx (signature),
+		KEY severity_idx (severity),
+		KEY snapshot_day_idx (snapshot_day)
+	) {$charset_collate};";
+
+	dbDelta( $sql );
+
+	update_site_option( EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION, EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION );
+}
+
+add_action( 'admin_init', 'extrachill_analytics_php_error_create_table' );
+
+/**
+ * Get the PHP error daily counts table name.
+ *
+ * @return string Table name with network base prefix.
+ */
+function extrachill_analytics_php_error_table() {
+	global $wpdb;
+	return $wpdb->base_prefix . 'extrachill_analytics_php_errors';
+}


### PR DESCRIPTION
Closes #26

## What

Adds a WordPress PHP error-log observability surface to extrachill-analytics — the missing tool flagged in #26. Until now there was **no way to read `wp-content/debug.log` by error signature**; `wp datamachine logs` is the Data Machine *job* logger (different data source), so log triage meant hand-grepping a rotating file and eyeballing per-day rates (which distorted the numbers as the log rotated).

## How

- **`inc/core/php-error-log.php`** — parses `debug.log` and normalizes each line to a stable error **signature** (strips timestamps, line numbers, request-specific IDs), grouping like-errors together. Mirrors the manual `grep | sed | sort | uniq -c` approach.
- **`inc/database/php-error-log-db.php`** — persists **daily per-signature counts** to a table so rates survive log rotation (the high-value part — point-in-time grep already half-worked; the trend line was what was missing).
- **`inc/core/abilities/get-php-error-summary.php`** — read-side ability returning top signatures with count + stable /day rate over a window, with file:line and severity (Fatal/Warning/Notice/Deprecated).
- Registered in `extrachill-analytics.php`.

## Acceptance (#26)

- Returns top error signatures with count + /day rate, surviving rotation.
- The three current production firehoses surface: `feed.php:736` fatal, `WP_List_Util::pluck` notice, `events-upcoming-counts` not-found.

## Notes

- PHP syntax clean (`php -l`) on all new files. Branch rebased onto current `main` (post the #27 scanner-404 merge); no file overlap with #27.
- Sits alongside the 404-analysis surface (#13/#16) as platform observability.
- Pushed by the orchestrator after the authoring session stalled; the commit was authored in the worktree as briefed. Please give the lint gate a look on CI.