### PR TITLE
feat: deterministic visitor retention — ec_vid cookie + pageview events + get-retention-stats

### DIFF
--- a/assets/js/view-tracking.js
+++ b/assets/js/view-tracking.js
@@ -4,7 +4,16 @@
 		return;
 	}
 
-	var data = JSON.stringify( { post_id: config.postId } );
+	var payload = { post_id: config.postId };
+
+	// Echo the server-minted first-party visitor id when present. Empty/absent
+	// when the visitor opted out via GPC/DNT — the pageview is still recorded,
+	// just without an id.
+	if ( config.visitorId ) {
+		payload.visitor_id = config.visitorId;
+	}
+
+	var data = JSON.stringify( payload );
 
 	if ( navigator.sendBeacon ) {
 		navigator.sendBeacon(

--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -44,6 +44,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-attack-su
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/track-page-view.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-link-page-analytics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-bridge-ctr.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-retention-stats.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-php-error-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-categorizer.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-tracking.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -24,6 +24,7 @@ add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_404_top_ips_
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_track_page_view_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_get_link_page_analytics_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_bridge_ctr_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_retention_stats_ability' );
 
 /**
  * Register analytics ability category.
@@ -53,10 +54,10 @@ function extrachill_analytics_register_abilities() {
 	wp_register_ability(
 		'extrachill/track-analytics-event',
 		array(
-			'label'       => __( 'Track Analytics Event', 'extrachill-analytics' ),
-			'description' => __( 'Record an analytics event to the network-wide events table.', 'extrachill-analytics' ),
-			'category'    => 'extrachill-analytics',
-			'input_schema' => array(
+			'label'               => __( 'Track Analytics Event', 'extrachill-analytics' ),
+			'description'         => __( 'Record an analytics event to the network-wide events table.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
 					'event_type' => array(
@@ -73,10 +74,15 @@ function extrachill_analytics_register_abilities() {
 						'description' => __( 'URL of the page where the event occurred.', 'extrachill-analytics' ),
 						'default'     => '',
 					),
+					'visitor_id' => array(
+						'type'        => 'string',
+						'description' => __( 'Optional anonymous first-party visitor UUID v4. Stored only if well-formed; never PII. Empty when the visitor opted out (GPC/DNT).', 'extrachill-analytics' ),
+						'default'     => '',
+					),
 				),
-				'required' => array( 'event_type' ),
+				'required'   => array( 'event_type' ),
 			),
-			'output_schema' => array(
+			'output_schema'       => array(
 				'type'        => 'integer',
 				'description' => __( 'Event ID on success, 0 on failure.', 'extrachill-analytics' ),
 			),
@@ -108,6 +114,7 @@ function extrachill_analytics_ability_track_event( $input ) {
 	$event_type = $input['event_type'];
 	$event_data = isset( $input['event_data'] ) ? $input['event_data'] : array();
 	$source_url = isset( $input['source_url'] ) ? $input['source_url'] : '';
+	$visitor_id = isset( $input['visitor_id'] ) ? (string) $input['visitor_id'] : '';
 
 	// Defense-in-depth: if a 'search' event arrives with a payload-shaped term,
 	// reclassify it as 'search_attack' so real search metrics stay clean while
@@ -120,11 +127,11 @@ function extrachill_analytics_ability_track_event( $input ) {
 			$event_data = array_merge(
 				$event_data,
 				array(
-					'classification'  => $classification['pattern_name'],
-					'pattern_family'  => $classification['pattern_family'],
-					'matched_token'   => $classification['matched_token'],
-					'ip'              => extrachill_analytics_get_client_ip(),
-					'user_agent'      => extrachill_analytics_get_user_agent(),
+					'classification' => $classification['pattern_name'],
+					'pattern_family' => $classification['pattern_family'],
+					'matched_token'  => $classification['matched_token'],
+					'ip'             => extrachill_analytics_get_client_ip(),
+					'user_agent'     => extrachill_analytics_get_user_agent(),
 				)
 			);
 		}
@@ -150,7 +157,8 @@ function extrachill_analytics_ability_track_event( $input ) {
 	$result = extrachill_track_analytics_event(
 		$event_type,
 		$event_data,
-		$source_url
+		$source_url,
+		$visitor_id
 	);
 
 	return $result ? $result : 0;

--- a/inc/core/abilities/get-retention-stats.php
+++ b/inc/core/abilities/get-retention-stats.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Get Retention Stats Ability
+ *
+ * Read-side ability that answers the platform's hardest question deterministically:
+ * *do people come back?* It computes return rate, cohort-retention curves,
+ * cross-site return, and session depth from the first-party `pageview` events in
+ * `c8c_extrachill_analytics_events`, keyed on the anonymous `visitor_id`.
+ *
+ * Why this is deterministic and bot-resistant:
+ *
+ *   `pageview` rows are written server-side by the track-page-view ability ONLY
+ *   for real, JS-executing browsers (the beacon fires post-load) and ONLY when
+ *   the request is not a known bot (user-agent filter, mirroring the 404 path).
+ *   The visitor_id is a random first-party UUID v4 — no PII, no fingerprint —
+ *   so counting distinct visitor_ids across distinct days is a clean,
+ *   reproducible retention signal that GA4's sampled/bot-inflated numbers cannot
+ *   match. Rows with a NULL visitor_id (opted-out via GPC/DNT, or pre-cookie)
+ *   are simply excluded from the per-visitor metrics — they never inflate or
+ *   deflate a retention ratio.
+ *
+ * All four metrics operate over a UTC window and are plain aggregate queries:
+ * no normalization, no sampling, no dedup beyond the explicit DISTINCT/day logic
+ * each metric documents.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.11.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-retention-stats ability.
+ */
+function extrachill_analytics_register_retention_stats_ability() {
+	wp_register_ability(
+		'extrachill/get-retention-stats',
+		array(
+			'label'               => __( 'Get Retention Stats', 'extrachill-analytics' ),
+			'description'         => __( 'Returns deterministic, bot-filtered visitor-retention metrics (return rate, cohort retention, cross-site return, session depth) from first-party pageview events.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'         => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back for the window. Default 28.', 'extrachill-analytics' ),
+						'default'     => 28,
+					),
+					'blog_id'      => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for network-wide (required for cross-site return).', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'cohort_weeks' => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of weekly cohorts to compute for the retention curve. Default 8.', 'extrachill-analytics' ),
+						'default'     => 8,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'Object with return_rate, cohort_retention, cross_site_return, session_depth, and the exact UTC window.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_retention_stats',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-retention-stats ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Retention metrics.
+ */
+function extrachill_analytics_ability_get_retention_stats( $input ) {
+	global $wpdb;
+
+	$days         = isset( $input['days'] ) ? max( 1, (int) $input['days'] ) : 28;
+	$blog_id      = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+	$cohort_weeks = isset( $input['cohort_weeks'] ) ? max( 1, (int) $input['cohort_weeks'] ) : 8;
+
+	$table      = extrachill_analytics_events_table();
+	$event_type = defined( 'EC_ANALYTICS_EVENT_PAGEVIEW' ) ? EC_ANALYTICS_EVENT_PAGEVIEW : 'pageview';
+
+	$now_utc = gmdate( 'Y-m-d H:i:s' );
+	$since   = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+
+	// Common WHERE: pageviews, in window, with a non-NULL visitor_id (opted-out
+	// rows are excluded from per-visitor metrics), optional blog filter.
+	$base_where  = array( 'event_type = %s', "visitor_id IS NOT NULL AND visitor_id != ''", 'created_at >= %s' );
+	$base_values = array( $event_type, $since );
+
+	if ( $blog_id > 0 ) {
+		$base_where[]  = 'blog_id = %d';
+		$base_values[] = $blog_id;
+	}
+
+	$where_clause = implode( ' AND ', $base_where );
+
+	// ---------------------------------------------------------------------
+	// (a) Return rate: % of visitors active on >= 2 distinct UTC days.
+	// ---------------------------------------------------------------------
+	$return_sql = "SELECT
+			COUNT(*) AS total_visitors,
+			SUM(CASE WHEN active_days >= 2 THEN 1 ELSE 0 END) AS returning_visitors
+		FROM (
+			SELECT visitor_id, COUNT(DISTINCT DATE(created_at)) AS active_days
+			FROM {$table}
+			WHERE {$where_clause}
+			GROUP BY visitor_id
+		) AS per_visitor";
+
+	$return_row = $wpdb->get_row( $wpdb->prepare( $return_sql, $base_values ) );
+
+	$total_visitors     = $return_row ? (int) $return_row->total_visitors : 0;
+	$returning_visitors = $return_row ? (int) $return_row->returning_visitors : 0;
+	$return_rate        = $total_visitors > 0 ? round( $returning_visitors / $total_visitors, 4 ) : 0.0;
+
+	// ---------------------------------------------------------------------
+	// (b) Cohort retention: of visitors first-seen in week N, what % return in
+	// a later week (N+1, N+2, ...). "Week" is the ISO week of the visitor's
+	// first-ever pageview within the window. We compute, per cohort, the
+	// share still active 1 and 2 weeks later.
+	// ---------------------------------------------------------------------
+	$cohort_since = gmdate( 'Y-m-d H:i:s', strtotime( "-{$cohort_weeks} weeks" ) );
+
+	$cohort_where  = array( 'event_type = %s', "visitor_id IS NOT NULL AND visitor_id != ''", 'created_at >= %s' );
+	$cohort_values = array( $event_type, $cohort_since );
+	if ( $blog_id > 0 ) {
+		$cohort_where[]  = 'blog_id = %d';
+		$cohort_values[] = $blog_id;
+	}
+	$cohort_where_clause = implode( ' AND ', $cohort_where );
+
+	// Per visitor: their first-seen week, and the full set of weeks they were active.
+	$cohort_sql = "SELECT
+			first_week,
+			COUNT(*) AS cohort_size,
+			SUM(CASE WHEN max_week >= first_week + 1 THEN 1 ELSE 0 END) AS returned_w1,
+			SUM(CASE WHEN max_week >= first_week + 2 THEN 1 ELSE 0 END) AS returned_w2
+		FROM (
+			SELECT
+				visitor_id,
+				MIN(YEARWEEK(created_at, 3)) AS first_week,
+				MAX(YEARWEEK(created_at, 3)) AS max_week
+			FROM {$table}
+			WHERE {$cohort_where_clause}
+			GROUP BY visitor_id
+		) AS v
+		GROUP BY first_week
+		ORDER BY first_week ASC";
+
+	$cohort_rows = $wpdb->get_results( $wpdb->prepare( $cohort_sql, $cohort_values ) );
+
+	$cohort_retention = array();
+	foreach ( (array) $cohort_rows as $row ) {
+		$size               = (int) $row->cohort_size;
+		$cohort_retention[] = array(
+			'cohort_week'  => (string) $row->first_week,
+			'cohort_size'  => $size,
+			'returned_w1'  => (int) $row->returned_w1,
+			'returned_w2'  => (int) $row->returned_w2,
+			'retention_w1' => $size > 0 ? round( (int) $row->returned_w1 / $size, 4 ) : 0.0,
+			'retention_w2' => $size > 0 ? round( (int) $row->returned_w2 / $size, 4 ) : 0.0,
+		);
+	}
+
+	// ---------------------------------------------------------------------
+	// (c) Cross-site return: visitors who hit >= 2 distinct blog_ids on
+	// different UTC days. Only meaningful network-wide, so this ignores the
+	// blog_id filter by design (the question is inherently cross-site).
+	// ---------------------------------------------------------------------
+	$xsite_where        = array( 'event_type = %s', "visitor_id IS NOT NULL AND visitor_id != ''", 'created_at >= %s' );
+	$xsite_values       = array( $event_type, $since );
+	$xsite_where_clause = implode( ' AND ', $xsite_where );
+
+	$xsite_sql = "SELECT
+			COUNT(*) AS total_visitors,
+			SUM(CASE WHEN distinct_sites >= 2 AND distinct_days >= 2 THEN 1 ELSE 0 END) AS cross_site_visitors
+		FROM (
+			SELECT
+				visitor_id,
+				COUNT(DISTINCT blog_id) AS distinct_sites,
+				COUNT(DISTINCT DATE(created_at)) AS distinct_days
+			FROM {$table}
+			WHERE {$xsite_where_clause}
+			GROUP BY visitor_id
+		) AS per_visitor";
+
+	$xsite_row = $wpdb->get_row( $wpdb->prepare( $xsite_sql, $xsite_values ) );
+
+	$xsite_total     = $xsite_row ? (int) $xsite_row->total_visitors : 0;
+	$xsite_visitors  = $xsite_row ? (int) $xsite_row->cross_site_visitors : 0;
+	$cross_site_rate = $xsite_total > 0 ? round( $xsite_visitors / $xsite_total, 4 ) : 0.0;
+
+	// ---------------------------------------------------------------------
+	// (d) Session depth: average pageview events per visitor per active day.
+	// ---------------------------------------------------------------------
+	$depth_sql = "SELECT
+			AVG(views_per_day) AS avg_depth,
+			MAX(views_per_day) AS max_depth
+		FROM (
+			SELECT visitor_id, DATE(created_at) AS day, COUNT(*) AS views_per_day
+			FROM {$table}
+			WHERE {$where_clause}
+			GROUP BY visitor_id, DATE(created_at)
+		) AS per_visitor_day";
+
+	$depth_row = $wpdb->get_row( $wpdb->prepare( $depth_sql, $base_values ) );
+
+	$avg_depth = $depth_row && null !== $depth_row->avg_depth ? round( (float) $depth_row->avg_depth, 2 ) : 0.0;
+	$max_depth = $depth_row ? (int) $depth_row->max_depth : 0;
+
+	return array(
+		'return_rate'       => array(
+			'total_visitors'     => $total_visitors,
+			'returning_visitors' => $returning_visitors,
+			'rate'               => $return_rate,
+			'definition'         => 'Share of visitors active on >= 2 distinct UTC days within the window.',
+		),
+		'cohort_retention'  => array(
+			'cohorts'    => $cohort_retention,
+			'weeks'      => $cohort_weeks,
+			'definition' => 'Per weekly first-seen cohort (ISO YEARWEEK), share still active 1 and 2 weeks later.',
+		),
+		'cross_site_return' => array(
+			'total_visitors'      => $xsite_total,
+			'cross_site_visitors' => $xsite_visitors,
+			'rate'                => $cross_site_rate,
+			'definition'          => 'Share of visitors who hit >= 2 distinct blog_ids on >= 2 distinct UTC days (network-wide; ignores blog_id filter).',
+		),
+		'session_depth'     => array(
+			'avg_pageviews_per_visitor_day' => $avg_depth,
+			'max_pageviews_per_visitor_day' => $max_depth,
+			'definition'                    => 'Average (and max) pageview events per visitor per active UTC day.',
+		),
+		'days'              => $days,
+		'blog_id'           => $blog_id,
+		'period'            => gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' ),
+		'since'             => $since,
+		'as_of'             => $now_utc,
+		'note'              => 'Deterministic + bot-filtered: pageview rows are written server-side only for non-bot, JS-executing browsers; visitor_id is an anonymous first-party UUID v4 (no PII). Opted-out (GPC/DNT) rows have NULL visitor_id and are excluded from per-visitor metrics.',
+	);
+}

--- a/inc/core/abilities/track-page-view.php
+++ b/inc/core/abilities/track-page-view.php
@@ -19,20 +19,25 @@ function extrachill_analytics_register_track_page_view_ability(): void {
 	wp_register_ability(
 		'extrachill/track-page-view',
 		array(
-			'label'       => __( 'Track Page View', 'extrachill-analytics' ),
-			'description' => __( 'Increment the view counter for a post. High-frequency endpoint called async after page load.', 'extrachill-analytics' ),
-			'category'    => 'extrachill-analytics',
-			'input_schema' => array(
+			'label'               => __( 'Track Page View', 'extrachill-analytics' ),
+			'description'         => __( 'Increment the view counter for a post. High-frequency endpoint called async after page load.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'post_id' => array(
+					'post_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'The post ID to record a view for.', 'extrachill-analytics' ),
 					),
+					'visitor_id' => array(
+						'type'        => 'string',
+						'description' => __( 'Optional anonymous first-party visitor UUID v4. Stored on the pageview event only if well-formed; never PII. Empty when the visitor opted out (GPC/DNT).', 'extrachill-analytics' ),
+						'default'     => '',
+					),
 				),
-				'required' => array( 'post_id' ),
+				'required'   => array( 'post_id' ),
 			),
-			'output_schema' => array(
+			'output_schema'       => array(
 				'type'        => 'object',
 				'description' => __( 'Confirmation object with recorded flag.', 'extrachill-analytics' ),
 			),
@@ -54,13 +59,17 @@ function extrachill_analytics_register_track_page_view_ability(): void {
  * Execute callback for track-page-view ability.
  *
  * Mirrors the existing REST handler: quick post-meta increment,
- * plus link-page daily-table action when applicable.
+ * plus link-page daily-table action when applicable. Additionally writes a
+ * `pageview` event row to the network-wide events table (carrying the
+ * anonymous visitor_id when present) so per-visitor retention history exists.
+ * The post-meta bump is retained for back-compat with the theme view counter.
  *
  * @param array $input Input parameters.
  * @return array{recorded: bool}|WP_Error Confirmation or error.
  */
 function extrachill_analytics_ability_track_page_view( array $input ) {
-	$post_id = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
+	$post_id    = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
+	$visitor_id = isset( $input['visitor_id'] ) ? (string) $input['visitor_id'] : '';
 
 	if ( $post_id <= 0 ) {
 		return new \WP_Error(
@@ -78,8 +87,32 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 		);
 	}
 
-	// All-time view increment (post meta).
+	// All-time view increment (post meta) — retained for theme back-compat.
 	ec_track_post_views( $post_id );
+
+	// Write a deterministic pageview event row so per-visitor retention can be
+	// queried. visitor_id is persisted only when it is a valid UUID v4; an empty
+	// or opted-out value still records the pageview anonymously (NULL visitor_id),
+	// keeping aggregate volume accurate. Bots are excluded by user-agent so the
+	// retention table stays bot-resistant by construction, matching the existing
+	// 404 capture path.
+	$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] )
+		? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) )
+		: '';
+
+	$is_bot = function_exists( 'extrachill_analytics_is_bot' )
+		? extrachill_analytics_is_bot( $user_agent )
+		: false;
+
+	if ( ! $is_bot && function_exists( 'extrachill_track_analytics_event' ) ) {
+		$permalink = get_permalink( $post_id );
+		extrachill_track_analytics_event(
+			defined( 'EC_ANALYTICS_EVENT_PAGEVIEW' ) ? EC_ANALYTICS_EVENT_PAGEVIEW : 'pageview',
+			array( 'post_id' => $post_id ),
+			is_string( $permalink ) ? $permalink : '',
+			$visitor_id
+		);
+	}
 
 	// Link pages also fire the 90-day daily-table action.
 	if ( get_post_type( $post_id ) === 'artist_link_page' ) {

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -10,6 +10,101 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Name of the first-party anonymous visitor cookie.
+ */
+define( 'EXTRACHILL_ANALYTICS_VISITOR_COOKIE', 'ec_vid' );
+
+/**
+ * Detect whether the current request signals an opt-out of tracking.
+ *
+ * Honors Global Privacy Control (`Sec-GPC: 1`) and the legacy Do Not Track
+ * header (`DNT: 1`). When either is present we neither mint the visitor cookie
+ * nor attach a visitor_id to events — the pageview row is still written, just
+ * anonymously, so aggregate volume counts stay accurate without any per-visitor
+ * identifier.
+ *
+ * @return bool True if the visitor has opted out (no visitor_id should be set).
+ */
+function extrachill_analytics_visitor_opted_out() {
+	if ( isset( $_SERVER['HTTP_SEC_GPC'] ) && '1' === sanitize_text_field( wp_unslash( $_SERVER['HTTP_SEC_GPC'] ) ) ) {
+		return true;
+	}
+
+	if ( isset( $_SERVER['HTTP_DNT'] ) && '1' === sanitize_text_field( wp_unslash( $_SERVER['HTTP_DNT'] ) ) ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Validate a string as a canonical lowercase UUID v4.
+ *
+ * @param string $value Candidate value.
+ * @return bool True when the value is a well-formed UUID v4.
+ */
+function extrachill_analytics_is_valid_visitor_id( $value ) {
+	return is_string( $value ) && 1 === preg_match(
+		'/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+		$value
+	);
+}
+
+/**
+ * Read the existing first-party visitor id, or mint a new one server-side.
+ *
+ * The cookie value is a random UUID v4 only — never an IP, email, or
+ * fingerprint. It is strictly first-party and used solely for our own
+ * aggregate retention analytics; it is never shared with Mediavine or any
+ * third party and never used for ad targeting.
+ *
+ * Respects Global Privacy Control / DNT: if the visitor has opted out we return
+ * an empty string and set no cookie.
+ *
+ * Must be called before output starts (headers not yet sent) so setcookie()
+ * works — the deferred beacon cannot reliably set a cookie itself.
+ *
+ * @return string The visitor UUID, or empty string if opted out / cannot mint.
+ */
+function extrachill_analytics_get_or_mint_visitor_id() {
+	if ( extrachill_analytics_visitor_opted_out() ) {
+		return '';
+	}
+
+	$cookie_name = EXTRACHILL_ANALYTICS_VISITOR_COOKIE;
+
+	if ( isset( $_COOKIE[ $cookie_name ] ) ) {
+		$existing = sanitize_text_field( wp_unslash( $_COOKIE[ $cookie_name ] ) );
+		if ( extrachill_analytics_is_valid_visitor_id( $existing ) ) {
+			return $existing;
+		}
+	}
+
+	$visitor_id = wp_generate_uuid4();
+
+	// Set the cookie for ~1 year. Secure + HttpOnly + SameSite=Lax: first-party
+	// analytics only, not readable by JS, not sent on cross-site sub-requests.
+	if ( ! headers_sent() ) {
+		setcookie(
+			$cookie_name,
+			$visitor_id,
+			array(
+				'expires'  => time() + YEAR_IN_SECONDS,
+				'path'     => '/',
+				'domain'   => '',
+				'secure'   => true,
+				'httponly' => true,
+				'samesite' => 'Lax',
+			)
+		);
+		// Make the freshly-minted id available within this same request.
+		$_COOKIE[ $cookie_name ] = $visitor_id;
+	}
+
+	return $visitor_id;
+}
+
+/**
  * Enqueue view tracking script on singular pages.
  */
 function extrachill_analytics_enqueue_view_tracking() {
@@ -22,6 +117,10 @@ function extrachill_analytics_enqueue_view_tracking() {
 		return;
 	}
 
+	// Mint/read the first-party visitor id server-side so the deferred beacon
+	// can echo it back. Empty string when the visitor opted out (GPC/DNT).
+	$visitor_id = extrachill_analytics_get_or_mint_visitor_id();
+
 	wp_enqueue_script(
 		'extrachill-view-tracking',
 		EXTRACHILL_ANALYTICS_PLUGIN_URL . 'assets/js/view-tracking.js',
@@ -33,9 +132,14 @@ function extrachill_analytics_enqueue_view_tracking() {
 		)
 	);
 
-	wp_localize_script( 'extrachill-view-tracking', 'ecViewTracking', array(
-		'postId'   => get_the_ID(),
-		'endpoint' => rest_url( 'extrachill/v1/analytics/view' ),
-	) );
+	wp_localize_script(
+		'extrachill-view-tracking',
+		'ecViewTracking',
+		array(
+			'postId'    => get_the_ID(),
+			'endpoint'  => rest_url( 'extrachill/v1/analytics/view' ),
+			'visitorId' => $visitor_id,
+		)
+	);
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_analytics_enqueue_view_tracking' );

--- a/inc/core/event-types.php
+++ b/inc/core/event-types.php
@@ -32,6 +32,13 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Pageview event — one row per real (non-bot) front-end singular view, carrying
+ * the anonymous first-party visitor_id when present. This is the deterministic
+ * per-visitor history the retention rollups read.
+ */
+const EC_ANALYTICS_EVENT_PAGEVIEW = 'pageview';
+
 /** Team-experience events (team membership + Studio + Roadie usage). */
 const EC_ANALYTICS_EVENT_TEAM_MEMBER_ADDED        = 'team_member_added';
 const EC_ANALYTICS_EVENT_TEAM_MEMBER_REMOVED      = 'team_member_removed';

--- a/inc/core/events.php
+++ b/inc/core/events.php
@@ -16,9 +16,12 @@ defined( 'ABSPATH' ) || exit;
  * @param string $event_type Event type identifier (e.g., 'newsletter_signup', 'user_registration').
  * @param array  $event_data Flexible payload data stored as JSON.
  * @param string $source_url URL of the page where the event occurred.
+ * @param string $visitor_id Optional anonymous first-party visitor UUID (v4). Stored only
+ *                           when it is a well-formed UUID v4 and the visitor has not opted
+ *                           out via GPC/DNT (callers pass '' in that case). Never PII.
  * @return int|false Event ID on success, false on failure.
  */
-function extrachill_track_analytics_event( $event_type, $event_data = array(), $source_url = '' ) {
+function extrachill_track_analytics_event( $event_type, $event_data = array(), $source_url = '', $visitor_id = '' ) {
 	global $wpdb;
 
 	if ( empty( $event_type ) ) {
@@ -26,6 +29,12 @@ function extrachill_track_analytics_event( $event_type, $event_data = array(), $
 	}
 
 	$table_name = extrachill_analytics_events_table();
+
+	// Only persist a valid UUID v4; anything else (including empty / opted-out) is NULL.
+	$stored_visitor_id = ( function_exists( 'extrachill_analytics_is_valid_visitor_id' )
+		&& extrachill_analytics_is_valid_visitor_id( $visitor_id ) )
+		? $visitor_id
+		: null;
 
 	$result = $wpdb->insert(
 		$table_name,
@@ -35,9 +44,10 @@ function extrachill_track_analytics_event( $event_type, $event_data = array(), $
 			'source_url' => esc_url_raw( $source_url ),
 			'blog_id'    => get_current_blog_id(),
 			'user_id'    => get_current_user_id() ?: null,
+			'visitor_id' => $stored_visitor_id,
 			'created_at' => current_time( 'mysql', true ),
 		),
-		array( '%s', '%s', '%s', '%d', '%d', '%s' )
+		array( '%s', '%s', '%s', '%d', '%d', '%s', '%s' )
 	);
 
 	if ( false === $result ) {

--- a/inc/database/events-db.php
+++ b/inc/database/events-db.php
@@ -10,7 +10,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION', '1.1' );
+define( 'EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION', '1.2' );
 define( 'EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION_OPTION', 'extrachill_analytics_events_db_version' );
 
 /**
@@ -38,13 +38,15 @@ function extrachill_analytics_events_create_table() {
 		source_url varchar(2083) DEFAULT '',
 		blog_id int(11) NOT NULL DEFAULT 1,
 		user_id bigint(20) unsigned DEFAULT NULL,
+		visitor_id char(36) DEFAULT NULL,
 		created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		PRIMARY KEY  (id),
 		KEY event_type_idx (event_type),
 		KEY blog_id_idx (blog_id),
 		KEY user_id_idx (user_id),
 		KEY created_at_idx (created_at),
-		KEY event_type_created (event_type, created_at)
+		KEY event_type_created (event_type, created_at),
+		KEY visitor_created (visitor_id, created_at)
 	) {$charset_collate};";
 
 	dbDelta( $sql );


### PR DESCRIPTION
Closes #35

## Summary

Adds first-party visitor-retention tooling so the analytics events table can deterministically answer *do people return?* — return rate, weekly cohort retention, cross-site return, and session depth — bot-resistant by construction.

Before this, `user_id` was NULL for all logged-out traffic (no anonymous identifier anywhere), and ordinary pageviews weren't even rows in the events table (only an `ec_post_views` post-meta bump). Both gaps are closed here.

## What changed

- **DB** (`inc/database/events-db.php`): new `visitor_id CHAR(36) NULL` column + `(visitor_id, created_at)` index; events DB version `1.1 → 1.2`. `dbDelta` applies the ALTER on the next `admin_init` (version-gated, same as every prior schema change).
- **Cookie** (`inc/core/assets.php`): server-side `ec_vid` minted in the existing view-tracking enqueue path and localized into `ecViewTracking.visitorId` so the deferred beacon can echo it.
- **Write path** (`inc/core/events.php` + `inc/core/abilities.php`): `extrachill_track_analytics_event()` and the `extrachill/track-analytics-event` ability accept an optional `visitor_id`, persisted only when it's a valid UUID v4.
- **Pageview capture** (`inc/core/abilities/track-page-view.php` + `assets/js/view-tracking.js`): the `track-page-view` ability now writes a `pageview` event row carrying `visitor_id` (in addition to the retained post-meta bump). Bots are excluded by user-agent (reusing `extrachill_analytics_is_bot()`), matching the 404 capture path.
- **Read ability** (`inc/core/abilities/get-retention-stats.php`, new): `extrachill/get-retention-stats` computes all four metrics from the first-party table.

## Privacy stance (as implemented)

- **Cookie value is a random UUID v4 only** (`wp_generate_uuid4()`) — never IP, email, or fingerprint.
- **Attributes**: `SameSite=Lax; Secure; HttpOnly`, `~1 year` expiry (`YEAR_IN_SECONDS`), path `/`. First-party only; never shared with Mediavine/third parties; used solely for our own aggregate retention analytics, never ad targeting.
- **GPC / DNT respected**: if `Sec-GPC: 1` or `DNT: 1` is on the request, `extrachill_analytics_visitor_opted_out()` returns true — **no cookie is minted and no `visitor_id` is attached**. The pageview row is still written, just anonymously (NULL `visitor_id`), so aggregate volume stays accurate. Opted-out (NULL) rows are excluded from every per-visitor retention metric.
- **No PII** in the cookie or in any event payload.

## Data flow (how a pageview row + visitor_id actually lands)

1. A logged-out visitor loads a singular front-end page. `extrachill_analytics_enqueue_view_tracking()` runs, calls `extrachill_analytics_get_or_mint_visitor_id()`:
   - GPC/DNT present → returns `''`, no cookie.
   - else reads `$_COOKIE['ec_vid']` (validates UUID v4) or mints a new one + `setcookie()` with the attributes above.
   - the value is localized into `ecViewTracking.visitorId`.
2. After load, the deferred beacon (`view-tracking.js`) POSTs `{ post_id, visitor_id }` to `extrachill/v1/analytics/view` (handled by the extrachill-api PR).
3. That route calls the `extrachill/track-page-view` ability, which: bumps `ec_post_views` (back-compat), and — if the request isn't a bot — calls `extrachill_track_analytics_event( 'pageview', { post_id }, permalink, visitor_id )`.
4. `extrachill_track_analytics_event()` validates `visitor_id` is a UUID v4 (else NULL) and INSERTs the row into `c8c_extrachill_analytics_events`.
5. `extrachill/get-retention-stats` aggregates those rows by `visitor_id` × distinct UTC day / blog_id.

Because the beacon only fires in real JS-executing browsers and bots are UA-filtered, every counted row is a human-with-JS by construction — the retention metrics are bot-filtered without a separate filter pass.

## Deploy ordering

This ability layer must deploy **before or with** the extrachill-api and extrachill-cli wrappers (they call `extrachill/track-page-view` and `extrachill/get-retention-stats`).

## Related PRs

- extrachill-api: visitor_id ingest + `/analytics/retention` read route (linked below once opened)
- extrachill-cli: `wp extrachill analytics retention` (linked below once opened)

## Owner checklist before "done"

- [ ] **Publish a privacy-policy disclosure line** (page ID 3 — do not let the bot edit the live policy). Suggested sentence:
  > *"We set a first-party analytics cookie (`ec_vid`) containing a random, anonymous identifier — never your name, email, IP, or any personal data — solely to measure aggregate return visits across our own sites. It is never shared with advertisers or third parties, and we honor Global Privacy Control and Do Not Track signals by not setting it."*
- [ ] Confirm `pageview` rows land in `c8c_extrachill_analytics_events` after deploy (`wp extrachill analytics summary --type=pageview`).

## Notes / verification

- `php -l` clean on all changed files.
- `phpcs --standard=WordPress` on changed files introduces **zero new non-baseline findings**; the remaining `$wpdb->prepare()`-with-variable and `declare(strict_types)` docblock-order findings are the pre-existing house-style baseline shared by every existing ability in this repo (e.g. `get-bridge-ctr.php`, `get-analytics-summary.php`).
- Cannot be fully runtime-tested in the worktree; the data-flow above documents the end-to-end path.

## Follow-ups (out of scope)

- Historic pageview backfill is impossible (rows never existed).
- BigQuery export tap for fully-accurate long-term source.