### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -28,6 +28,14 @@ add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_get_link_pag
  * Register analytics ability category.
  */
 function extrachill_analytics_register_category() {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill-analytics' ) ) {
+		return;
+	}
+
 	wp_register_ability_category(
 		'extrachill-analytics',
 		array(


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "extrachill-analytics" is already registered.
in /var/www/extrachill.com/wp-includes/functions.php on line 6170
```

## Root cause

On the multisite, WordPress core's `wp_abilities_api_categories_init` action fires more than once per request. `extrachill_analytics_register_category()` called `wp_register_ability_category()` unconditionally, so the second hook fire re-registered the already-registered `extrachill-analytics` category and tripped core's `_doing_it_wrong` notice.

## The fix

Guard the registration with core's idempotency check `wp_has_ability_category()` (plus a `function_exists` guard for the API surface) so a repeat fire is a clean no-op. Slug, label, description, and hook are unchanged.