### PR TITLE
fix: add active-window lens to php-error-summary so health rate reflects current errors

### DIFF
--- a/inc/core/abilities/get-php-error-summary.php
+++ b/inc/core/abilities/get-php-error-summary.php
@@ -86,6 +86,10 @@ function extrachill_analytics_register_php_error_summary_ability() {
  *   [
  *     'rows'                => [ [ signature, severity, file, count, per_day, sample, first_seen, last_seen ], ... ],
  *     'total'               => int,
+ *     'active_total'        => int,    // Hits from signatures still firing within the active window.
+ *     'active_per_day'      => float,  // active_total / days_covered — the CURRENT error rate.
+ *     'active_window_hours' => int,    // The activity threshold used to decide still-firing vs resolved.
+ *     'active_signatures'   => int,    // Distinct signatures whose last_seen is within the active window.
  *     'distinct_signatures' => int,
  *     'window_days'         => int,
  *     'days_covered'        => int,
@@ -94,6 +98,13 @@ function extrachill_analytics_register_php_error_summary_ability() {
  *     'truncated'           => bool,
  *     'log_path'            => string,
  *   ]
+ *
+ * The `active_*` keys are the "currently firing" lens: a signature whose
+ * last_seen is older than the active window is treated as RESOLVED and excluded
+ * from `active_total` / `active_per_day`, so a spike that was fixed hours ago
+ * stops inflating the current error rate. The full-window `total` is preserved
+ * unchanged for trend continuity. The activity window defaults to 24 hours and
+ * is filterable via `extrachill_analytics_error_active_window_hours`.
  */
 function extrachill_analytics_ability_get_php_error_summary( $input ) {
 	global $wpdb;
@@ -233,12 +244,33 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 		}
 	);
 
-	$grand_total = 0;
+	// Active-window threshold: a signature whose last_seen is older than this many
+	// hours is considered RESOLVED and excluded from the "currently firing" lens.
+	// The live tail is the arbiter — if a signature has stopped appearing, it no
+	// longer counts toward the current error rate even if it still sits in the
+	// persisted window total.
+	$active_window_hours = (int) apply_filters( 'extrachill_analytics_error_active_window_hours', 24 );
+	$active_window_hours = max( 1, $active_window_hours );
+	$active_cutoff       = time() - ( $active_window_hours * HOUR_IN_SECONDS );
+
+	$grand_total       = 0;
+	$active_total      = 0;
+	$active_signatures = 0;
 	foreach ( $rows as &$row ) {
 		$grand_total   += $row['count'];
 		$row['per_day'] = round( $row['count'] / $denominator, 1 );
+
+		// Mark each row active/resolved and accumulate the active-only totals.
+		$last_seen_ts  = ! empty( $row['last_seen'] ) ? strtotime( (string) $row['last_seen'] . ' UTC' ) : false;
+		$row['active'] = ( false !== $last_seen_ts && $last_seen_ts >= $active_cutoff );
+		if ( $row['active'] ) {
+			$active_total += $row['count'];
+			++$active_signatures;
+		}
 	}
 	unset( $row );
+
+	$active_per_day = round( $active_total / $denominator, 1 );
 
 	$distinct  = count( $rows );
 	$truncated = false;
@@ -257,6 +289,10 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 	return array(
 		'rows'                => $rows,
 		'total'               => $grand_total,
+		'active_total'        => $active_total,
+		'active_per_day'      => $active_per_day,
+		'active_window_hours' => $active_window_hours,
+		'active_signatures'   => $active_signatures,
 		'distinct_signatures' => $distinct,
 		'window_days'         => $days,
 		'days_covered'        => $days_covered,


### PR DESCRIPTION
## Root cause

`wp extrachill platform health` headlines a network **"Errors/day: ~10,889"** figure that overstates the *current* error rate. `extrachill/get-php-error-summary` builds `total` by **blending the persisted snapshot table with a live-tail re-parse** of the whole window, and the consumer (`HealthCommand::compose_errors()`) does `total / days_covered`. The problem is the **numerator**: it counts error spikes that were already fixed-and-deployed the same day.

On 2026-06-20 the blended total (~98,006) is dominated by three now-resolved signatures:

| count | last_seen (UTC) | severity | signature |
|------:|-----------------|----------|-----------|
| 14,502 | 2026-06-20 00:35 | warning | `Undefined array key "slug"` (theme.json font filter) |
| 14,502 | 2026-06-20 00:35 | deprecated | `str_replace(): Passing null` (same path) |
| 11,891 | 2026-06-20 03:56 | fatal | `Uncaught ValueError: setcookie()` (cookie fatal, fixed v0.14.1) |

These are dead, but they fully inflate the headline. The `days_covered` divisor (9, due to log rotation) is **correct** — the bug is the numerator, not the divisor.

## The fix (additive "currently firing" lens)

Added an `active_*` lens to the ability output. A signature whose `last_seen` is older than the **active window** is treated as RESOLVED and excluded from the active totals. The live tail is the arbiter — a signature that has stopped firing no longer counts toward the current rate even though it still sits in the persisted window `total`.

New keys (all additive; nothing removed):

- `active_total` — hits from signatures still firing within the active window
- `active_per_day` — `active_total / days_covered` → the **current** error rate
- `active_window_hours` — the threshold used
- `active_signatures` — distinct still-firing signatures
- each row also gains an `active` boolean

**Active window default: 24h**, filterable via **`extrachill_analytics_error_active_window_hours`** (matching the threshold the issue specifies; no magic literal — single filtered constant with a documented default).

## Before / after (live verification, days=28, limit=0)

```
blended      total=98010   per_day=10890     <- old headline
window=24h   active_total=76298  active_per_day=8477.6  active_sigs=546   <- new default
window=12h   active_total=37252  active_per_day=4139.1  active_sigs=19
window= 6h   active_total=1578   active_per_day=175.3   active_sigs=15
window= 1h   active_total=201    active_per_day=22.3    active_sigs=9
```

At the 24h default the active figure already drops the entire prior-day backlog and is meaningfully lower than the blend. **Note / judgment call:** the three big resolved spikes above fired earlier *this morning* (00:35 / 03:56), so they're still inside a 24h window. The filter is the tuning knob — tightening to 12h or 6h (`add_filter('extrachill_analytics_error_active_window_hours', fn() => 6);`) collapses the rate to the genuinely-current ~175/day once this-morning's fixed spikes age out. I kept the default at the issue-specified 24h rather than hardcoding a tighter value; operators/the scorecard can tune it via the filter.

## Backward compatibility

All existing keys are unchanged in shape: `rows`, `total`, `distinct_signatures`, `window_days`, `days_covered`, `period`, `source`, `truncated`, `log_path`. The full-window `total` is intentionally preserved for trend continuity. Existing readers are unaffected.

## Follow-up (separate repo)

The consumer `extrachill-cli` `HealthCommand::compose_errors()` still does `total / days_covered`. A small follow-up PR in **extrachill-cli** should switch the headline to `active_per_day` (with `total`/window kept available for trend). Tracked under #54.

## Layer note

All error-aggregation logic stays in `extrachill-analytics` (it owns the error-capture surface). No logic moved into the CLI consumer.

## Verification

- `php -l` clean on the touched file.
- `phpcs --standard=WordPress` → 0 errors / 0 warnings (exit 0).
- Ran the ability live (read-only) against the install to produce the before/after table above.

Addresses #54 (closing deferred until the extrachill-cli consumer adopts `active_per_day`).