### PR TITLE
fix: mint ec_vid visitor cookie before output starts (template_redirect)

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -62,13 +62,24 @@ function extrachill_analytics_is_valid_visitor_id( $value ) {
  * an empty string and set no cookie.
  *
  * Must be called before output starts (headers not yet sent) so setcookie()
- * works — the deferred beacon cannot reliably set a cookie itself.
+ * works — the deferred beacon cannot reliably set a cookie itself. The result
+ * is memoized per-request so callers after output has started (e.g. the
+ * footer enqueue) read the already-resolved id without re-minting.
  *
  * @return string The visitor UUID, or empty string if opted out / cannot mint.
  */
 function extrachill_analytics_get_or_mint_visitor_id() {
+	static $resolved = null;
+
+	// Memoized: a prior early-hook call already resolved (and, if needed,
+	// minted + set the cookie for) this request. Never re-mint.
+	if ( null !== $resolved ) {
+		return $resolved;
+	}
+
 	if ( extrachill_analytics_visitor_opted_out() ) {
-		return '';
+		$resolved = '';
+		return $resolved;
 	}
 
 	$cookie_name = EXTRACHILL_ANALYTICS_VISITOR_COOKIE;
@@ -76,7 +87,8 @@ function extrachill_analytics_get_or_mint_visitor_id() {
 	if ( isset( $_COOKIE[ $cookie_name ] ) ) {
 		$existing = sanitize_text_field( wp_unslash( $_COOKIE[ $cookie_name ] ) );
 		if ( extrachill_analytics_is_valid_visitor_id( $existing ) ) {
-			return $existing;
+			$resolved = $existing;
+			return $resolved;
 		}
 	}
 
@@ -84,6 +96,8 @@ function extrachill_analytics_get_or_mint_visitor_id() {
 
 	// Set the cookie for ~1 year. Secure + HttpOnly + SameSite=Lax: first-party
 	// analytics only, not readable by JS, not sent on cross-site sub-requests.
+	// Guarded against headers_sent() as defense-in-depth; the early
+	// template_redirect hook below is what actually makes this succeed.
 	if ( ! headers_sent() ) {
 		setcookie(
 			$cookie_name,
@@ -101,8 +115,32 @@ function extrachill_analytics_get_or_mint_visitor_id() {
 		$_COOKIE[ $cookie_name ] = $visitor_id;
 	}
 
-	return $visitor_id;
+	$resolved = $visitor_id;
+	return $resolved;
 }
+
+/**
+ * Mint/read the visitor cookie early, before any template output starts.
+ *
+ * `template_redirect` fires after the main query is resolved but before
+ * `get_header()` (and therefore before the theme sends any body output), so
+ * `headers_sent()` is still false here and `setcookie()` succeeds. The later
+ * footer enqueue on `wp_enqueue_scripts` (which runs after output has begun)
+ * then reads the memoized result instead of trying — and failing — to set the
+ * cookie itself.
+ *
+ * Gated on the same conditions as the enqueue: singular, non-preview, and not
+ * opted out via GPC/DNT.
+ */
+function extrachill_analytics_prime_visitor_cookie() {
+	if ( ! is_singular() || is_preview() ) {
+		return;
+	}
+
+	// Resolves + (when applicable) sets the cookie, memoizing for this request.
+	extrachill_analytics_get_or_mint_visitor_id();
+}
+add_action( 'template_redirect', 'extrachill_analytics_prime_visitor_cookie' );
 
 /**
  * Enqueue view tracking script on singular pages.
@@ -117,8 +155,9 @@ function extrachill_analytics_enqueue_view_tracking() {
 		return;
 	}
 
-	// Mint/read the first-party visitor id server-side so the deferred beacon
-	// can echo it back. Empty string when the visitor opted out (GPC/DNT).
+	// Read the visitor id already resolved on template_redirect (before output
+	// started, so its cookie was actually set). Empty string when the visitor
+	// opted out (GPC/DNT). Memoization guarantees no re-mint here.
 	$visitor_id = extrachill_analytics_get_or_mint_visitor_id();
 
 	wp_enqueue_script(


### PR DESCRIPTION
## Summary

Fixes #37. The `ec_vid` first-party visitor cookie was never being set, so every `pageview` row landed with `visitor_id = NULL` and all retention metrics were stuck at 0%.

## Root cause

`extrachill_analytics_get_or_mint_visitor_id()` correctly guards `setcookie()` with `if ( ! headers_sent() )`, but it was only invoked from `extrachill_analytics_enqueue_view_tracking()`, hooked on **`wp_enqueue_scripts`**. That hook fires inside `get_header()` — *after* the theme has already begun sending output — so `headers_sent()` is always `true` by then and the `setcookie()` was silently skipped on every request. The cookie could not be set from that hook.

## Fix — hook timing

1. **New early hook `extrachill_analytics_prime_visitor_cookie()` on `template_redirect`.** `template_redirect` fires after the main query is resolved but **before** `get_header()` / any body output, so `headers_sent()` is still `false` and `setcookie()` actually succeeds. It is gated on the same conditions as the enqueue (`is_singular()`, not `is_preview()`, and the GPC/DNT `extrachill_analytics_visitor_opted_out()` check).
2. **`extrachill_analytics_get_or_mint_visitor_id()` now memoizes** the resolved id in a request-scoped `static`. The early hook resolves (and, when needed, mints + sets the cookie); the later footer enqueue reads the memoized value and **never re-mints**.
3. **No change to cookie attributes or privacy behavior:** UUIDv4 only, `SameSite=Lax; Secure; HttpOnly`, ~1yr expiry; GPC/DNT → no cookie + anonymous pageview still written; no PII. The `headers_sent()` guard is kept as defense-in-depth.

## Verification

- `php -l inc/core/assets.php` → **No syntax errors detected**.
- `phpcs --standard=WordPress inc/core/assets.php` → **exit 0, 0 errors / 0 warnings**.

### Expected live behavior post-deploy
- `curl -sI` to a singular post (no GPC) → **`Set-Cookie: ec_vid=<uuid>; ... SameSite=Lax; Secure; HttpOnly`** header present (the cookie is now minted on `template_redirect`, before output, so the header lands in the response).
- Same request with `Sec-GPC: 1` (or `DNT: 1`) → **still no `Set-Cookie: ec_vid`** — opt-out is checked before minting, regression-guarded.
- New `pageview` rows carry a **non-NULL `visitor_id`** for normal visitors; `wp extrachill analytics retention` starts showing non-zero visitor counts as real traffic flows.

Closes #37