### PR TITLE
build: pin ajv ^8 to fix wp-scripts webpack build on Node 25

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 	"author": "Chris Huber <hello@chubes.net>",
 	"license": "GPL-2.0+",
 	"devDependencies": {
-		"@wordpress/scripts": "^30.15.0"
+		"@wordpress/scripts": "^30.15.0",
+		"ajv": "^8.20.0"
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^7.0.0",


### PR DESCRIPTION
## Summary

`@wordpress/scripts` webpack builds for this plugin silently failed on the live extrachill.com VPS (Node 25). npm hoists **ajv v6.15.0** to top-level `node_modules/ajv`, but `ajv-keywords@5.x` (pulled in via `schema-utils` → `copy-webpack-plugin`) requires **ajv v8** (`ajv/dist/compile/codegen`).

The universal build script downgrades the resulting error to a non-fatal **warning** and ships a **PHP-only artifact with no JS/CSS** — silently stripping the plugin's blocks.

## Reproduced error

```
[webpack-cli] Error: Cannot find module 'ajv/dist/compile/codegen'
```

Confirmed reproducible: after `npm install --legacy-peer-deps`, top-level `node_modules/ajv` was **v6.15.0** and `npm run build` failed with the error above.

## Fix

Pin `"ajv": "^8.20.0"` as a `devDependency` so npm hoists v8 to top-level, allowing `ajv-keywords` to resolve `ajv/dist/compile/codegen`.

## Verification

After the fix, top-level `node_modules/ajv` is **v8.20.0** and `npm run build` compiles successfully:

```
asset analytics.js 12.3 KiB [emitted] [minimized] (name: analytics)
asset analytics.css 2.44 KiB [emitted] (name: analytics)
webpack 5.107.2 compiled successfully in 2113 ms
```

`node -e "console.log(require.resolve('ajv/dist/compile/codegen'))"` now resolves cleanly, and `build/` emits `analytics.js`, `analytics.css`, `analytics-rtl.css`, and `analytics.asset.php`.

## Files changed

- `package.json` — added `"ajv": "^8.20.0"` to `devDependencies`

(`package-lock.json` is not tracked in this repo, so it is not committed.)

Part of Extra-Chill/extrachill-community#126