### PR TITLE
fix: assign $cookie_name before setcookie in visitor-id mint (500s every page)

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -120,7 +120,8 @@ function extrachill_analytics_get_or_mint_visitor_id() {
 		return $resolved;
 	}
 
-	$visitor_id = wp_generate_uuid4();
+	$cookie_name = EXTRACHILL_ANALYTICS_VISITOR_COOKIE;
+	$visitor_id  = wp_generate_uuid4();
 
 	// Set the cookie for ~1 year. Secure + HttpOnly + SameSite=Lax: first-party
 	// analytics only, not readable by JS, not sent on cross-site sub-requests.


### PR DESCRIPTION
## Summary

Fixes a HIGH-severity sitewide fatal: every singular `is_page()` request on extrachill.com (blog 1) currently returns **HTTP 500** (e.g. `/about/`, `/power/`).

`extrachill_analytics_get_or_mint_visitor_id()` referenced `$cookie_name` at the `setcookie()` call (and the following `$_COOKIE[...]` write) **without ever assigning it**. On PHP 8 `setcookie()` then receives an empty name and throws:

```
Uncaught ValueError: setcookie(): Argument #1 ($name) must not be empty
  at inc/core/assets.php:130
```

The sibling reader `extrachill_analytics_read_visitor_id()` already does this correctly (`$cookie_name = EXTRACHILL_ANALYTICS_VISITOR_COOKIE;`). This PR adds the same one-line assignment to the mint function.

## Change
```php
$cookie_name = EXTRACHILL_ANALYTICS_VISITOR_COOKIE;
$visitor_id  = wp_generate_uuid4();
```

## Verify after deploy
- `curl -s -o /dev/null -w "%{http_code}" https://extrachill.com/about/` → 200
- `curl -s -o /dev/null -w "%{http_code}" https://extrachill.com/power/` → 200

Closes #46.