### PR TITLE
fix: stop get-surface-growth demand slope truncation from date_stats 25-row cap

### DIFF
--- a/inc/core/abilities/get-surface-growth.php
+++ b/inc/core/abilities/get-surface-growth.php
@@ -338,12 +338,15 @@ function extrachill_analytics_surface_demand_growth( $surface, $ga_ability, $ga_
 	$prev_end    = gmdate( 'Y-m-d', strtotime( "-" . ( $days + 1 ) . ' days' ) );
 	$prev_start  = gmdate( 'Y-m-d', strtotime( "-" . ( $days * 2 ) . ' days' ) );
 
-	$cur_total  = extrachill_analytics_ga_sessions_for_window( $ga_ability, $host, $cur_start, $cur_end );
+	// The window is $days long; date_stats returns one row per day, so the
+	// expected series length is $days. Pass it through so the helper can both
+	// request a high-enough row limit AND detect a silently-truncated series.
+	$cur_total  = extrachill_analytics_ga_sessions_for_window( $ga_ability, $host, $cur_start, $cur_end, $days );
 	if ( is_wp_error( $cur_total ) ) {
 		return extrachill_analytics_not_instrumented( 'GA date_stats failed for current window: ' . $cur_total->get_error_message() );
 	}
 
-	$prev_total = extrachill_analytics_ga_sessions_for_window( $ga_ability, $host, $prev_start, $prev_end );
+	$prev_total = extrachill_analytics_ga_sessions_for_window( $ga_ability, $host, $prev_start, $prev_end, $days );
 	if ( is_wp_error( $prev_total ) ) {
 		return extrachill_analytics_not_instrumented( 'GA date_stats failed for previous window: ' . $prev_total->get_error_message() );
 	}
@@ -392,19 +395,42 @@ function extrachill_analytics_surface_demand_growth( $surface, $ga_ability, $ga_
 /**
  * Sum sessions for a host over a GA date window via action=date_stats.
  *
- * @param WP_Ability $ga_ability GA ability instance.
- * @param string     $host       Hostname filter.
- * @param string     $start      Start date (YYYY-MM-DD).
- * @param string     $end        End date (YYYY-MM-DD).
- * @return int|WP_Error Total sessions, or error.
+ * The date_stats action returns one row per DAY, so a window of N days is an
+ * N-row series. The datamachine/google-analytics ability applies a DEFAULT_LIMIT
+ * of 25 rows when no explicit limit is given (returning oldest-first and dropping
+ * the NEWEST days past the cap). Summing that truncated series silently
+ * understates the current window and manufactures a downward demand slope
+ * (analytics#50).
+ *
+ * To avoid that we (1) request an explicit limit large enough to cover the whole
+ * window, and (2) treat a series that still comes back shorter than the expected
+ * day-count as a coverage gap (WP_Error) rather than trusting a partial sum — a
+ * known-truncated series must never produce a confident slope. The caller maps
+ * the WP_Error to a not_instrumented marker, so the figure degrades honestly.
+ *
+ * @param WP_Ability $ga_ability    GA ability instance.
+ * @param string     $host          Hostname filter.
+ * @param string     $start         Start date (YYYY-MM-DD).
+ * @param string     $end           End date (YYYY-MM-DD).
+ * @param int        $expected_days Expected number of daily rows for the window.
+ * @return int|WP_Error Total sessions, or error (incl. truncated-series guard).
  */
-function extrachill_analytics_ga_sessions_for_window( $ga_ability, $host, $start, $end ) {
+function extrachill_analytics_ga_sessions_for_window( $ga_ability, $host, $start, $end, $expected_days = 0 ) {
+	$expected_days = max( 0, (int) $expected_days );
+
+	// Request enough rows to cover the whole window plus a small buffer. A
+	// one-row-per-day series can never exceed the window length, so this stays
+	// well under the ability's MAX_LIMIT (10000). Keep a sane floor for callers
+	// that don't pass an expected day-count.
+	$limit = max( $expected_days + 5, 60 );
+
 	$result = $ga_ability->execute(
 		array(
 			'action'     => 'date_stats',
 			'hostname'   => $host,
 			'start_date' => $start,
 			'end_date'   => $end,
+			'limit'      => $limit,
 		)
 	);
 
@@ -417,8 +443,28 @@ function extrachill_analytics_ga_sessions_for_window( $ga_ability, $host, $start
 		return new WP_Error( 'ga_demand_failed', $msg );
 	}
 
+	$rows      = (array) ( $result['results'] ?? array() );
+	$row_count = count( $rows );
+
+	// Truncation guard: if the daily series came back shorter than the window it
+	// is supposed to cover, we are summing partial data — which biases the slope.
+	// Degrade to a coverage gap rather than report a wrong, confident figure.
+	if ( $expected_days > 0 && $row_count < $expected_days ) {
+		return new WP_Error(
+			'ga_demand_truncated',
+			sprintf(
+				/* translators: 1: rows returned, 2: expected day count, 3: window start, 4: window end. */
+				'date_stats returned a truncated daily series (%1$d of %2$d expected days) for %3$s..%4$s; refusing to report a slope from partial data.',
+				$row_count,
+				$expected_days,
+				$start,
+				$end
+			)
+		);
+	}
+
 	$total = 0;
-	foreach ( (array) ( $result['results'] ?? array() ) as $row ) {
+	foreach ( $rows as $row ) {
 		$total += (int) ( $row['sessions'] ?? 0 );
 	}
 


### PR DESCRIPTION
## Root cause

`extrachill_analytics_ga_sessions_for_window()` in `inc/core/abilities/get-surface-growth.php` called the `datamachine/google-analytics` ability with `action=date_stats` and **no `limit`**, then `foreach`-summed `$row['sessions']`.

The ability applies a **`DEFAULT_LIMIT` of 25 rows** when no explicit limit is given (`DataMachineBusiness\...\GoogleAnalyticsAbilities`, `MAX_LIMIT = 10000`). For `date_stats` a **row is a DAY**, returned oldest-first. So any window longer than 25 days silently dropped the **newest** days off the tail:

- A 28-day window (`--weeks=4`) summed only **25 of 28** days.
- A 42-day window (`--weeks=6`) summed only **25 of 42** days — dropping 17 days.

Dropping the newest days from the **current** window systematically understates current demand → a **manufactured downward demand slope**. Confirmed live: a 28-day events `date_stats` returned exactly 25 rows (missing `2026-06-17/18/19`); with an explicit limit it returns all 28.

## The fix

1. **Explicit, window-sized limit.** Thread the window's day-count (`$days`) from `extrachill_analytics_surface_demand_growth()` into `extrachill_analytics_ga_sessions_for_window()` and request `limit = max($expected_days + 5, 60)` — comfortably under `MAX_LIMIT` (a one-row-per-day series can never exceed the window length), self-documenting rather than a magic number, with a sane floor for callers that don't pass a day-count.
2. **Truncation guard → degrade honestly.** If the returned series still comes back **shorter than the window's day-count**, the sum is partial and the slope would be biased. Rather than trust it, return a `WP_Error` (`ga_demand_truncated`), which the caller already maps to a `not_instrumented` coverage marker. This matches the ability's design note — *"Unmeasurable dimensions return a not_instrumented marker, never a zero"* — a coverage gap is honest; a wrong, confident slope is not. (Chose option **(b) degrade-to-not_instrumented** over a log/flag because a known-truncated series must never produce a confident slope.)
3. Both the **current-window and previous-window** calls go through the same helper, so one fix covers both (verified).

## Before / after (live verification, read-only)

`events.extrachill.com` demand, current vs previous equal window:

| window | before (no limit) | after (explicit limit) |
|---|---|---|
| `--weeks=4` (28d) | cur=18923 (25 rows), prev=24823 (25 rows), **slope −23.77%** | cur=19747 (**28 rows**), prev=25337 (**28 rows**), **slope −22.06%** |
| `--weeks=6` (42d) | (would drop 17 newest days/window) | events rows=**42**, **slope −0.73%** (essentially flat) |

The `--weeks=6` result is the clearest proof: with the newest 17 days/window restored, the events demand slope collapses from a steep manufactured decline to **−0.73% (flat)**. This aligns with the bot-resistant truth in #50 — first-party events pageviews held ~1,500/day on 06-18/06-19, bounce fell 0.88→0.53 and dwell rose 8s→210s over the window (bots leaving, humans staying). The corrected slope no longer shows a steep decline.

## Cross-layer follow-up (tracked, not in this PR)

The deeper cause is upstream: the **DMB `date_stats` 25-row `DEFAULT_LIMIT`** silently truncates any window-bounded daily series, a footgun for *any* trend/slope consumer, not just this one. This PR fixes the **consumer** (analytics) so the growth instrument stops lying — correct and in-scope — but the upstream ability should **also** be addressed: raise/remove the default cap for the window-bounded `date_stats` action, or return a `has_more`/`truncated` flag so consumers can detect partial series. That cross-layer fix is already documented in **#50** and intentionally **not** touched here (this PR stays scoped to `extrachill-analytics`).

## Verification

- `php -l` clean.
- `phpcs --standard=WordPress` on the changed region: **0 findings** (pre-existing alignment warnings elsewhere in the file are untouched baseline — left alone to keep the diff scoped).
- Live read-only execution of `wp_get_ability('extrachill/get-surface-growth')->execute(['weeks'=>4])` and `['weeks'=>6]` confirms full-window sums (28/42 rows) and the corrected slopes above.

Closes #50