### PR TITLE
fix: make analytics summary 404 count reproducible (window self-documents)

### DIFF
--- a/inc/core/abilities/get-analytics-summary.php
+++ b/inc/core/abilities/get-analytics-summary.php
@@ -78,9 +78,20 @@ function extrachill_analytics_ability_get_summary( $input ) {
 	$where  = array( '1=1' );
 	$values = array();
 
+	// Capture the exact UTC instant this summary is computed at, and the rolling
+	// lower bound derived from it, so the reported counts are reproducible to the
+	// second. created_at is stored in UTC via current_time( 'mysql', true ), so the
+	// bound must be computed in UTC too. Both values are returned to the caller so a
+	// raw COUNT(*) can be reproduced exactly against the same window — the summary
+	// applies no dedup, DISTINCT, or normalization; it is a plain COUNT(*) over this
+	// half-open-on-now, closed-on-since window.
+	$now_utc = gmdate( 'Y-m-d H:i:s' );
+	$since   = '';
+
 	if ( $days > 0 ) {
+		$since    = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
 		$where[]  = 'created_at >= %s';
-		$values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+		$values[] = $since;
 	}
 
 	if ( ! empty( $event_type ) ) {
@@ -126,5 +137,10 @@ function extrachill_analytics_ability_get_summary( $input ) {
 		'period'      => $days > 0
 			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
 			: 'all time',
+		// Exact UTC window the counts were computed over. 'since' is the inclusive
+		// lower bound (empty for all-time); 'as_of' is the instant the summary ran.
+		// Counts are reproducible via a raw COUNT(*) using created_at >= since.
+		'since'       => $since,
+		'as_of'       => $now_utc,
 	);
 }


### PR DESCRIPTION
Closes #33.

## Root cause of the divergence

The `wp extrachill analytics summary` 404_error count diverged from a raw
`COUNT(*)` on `c8c_extrachill_analytics_events` (66,338 vs 65,702 at issue time,
~1%). **This is not a bug in the query — there is no normalization, dedup,
`DISTINCT`, or timezone off-by-one.** The summary's count is a plain `COUNT(*)`.

The gap is a **rolling-window timing artifact**. Both sources compute their
28-day lower bound *independently, at the moment each runs*:

- the summary in **PHP**: `gmdate('Y-m-d H:i:s', strtotime("-28 days"))`
- the raw query in **MySQL**: `DATE_SUB(NOW(), INTERVAL 28 DAY)`

`created_at` is stored in **UTC** (`current_time('mysql', true)`), and on this
VPS MySQL's clock is UTC (`NOW()` == `UTC_TIMESTAMP()`), so the two bounds are
the *same kind* of instant — there is no fixed offset. But 404s arrive at
~2,344/day (~1.6/min). Running the two `wp` commands minutes/hours apart slides
the rolling window: rows age out of one bound while new rows arrive in the other.
A 636-row gap ≈ a few hours of 404 traffic.

### Proof

Computing both bounds at the **same instant** yields identical results:

```
PHP strtotime(-28d) gmdate bound: 2026-05-20 05:43:43
MySQL DATE_SUB(NOW(),28 DAY):     2026-05-20 05:43:43
count (PHP bound):  65629
count (MySQL bound): 65629   ← identical
```

When the two issue commands ran at different wall-clock times, each used its own
`now` → different windows → the ~1% gap.

## Fix (issue option 1: make the number self-documenting)

The `extrachill/get-analytics-summary` ability now returns the exact UTC window
it computed over:

- `since` — the inclusive UTC lower bound actually used (empty for all-time)
- `as_of` — the UTC instant the summary ran

Any reported count is now reproducible to the second via:

```sql
SELECT COUNT(*) FROM c8c_extrachill_analytics_events
WHERE event_type = '<type>' AND created_at >= '<since>';
```

No dashboard behavior changes; the SQL itself is untouched (just the returned
metadata + an explanatory comment). The companion CLI change
(Extra-Chill/extrachill-cli `analytics-404-window`) prints this `since`/`as_of`
window in the table header so a 404 delta never again needs a "which source?"
asterisk.

## Verification

- `php -l` clean on the changed file.
- phpcs (WordPress standard): **0 net new findings** vs `main` baseline (19
  pre-existing house-style findings unchanged).
- Reproducibility confirmed live: surfaced `since` bound makes a raw `COUNT(*)`
  match the summary count exactly (65,611 == 65,611).