### PR TITLE
fix: stitch visitor_id to non-pageview events + filter bot search demand

### DIFF
--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -138,6 +138,36 @@ function extrachill_analytics_ability_track_event( $input ) {
 		}
 	}
 
+	// Endpoint-automation gate for search demand signals. Community search is
+	// hammered by automation firing legitimate-looking artist names from the
+	// bare homepage (~7,800 searches in 2 days, all with no visitor cookie),
+	// which inflates the zero-result "demand" list. The existing payload
+	// classifier above only catches scanner/injection *terms*, not a bot
+	// spraying real names. Stamp a deterministic `is_bot` flag on `search`
+	// events so demand readers can exclude automation while volume stays
+	// visible — the same "keep it, don't hide it" posture as search_attack.
+	//
+	// Signal: a known-bot user agent. A real human searches only after loading
+	// a page (which mints the ec_vid cookie), so we additionally treat a
+	// cookieless search as bot-suspect. visitor_id resolution runs in the
+	// tracker; here we read the cookie presence directly to avoid re-minting.
+	if ( 'search' === $event_type && is_array( $event_data ) ) {
+		$user_agent = extrachill_analytics_get_user_agent();
+
+		$ua_is_bot = function_exists( 'extrachill_analytics_is_bot' )
+			&& extrachill_analytics_is_bot( $user_agent );
+
+		$has_visitor_cookie = function_exists( 'extrachill_analytics_read_visitor_id' )
+			&& '' !== extrachill_analytics_read_visitor_id();
+
+		// Bot when the UA matches a known crawler, or when the search is
+		// cookieless AND the UA is empty (headless/scripted clients routinely
+		// send no User-Agent). A human who reached the search box has a cookie.
+		$is_bot = $ua_is_bot || ( ! $has_visitor_cookie && '' === $user_agent );
+
+		$event_data['is_bot'] = $is_bot;
+	}
+
 	/**
 	 * Filter whether to track an analytics event.
 	 *

--- a/inc/core/abilities/get-search-gaps.php
+++ b/inc/core/abilities/get-search-gaps.php
@@ -157,6 +157,15 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 	$where[]  = "CHAR_LENGTH({$term_expr}) <= %d";
 	$values[] = $max_len;
 
+	// Exclude endpoint-automation searches flagged at insert time by the
+	// `is_bot` gate in extrachill_analytics_ability_track_event(). The flag is
+	// a JSON boolean, so JSON_EXTRACT returns the literal `true` for bot rows.
+	// Older rows predating the flag have no key (JSON_EXTRACT → NULL) and are
+	// intentionally kept — this filter only drops rows EXPLICITLY marked bot,
+	// so the demand list excludes automation without silently dropping legacy
+	// human searches.
+	$where[] = "COALESCE(JSON_EXTRACT(event_data, '$.is_bot'), false) = false";
+
 	$where_clause = implode( ' AND ', $where );
 	$where_values = $values;
 
@@ -167,9 +176,12 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 	// this is an on-demand admin/CLI report, not a hot path.
 	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
-	// Total human-plausible searches in window (after length filter; the
-	// classifier-based exclusion is applied per-term below for the buckets, and
-	// reflected via excluded_bot).
+	// Total human-plausible searches in window (after the length filter AND the
+	// endpoint-automation `is_bot` exclusion in $where; the term-classifier
+	// exclusion is applied per-term below for the buckets, and reflected via
+	// excluded_bot). Because the is_bot filter lives in the shared $where, it
+	// trims the denominator and the buckets identically, keeping
+	// zero_result_rate honest.
 	$total_sql      = "SELECT COUNT(*) FROM {$table} WHERE {$where_clause}";
 	$total_searches = empty( $where_values )
 		? (int) $wpdb->get_var( $total_sql )

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -51,6 +51,37 @@ function extrachill_analytics_is_valid_visitor_id( $value ) {
 }
 
 /**
+ * Read the existing first-party visitor id from the cookie WITHOUT minting.
+ *
+ * This is the read-only resolver used by server-side, non-pageview event
+ * writes (search, 404, registration, email, etc.). Minting a cookie is the
+ * pageview path's job — it owns the early `template_redirect` hook where
+ * `headers_sent()` is still false. A search or 404 write happens deep in the
+ * request (often after output has begun), so it must NOT try to mint; it just
+ * stitches to the visitor's already-established `ec_vid` cookie when one
+ * exists. Honors GPC/DNT opt-out by returning an empty string.
+ *
+ * @return string The existing visitor UUID, or empty string when none is set
+ *                 or the visitor has opted out.
+ */
+function extrachill_analytics_read_visitor_id() {
+	if ( extrachill_analytics_visitor_opted_out() ) {
+		return '';
+	}
+
+	$cookie_name = EXTRACHILL_ANALYTICS_VISITOR_COOKIE;
+
+	if ( isset( $_COOKIE[ $cookie_name ] ) ) {
+		$existing = sanitize_text_field( wp_unslash( $_COOKIE[ $cookie_name ] ) );
+		if ( extrachill_analytics_is_valid_visitor_id( $existing ) ) {
+			return $existing;
+		}
+	}
+
+	return '';
+}
+
+/**
  * Read the existing first-party visitor id, or mint a new one server-side.
  *
  * The cookie value is a random UUID v4 only — never an IP, email, or
@@ -82,14 +113,11 @@ function extrachill_analytics_get_or_mint_visitor_id() {
 		return $resolved;
 	}
 
-	$cookie_name = EXTRACHILL_ANALYTICS_VISITOR_COOKIE;
-
-	if ( isset( $_COOKIE[ $cookie_name ] ) ) {
-		$existing = sanitize_text_field( wp_unslash( $_COOKIE[ $cookie_name ] ) );
-		if ( extrachill_analytics_is_valid_visitor_id( $existing ) ) {
-			$resolved = $existing;
-			return $resolved;
-		}
+	// Read-only resolve first; if the cookie already exists we reuse it.
+	$existing = extrachill_analytics_read_visitor_id();
+	if ( '' !== $existing ) {
+		$resolved = $existing;
+		return $resolved;
 	}
 
 	$visitor_id = wp_generate_uuid4();

--- a/inc/core/events.php
+++ b/inc/core/events.php
@@ -19,6 +19,10 @@ defined( 'ABSPATH' ) || exit;
  * @param string $visitor_id Optional anonymous first-party visitor UUID (v4). Stored only
  *                           when it is a well-formed UUID v4 and the visitor has not opted
  *                           out via GPC/DNT (callers pass '' in that case). Never PII.
+ *                           When omitted/empty, this falls back to the existing `ec_vid`
+ *                           cookie (read-only, no minting) so server-side, non-pageview
+ *                           events (search, 404, registration, email) stitch to the same
+ *                           visitor as pageviews do.
  * @return int|false Event ID on success, false on failure.
  */
 function extrachill_track_analytics_event( $event_type, $event_data = array(), $source_url = '', $visitor_id = '' ) {
@@ -29,6 +33,21 @@ function extrachill_track_analytics_event( $event_type, $event_data = array(), $
 	}
 
 	$table_name = extrachill_analytics_events_table();
+
+	// Server-side stitching: when the caller didn't supply a valid visitor id
+	// (the pageview JS beacon is the only caller that does), fall back to the
+	// existing `ec_vid` cookie via the READ-ONLY resolver. This attaches a
+	// visitor_id to non-pageview events (search, 404, registration, email)
+	// without minting a new cookie here — minting stays the pageview path's
+	// job on the early template_redirect hook. GPC/DNT opt-out is honored by
+	// the resolver (returns '' → stored as NULL). Never PII.
+	if (
+		( ! function_exists( 'extrachill_analytics_is_valid_visitor_id' )
+			|| ! extrachill_analytics_is_valid_visitor_id( $visitor_id ) )
+		&& function_exists( 'extrachill_analytics_read_visitor_id' )
+	) {
+		$visitor_id = extrachill_analytics_read_visitor_id();
+	}
 
 	// Only persist a valid UUID v4; anything else (including empty / opted-out) is NULL.
 	$stored_visitor_id = ( function_exists( 'extrachill_analytics_is_valid_visitor_id' )


### PR DESCRIPTION
Closes Extra-Chill/extrachill-analytics#44.

Fixes the two linked analytics data-quality symptoms documented in #44.

## (A) Non-pageview events now carry `visitor_id`

**Problem:** only `pageview` events ever stamped `visitor_id` — every other type (search, 404, registration, email) was 100% NULL, because the JS pageview beacon was the only caller passing one. This blocked stitching any non-pageview event to a visitor.

**Fix:**
- New read-only resolver `extrachill_analytics_read_visitor_id()` (`inc/core/assets.php`) reads the existing `ec_vid` cookie **without minting** and honors GPC/DNT. `extrachill_analytics_get_or_mint_visitor_id()` now delegates its read path to it (no behavior change for the pageview path).
- `extrachill_track_analytics_event()` (`inc/core/events.php`) falls back to that resolver when the caller passes no valid `visitor_id`. Since every emit flows through this one function, search/404/registration/email now stitch to the same visitor as pageviews — **no caller signatures changed**.
- Minting stays the pageview path's job (early `template_redirect`, before output). Non-pageview writes happen deep in the request, so they only attach an *already-established* cookie — they never mint.

**Unblocks** the consumers that depend on this stitch:
- Extra-Chill/extrachill-users#145 (referrer/UTM on registration)
- Extra-Chill/extrachill-artist-platform#77 (artist-signup activation funnel)

## (B) Bot-inflated community search excluded from demand signal

**Problem:** community logged ~5,660 searches/day vs 65 pageviews — 7,826 from the bare homepage in 2 days, all cookieless. The zero-result "artist demand" list was volume-inflated. The existing classifier only catches payload-shaped *terms*, not a bot spraying real artist names.

**Fix:**
- Endpoint-automation gate in the `extrachill/track-analytics-event` handler (`inc/core/abilities.php`), right after the existing `search_attack` reclassification. Stamps a deterministic `is_bot` flag on `search` events: known-bot UA (`extrachill_analytics_is_bot()`), or cookieless + empty UA (headless/scripted clients). Events are kept and flagged — same "keep it visible, don't hide it" posture as `search_attack`.
- `extrachill/get-search-gaps` reader (`inc/core/abilities/get-search-gaps.php`) excludes `is_bot=true` rows via a shared `$where` clause, so the filter trims the denominator (`total_searches`) and the gap buckets identically — `zero_result_rate` stays honest. Legacy rows without the flag (`JSON_EXTRACT → NULL`) are intentionally kept, not dropped.

## Privacy / safety

- No new PII. `visitor_id` remains a random first-party UUID v4; GPC/DNT opt-out continues to record events anonymously (NULL).
- Network-wide by construction (events table is `base_prefix`-scoped).

## Verification

- `php -l` clean on all 4 changed files.
- `phpcs --standard=WordPress` (the repo's lint standard): changes add **zero new findings**. `events.php` error count is identical before/after (16 = 16, all pre-existing `$wpdb` baseline); the one new Yoda condition I introduced in `abilities.php` was fixed (only the pre-existing line-124 baseline error remains).