### PR TITLE
feat: add artist-signup activation funnel event types

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -47,6 +47,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-link-page
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-bridge-ctr.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-retention-stats.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-growth.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-activation-funnel.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-php-error-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-categorizer.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-tracking.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -26,6 +26,7 @@ add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_get_link_pag
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_bridge_ctr_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_retention_stats_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_surface_growth_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_activation_funnel_ability' );
 
 /**
  * Register analytics ability category.

--- a/inc/core/abilities/get-activation-funnel.php
+++ b/inc/core/abilities/get-activation-funnel.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Get Activation Funnel Ability
+ *
+ * Read-side ability that computes the artist-signup **activation funnel** —
+ * the ordered start->finish steps a new member walks while building/claiming
+ * an artist page — as a **per-person** funnel, so the conversion %s are
+ * trustworthy.
+ *
+ * Why this ability has to dedup
+ * -----------------------------
+ * The funnel-step events are emitted at lifecycle points that can fire more
+ * than once per person. In particular `artist_signup_started` is emitted on
+ * EVERY render of the create-artist form (artist-platform render.php), so a
+ * single indecisive visitor who reloads the form five times writes five rows.
+ * The generic `extrachill/get-analytics-summary` reader is a deliberate plain
+ * `COUNT(*)` (it documents that it applies "no dedup, DISTINCT, or
+ * normalization"), which is correct for raw event volume but WRONG for a
+ * funnel: counting rows instead of people inflates the top of the funnel and
+ * makes every downstream conversion % too low.
+ *
+ * This ability is the funnel's rightful reader: it iterates the ordered
+ * `EC_ANALYTICS_ARTIST_ACTIVATION_STEPS` group and counts each step by
+ * DISTINCT person, then computes step-to-step and overall conversion plus the
+ * single biggest abandon step.
+ *
+ * Identity / dedup key
+ * --------------------
+ * Every funnel step is a logged-in action, so the dedicated `user_id` column
+ * (populated server-side from `get_current_user_id()`) is the authoritative,
+ * reliably-present per-person identity — confirmed against live rows where
+ * `artist_profile_created` has a non-NULL user_id on 100% of rows. The
+ * anonymous first-party `visitor_id` is the fallback for any row whose user_id
+ * is NULL (opted-out context or a pre-login emit), which keeps the same
+ * member's pre/post-login path stitched into one identity. The dedup key is
+ * therefore `COALESCE(NULLIF(user_id,0), visitor_id)`; a row with neither is
+ * excluded from the per-person count (it cannot be attributed to a person).
+ *
+ * The window, UTC handling, and `since`/`as_of` reproducibility echo
+ * get-analytics-summary so a caller can reconcile the two readers exactly.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.13.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-activation-funnel ability.
+ */
+function extrachill_analytics_register_activation_funnel_ability() {
+	wp_register_ability(
+		'extrachill/get-activation-funnel',
+		array(
+			'label'               => __( 'Get Activation Funnel', 'extrachill-analytics' ),
+			'description'         => __( 'Returns the artist-signup activation funnel as a per-person funnel (DISTINCT user_id/visitor_id) with step-to-step and overall conversion and the biggest abandon step.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back. 0 for all time.', 'extrachill-analytics' ),
+						'default'     => 28,
+					),
+					'blog_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for network-wide.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'Object with an ordered steps array (event_type, label, people, conversion_from_prev, conversion_from_top), the biggest_abandon_step, and the exact UTC window.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_activation_funnel',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-activation-funnel ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Funnel data.
+ */
+function extrachill_analytics_ability_get_activation_funnel( $input ) {
+	global $wpdb;
+
+	$days    = isset( $input['days'] ) ? (int) $input['days'] : 28;
+	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+
+	$table = extrachill_analytics_events_table();
+
+	// Ordered start->finish steps. Falls back to the literal sequence if the
+	// constant group is somehow absent, so the reader never fatals on a partial
+	// deploy (the constants ship in this same plugin, so this is belt-and-braces).
+	$steps = defined( 'EC_ANALYTICS_ARTIST_ACTIVATION_STEPS' )
+		? EC_ANALYTICS_ARTIST_ACTIVATION_STEPS
+		: array( 'artist_signup_started', 'artist_profile_created', 'artist_profile_first_publish' );
+
+	// Capture the exact UTC instant and the rolling lower bound, mirroring
+	// get-analytics-summary so the two readers reconcile against the same window.
+	$now_utc = gmdate( 'Y-m-d H:i:s' );
+	$since   = '';
+
+	$window_where  = array();
+	$window_values = array();
+
+	if ( $days > 0 ) {
+		$since           = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+		$window_where[]  = 'created_at >= %s';
+		$window_values[] = $since;
+	}
+
+	if ( $blog_id > 0 ) {
+		$window_where[]  = 'blog_id = %d';
+		$window_values[] = $blog_id;
+	}
+
+	// Per-person dedup key: prefer the authoritative user_id column, fall back
+	// to the anonymous visitor_id so a pre-login emit still attributes to one
+	// person. A row with neither identity is excluded (can't be a "person").
+	$person_key = 'COALESCE(NULLIF(user_id, 0), visitor_id)';
+
+	$step_rows = array();
+	$top_count = 0;
+
+	foreach ( $steps as $index => $event_type ) {
+		$where  = array( 'event_type = %s', "{$person_key} IS NOT NULL AND {$person_key} != ''" );
+		$values = array( sanitize_key( $event_type ) );
+
+		if ( ! empty( $window_where ) ) {
+			$where  = array_merge( $where, $window_where );
+			$values = array_merge( $values, $window_values );
+		}
+
+		$where_clause = implode( ' AND ', $where );
+
+		// Count DISTINCT people who reached this step — not rows. This is the
+		// whole point: re-views of the form collapse to one person here.
+		$sql = "SELECT COUNT(DISTINCT {$person_key}) FROM {$table} WHERE {$where_clause}";
+
+		$people = (int) $wpdb->get_var( $wpdb->prepare( $sql, $values ) );
+
+		if ( 0 === $index ) {
+			$top_count = $people;
+		}
+
+		$step_rows[] = array(
+			'event_type' => $event_type,
+			'people'     => $people,
+			'index'      => $index,
+		);
+	}
+
+	// Compute conversion %s. conversion_from_prev = people(step)/people(prev);
+	// conversion_from_top = people(step)/people(first step). Both are 0..1.
+	$steps_out          = array();
+	$prev_count         = 0;
+	$biggest_abandon    = null;
+	$biggest_abandon_pp = -1.0; // largest drop in percentage points, prev->this.
+
+	foreach ( $step_rows as $row ) {
+		$people = $row['people'];
+		$index  = $row['index'];
+
+		$from_prev = ( $index > 0 && $prev_count > 0 ) ? round( $people / $prev_count, 4 ) : ( 0 === $index ? 1.0 : 0.0 );
+		$from_top  = $top_count > 0 ? round( $people / $top_count, 4 ) : 0.0;
+
+		// Abandon = share of the previous step that did NOT advance to this one.
+		if ( $index > 0 && $prev_count > 0 ) {
+			$drop_pp = ( 1 - ( $people / $prev_count ) );
+			if ( $drop_pp > $biggest_abandon_pp ) {
+				$biggest_abandon_pp = $drop_pp;
+				$biggest_abandon    = array(
+					'from_step' => $step_rows[ $index - 1 ]['event_type'],
+					'to_step'   => $row['event_type'],
+					'dropped'   => $prev_count - $people,
+					'drop_rate' => round( $drop_pp, 4 ),
+				);
+			}
+		}
+
+		$steps_out[] = array(
+			'event_type'           => $row['event_type'],
+			'people'               => $people,
+			'conversion_from_prev' => $from_prev,
+			'conversion_from_top'  => $from_top,
+		);
+
+		$prev_count = $people;
+	}
+
+	$last_count         = ! empty( $step_rows ) ? end( $step_rows )['people'] : 0;
+	$overall_conversion = $top_count > 0 ? round( $last_count / $top_count, 4 ) : 0.0;
+
+	return array(
+		'steps'                => $steps_out,
+		'overall_conversion'   => $overall_conversion,
+		'biggest_abandon_step' => $biggest_abandon,
+		'days'                 => $days,
+		'blog_id'              => $blog_id,
+		'period'               => $days > 0
+			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
+			: 'all time',
+		// Exact UTC window the counts were computed over, reproducible with the
+		// same created_at >= since bound used by get-analytics-summary.
+		'since'                => $since,
+		'as_of'                => $now_utc,
+		'note'                 => 'Per-person funnel: each step is COUNT(DISTINCT COALESCE(NULLIF(user_id,0), visitor_id)), so multiple emits per person (e.g. re-views of the create form emitting artist_signup_started) collapse to one. Rows with neither identity are excluded. Counts here are intentionally NOT comparable to get-analytics-summary COUNT(*) raw volume.',
+	);
+}

--- a/inc/core/event-types.php
+++ b/inc/core/event-types.php
@@ -48,10 +48,32 @@ const EC_ANALYTICS_EVENT_STUDIO_TRANSCRIPTION_RUN = 'studio_transcription_run';
 const EC_ANALYTICS_EVENT_ROADIE_SESSION_STARTED   = 'roadie_session_started';
 const EC_ANALYTICS_EVENT_ROADIE_TOOL_INVOKED      = 'roadie_tool_invoked';
 
-/** Artist-funnel events (access requests/approvals + profile creation). */
-const EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED = 'artist_access_requested';
-const EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED  = 'artist_access_approved';
-const EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED  = 'artist_profile_created';
+/**
+ * Artist-funnel events.
+ *
+ * The activation funnel a new member walks while trying to build/claim an
+ * artist page, ordered start -> finish:
+ *
+ *   user_registration        (emitted by extrachill-users on account create)
+ *     -> artist_signup_started        entered the create-artist flow
+ *       -> artist_profile_created     profile row inserted
+ *         -> artist_profile_first_publish   link page created/published
+ *
+ * Every emit site carries the anonymous first-party `visitor_id` (as the
+ * top-level ability arg) AND the `user_id` (in event_data) so a single
+ * member's pre/post-login path stitches into one queryable sequence and the
+ * step-to-step drop-off (and the specific abandon step) is computable. This
+ * is the same visitor_id<->user_id stitching the registration referrer/UTM
+ * work keys on (Extra-Chill/extrachill-users#145) — built once, shared.
+ *
+ * The access-gate events (`artist_access_requested` / `_approved`) sit
+ * upstream of this funnel for users who must request access first.
+ */
+const EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED     = 'artist_access_requested';
+const EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED      = 'artist_access_approved';
+const EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED       = 'artist_signup_started';
+const EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED      = 'artist_profile_created';
+const EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH = 'artist_profile_first_publish';
 
 /**
  * The team-experience event set surfaced by the cohort rollup
@@ -79,5 +101,21 @@ const EC_ANALYTICS_TEAM_EXPERIENCE_EVENTS = array(
 const EC_ANALYTICS_ARTIST_FUNNEL_EVENTS = array(
 	EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED,
 	EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED,
+	EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED,
 	EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED,
+	EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH,
+);
+
+/**
+ * The activation sub-funnel — the ordered start->finish steps a new member
+ * walks when building an artist page, EXCLUDING the upstream access-gate
+ * events. Readers iterate this to compute step-to-step conversion and locate
+ * the abandon step. Order is significant (funnel sequence).
+ *
+ * @var string[]
+ */
+const EC_ANALYTICS_ARTIST_ACTIVATION_STEPS = array(
+	EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED,
+	EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED,
+	EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH,
 );


### PR DESCRIPTION
## Summary

Adds the two missing event-type constants that complete the artist-signup **activation funnel**, so we can measure where new members drop off between registering and finishing an artist page.

Part of the funnel instrumentation for Extra-Chill/extrachill-artist-platform#77. **The emit sites live in the companion PR** (extrachill-artist-platform) — this PR only defines the canonical names + groups they reference.

## What changed

- New constants in `inc/core/event-types.php`:
  - `EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED` = `artist_signup_started`
  - `EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH` = `artist_profile_first_publish`
- Both added to `EC_ANALYTICS_ARTIST_FUNNEL_EVENTS`.
- New ordered group `EC_ANALYTICS_ARTIST_ACTIVATION_STEPS` (start->finish, access-gate events excluded) for readers computing step-to-step conversion and locating the abandon step.

The completed funnel:

```
user_registration                (extrachill-users)
  -> artist_signup_started        entered the create flow
    -> artist_profile_created     profile inserted (already emitted)
      -> artist_profile_first_publish   link page created/published
```

## Why here

`extrachill-analytics` owns the canonical event-name contract (issue #129 pattern): every emit site and reader references the constant, never a bare literal, so a rename happens in exactly one place and can never silently desync an emit from a read.

## Stitching note

Emit sites (companion PR) carry the anonymous first-party `visitor_id` + `user_id` so a member's pre/post-login path stitches into one queryable sequence — the same `visitor_id`↔`user_id` plumbing the registration referrer/UTM work keys on (Extra-Chill/extrachill-users#145).

## Companion PR

- Emit sites + shared helper: Extra-Chill/extrachill-artist-platform (branch `funnel-instrument`)

Refs Extra-Chill/extrachill-artist-platform#77