### PR TITLE
refactor: own the canonical team/funnel analytics event-name contract (users#129)

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -24,6 +24,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/events-db.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/php-error-log-db.php';
 
 // Core functionality (network-wide).
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/event-types.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/events.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/security-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';

--- a/inc/core/event-types.php
+++ b/inc/core/event-types.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Canonical Analytics Event-Name Contract
+ *
+ * SINGLE cross-plugin source of truth for the team-experience and
+ * artist-funnel analytics event_type strings (Extra-Chill/extrachill-users#129).
+ *
+ * Why extrachill-analytics owns these names
+ * -----------------------------------------
+ * extrachill-analytics owns the analytics substrate: the events table and
+ * the `extrachill/track-analytics-event` ability that EVERY emitter across
+ * extrachill-users / -studio / -roadie / -artist-platform already calls at
+ * runtime. That ability call is an existing hard runtime dependency on this
+ * plugin — so referencing a constant defined here adds ZERO new coupling.
+ * extrachill-analytics is also `Network: true` (active on every site), so
+ * these constants are guaranteed defined wherever an emitter or reader runs.
+ *
+ * Defining the names ONCE here — and having every emit site AND every reader
+ * reference the constant instead of a bare string literal — means a rename
+ * happens in exactly one place and can never silently desync an emit from a
+ * read (the "permanently-zero metric, no error" failure mode #129 is about).
+ *
+ * Consumers reference these constants directly. They do NOT need a local
+ * string fallback: if extrachill-analytics were ever absent, the
+ * `extrachill/track-analytics-event` ability would also be absent and each
+ * emit helper's existing `if ( ! $ability ) { return 0; }` guard no-ops the
+ * emit before the event_type is ever used.
+ *
+ * @package ExtraChill\Analytics
+ * @since   0.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/** Team-experience events (team membership + Studio + Roadie usage). */
+const EC_ANALYTICS_EVENT_TEAM_MEMBER_ADDED        = 'team_member_added';
+const EC_ANALYTICS_EVENT_TEAM_MEMBER_REMOVED      = 'team_member_removed';
+const EC_ANALYTICS_EVENT_STUDIO_DRAFT_CREATED     = 'studio_draft_created';
+const EC_ANALYTICS_EVENT_STUDIO_SUBMITTED         = 'studio_submitted_for_review';
+const EC_ANALYTICS_EVENT_STUDIO_TRANSCRIPTION_RUN = 'studio_transcription_run';
+const EC_ANALYTICS_EVENT_ROADIE_SESSION_STARTED   = 'roadie_session_started';
+const EC_ANALYTICS_EVENT_ROADIE_TOOL_INVOKED      = 'roadie_tool_invoked';
+
+/** Artist-funnel events (access requests/approvals + profile creation). */
+const EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED = 'artist_access_requested';
+const EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED  = 'artist_access_approved';
+const EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED  = 'artist_profile_created';
+
+/**
+ * The team-experience event set surfaced by the cohort rollup
+ * (`extrachill/get-team-experience-stats` in extrachill-users). Readers
+ * build their query array by iterating this group instead of re-listing
+ * the strings.
+ *
+ * @var string[]
+ */
+const EC_ANALYTICS_TEAM_EXPERIENCE_EVENTS = array(
+	EC_ANALYTICS_EVENT_TEAM_MEMBER_ADDED,
+	EC_ANALYTICS_EVENT_TEAM_MEMBER_REMOVED,
+	EC_ANALYTICS_EVENT_STUDIO_DRAFT_CREATED,
+	EC_ANALYTICS_EVENT_STUDIO_SUBMITTED,
+	EC_ANALYTICS_EVENT_STUDIO_TRANSCRIPTION_RUN,
+	EC_ANALYTICS_EVENT_ROADIE_SESSION_STARTED,
+	EC_ANALYTICS_EVENT_ROADIE_TOOL_INVOKED,
+);
+
+/**
+ * The artist-funnel event set.
+ *
+ * @var string[]
+ */
+const EC_ANALYTICS_ARTIST_FUNNEL_EVENTS = array(
+	EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED,
+	EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED,
+	EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED,
+);


### PR DESCRIPTION
## Summary
Establishes **extrachill-analytics as the single cross-plugin source of truth** for the team-experience + artist-funnel analytics event-name contract (Extra-Chill/extrachill-users#129). This is the keystone of a 5-PR set on branch `event-name-contract`.

## Why extrachill-analytics is the right home (zero new coupling)
- extrachill-analytics owns the analytics substrate: the events table **and** the `extrachill/track-analytics-event` ability that **every** emitter (users / studio / roadie / artist-platform) already calls at runtime. That ability call is an **existing hard runtime dependency** on this plugin — referencing a constant defined here adds **zero** new coupling.
- extrachill-analytics is `Network: true` (active on every site), so the constants are **guaranteed defined** wherever an emitter or reader runs.
- It already owns the event-type concept (`extrachill_get_analytics_event_types()` in `inc/core/events.php`).

## Changes
- **New file** `inc/core/event-types.php` — defines the canonical event-name constants ONCE, grouped:
  - `EC_ANALYTICS_TEAM_EXPERIENCE_EVENTS`: `team_member_added`, `team_member_removed`, `studio_draft_created`, `studio_submitted_for_review`, `studio_transcription_run`, `roadie_session_started`, `roadie_tool_invoked`
  - `EC_ANALYTICS_ARTIST_FUNNEL_EVENTS`: `artist_access_requested`, `artist_access_approved`, `artist_profile_created`
  - plus the individual `EC_ANALYTICS_EVENT_*` constants the group arrays compose from.
- `extrachill-analytics.php` — bootstrap loads `inc/core/event-types.php` before `inc/core/events.php`, so the constants are defined as early as the substrate.

## Single-source proof
Every emitter and reader across the other 4 plugins references these constants directly — **no local copies of the literals**. After this set, each of the 10 event-name strings appears as a bare literal in **exactly one file** (this one):
```
$ grep -rEn "'studio_draft_created'" <all 5 worktrees>/inc --include='*.php'
extrachill-analytics/inc/core/event-types.php:38:const EC_ANALYTICS_EVENT_STUDIO_DRAFT_CREATED = 'studio_draft_created';
# (and likewise for all 10 — single match each, all in event-types.php)
```

## Guard / no hard-fail
Consumers reference the constants directly. They need no local string fallback: if extrachill-analytics were ever absent, the `extrachill/track-analytics-event` ability would also be absent, and each emit helper's existing `if ( ! $ability ) { return 0; }` guard no-ops the emit before the event_type is ever read.

## No behavior change
Constants resolve to the byte-identical event_type strings used before.

## Verification
- `php -l` clean; phpcs (WordPress) **0 errors / 0 warnings** on `inc/core/event-types.php` and `extrachill-analytics.php`.

## Related PRs (branch `event-name-contract`)
- extrachill-users: Extra-Chill/extrachill-users#130
- extrachill-studio: Extra-Chill/extrachill-studio#98
- extrachill-roadie: Extra-Chill/extrachill-roadie#52
- extrachill-artist-platform: Extra-Chill/extrachill-artist-platform#74

Refs Extra-Chill/extrachill-users#129. Review all 5 together; do not merge standalone.
