### PR TITLE
fix: exclude already-redirected URLs from 404 reports (#31)

### DIFF
--- a/inc/core/404-categorizer.php
+++ b/inc/core/404-categorizer.php
@@ -280,6 +280,60 @@ function extrachill_analytics_extract_404_slug( $url ) {
 }
 
 /**
+ * Exclude 404 rows whose URL already has an active redirect rule.
+ *
+ * The 404 read-side reports aggregate raw 404 event rows in a rolling window
+ * with no awareness of the redirects table. A URL fixed with a 301 keeps
+ * showing as a top offender until its pre-fix rows age out. This helper drops
+ * those already-solved URLs by asking extrachill-seo (the redirects owner)
+ * which of the candidate URLs currently match an active rule.
+ *
+ * Dependency direction: analytics asks seo, never the reverse. The call is
+ * guarded by function_exists() so analytics never hard-depends on seo — if the
+ * helper is absent (seo inactive/older), the rows are returned unchanged,
+ * preserving the previous behavior. A single bulk call is used rather than
+ * N+1 per-URL lookups.
+ *
+ * @param array $rows Array of row objects each exposing a ->url property.
+ * @return array The input rows minus any whose URL has an active redirect.
+ */
+function extrachill_analytics_exclude_redirected_404_rows( $rows ) {
+	if ( empty( $rows ) || ! function_exists( 'extrachill_seo_filter_redirected_urls' ) ) {
+		return $rows;
+	}
+
+	// Collect candidate URLs (skip null/empty), preserving them for the lookup.
+	$urls = array();
+	foreach ( $rows as $row ) {
+		if ( isset( $row->url ) && '' !== $row->url ) {
+			$urls[] = $row->url;
+		}
+	}
+
+	if ( empty( $urls ) ) {
+		return $rows;
+	}
+
+	$redirected = extrachill_seo_filter_redirected_urls( $urls );
+
+	if ( empty( $redirected ) ) {
+		return $rows;
+	}
+
+	$redirected_lookup = array_fill_keys( $redirected, true );
+
+	$filtered = array();
+	foreach ( $rows as $row ) {
+		if ( isset( $row->url ) && isset( $redirected_lookup[ $row->url ] ) ) {
+			continue;
+		}
+		$filtered[] = $row;
+	}
+
+	return $filtered;
+}
+
+/**
  * Find a published post by slug.
  *
  * @param string $slug The post slug to search for.

--- a/inc/core/abilities/drill-404-category.php
+++ b/inc/core/abilities/drill-404-category.php
@@ -117,6 +117,10 @@ function extrachill_analytics_ability_drill_404_category( $input ) {
 	}
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
+	// Drop URLs that already have an active redirect rule so solved 404s
+	// don't keep resurfacing in the drill until their pre-fix rows age out.
+	$rows = extrachill_analytics_exclude_redirected_404_rows( $rows );
+
 	// Categories that are candidates for redirect suggestions.
 	$redirect_categories = array( 'legacy-html', 'content', 'date-prefix' );
 	$is_redirect_candidate = in_array( $category, $redirect_categories, true );

--- a/inc/core/abilities/get-404-patterns.php
+++ b/inc/core/abilities/get-404-patterns.php
@@ -100,6 +100,10 @@ function extrachill_analytics_ability_get_404_patterns( $input ) {
 	}
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
+	// Drop URLs that already have an active redirect rule so solved 404s
+	// don't inflate the pattern-category counts.
+	$rows = extrachill_analytics_exclude_redirected_404_rows( $rows );
+
 	// Aggregate by category.
 	$categories  = array();
 	$total_hits  = 0;

--- a/inc/core/abilities/get-404-top-urls.php
+++ b/inc/core/abilities/get-404-top-urls.php
@@ -97,8 +97,10 @@ function extrachill_analytics_ability_get_404_top_urls( $input ) {
 	$where_clause = implode( ' AND ', $where );
 
 	$values[] = $min_hits;
-	$values[] = $limit;
 
+	// Note: LIMIT is applied in PHP after excluding redirected URLs, so that
+	// dropping solved 404s doesn't shrink the result set below the requested
+	// limit when redirected rows would otherwise occupy top slots.
 	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	$sql = "SELECT
 		JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.requested_url')) AS url,
@@ -108,11 +110,14 @@ function extrachill_analytics_ability_get_404_top_urls( $input ) {
 		WHERE {$where_clause}
 		GROUP BY url
 		HAVING hits >= %d
-		ORDER BY hits DESC
-		LIMIT %d";
+		ORDER BY hits DESC";
 
 	$rows = $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	// Drop URLs that already have an active redirect rule so solved 404s
+	// don't keep ranking as top offenders until their pre-fix rows age out.
+	$rows = extrachill_analytics_exclude_redirected_404_rows( $rows );
 
 	$results = array();
 	foreach ( $rows as $row ) {
@@ -122,6 +127,10 @@ function extrachill_analytics_ability_get_404_top_urls( $input ) {
 			'last_seen' => $row->last_seen,
 			'category'  => extrachill_analytics_categorize_404_url( $row->url ),
 		);
+
+		if ( count( $results ) >= $limit ) {
+			break;
+		}
 	}
 
 	return $results;


### PR DESCRIPTION
## Summary

Fixes Extra-Chill/extrachill-seo#31. The 404 read-side reports (drill / patterns / top-urls) aggregated raw `404_error` event rows in the rolling window with **no awareness of the redirects table**, so a URL fixed with a 301 kept showing as a top offender until its pre-fix rows aged out.

**Proof (from #31):** `/big-ups-2023-in-review` had 78 404 rows in the 14d window, all dated *before* its redirect rule was created (~2026-06-15 13:46), zero after. `extrachill seo redirects test /big-ups-2023-in-review` → matches active rule #2900. The redirect works; the drill just kept counting pre-rule rows.

## Approach

**Filter at the read-side ability level** (the preferred option from #31): after each ability aggregates its candidate URLs, drop the ones extrachill-seo flags as currently redirected. No new CLI flag / no `redirected` boolean on every row — the reports simply stop surfacing solved URLs, which is the behavior every consumer (CLI, REST, chat) wants by default and keeps the output schema unchanged.

New shared helper in `inc/core/404-categorizer.php` (alongside the other 404 helpers):

```php
extrachill_analytics_exclude_redirected_404_rows( array $rows ): array
```

Called in all three abilities right after the aggregation query:
- `inc/core/abilities/drill-404-category.php`
- `inc/core/abilities/get-404-patterns.php` (drops redirected URLs before category counts are tallied)
- `inc/core/abilities/get-404-top-urls.php`

### Cross-plugin seam & function_exists guard
The helper calls extrachill-seo's bulk helper `extrachill_seo_filter_redirected_urls( array $urls ): array` (added in extrachill-seo#33) — **a single bulk call**, not N+1 per-URL queries.

Dependency direction is analytics → seo, never the reverse, and the call is wrapped in `function_exists( 'extrachill_seo_filter_redirected_urls' )`. **Analytics never hard-depends on seo:** if the helper is absent (seo inactive or an older version), the rows pass through unchanged and the previous behavior is preserved. The seam lives in seo because seo owns the redirects table and the matching/normalization logic — analytics must not reach into another plugin's table.

### Normalization parity
The seo helper mirrors the redirect matcher's normalization exactly (strip query/fragment, ensure leading slash, strip trailing slash, test both trailing-slash variants, `active = 1`). Verified with a standalone test of all the normalization edge cases (trailing slash, no leading slash, query+fragment, full URL, root, empty).

### top-urls LIMIT handling
`get-404-top-urls` previously applied `LIMIT %d` in SQL. That's now applied **in PHP after** the redirect exclusion, so dropping solved 404s doesn't shrink the result set below the requested limit when redirected URLs would otherwise occupy top slots. The `HAVING hits >= min_hits` + `ORDER BY hits DESC` stay in SQL.

## Cross-repo references
- Helper PR (merge first): **Extra-Chill/extrachill-seo#33** ("Part of #31").
- This PR is the one that fully closes #31.

## Verification
- `php -l` clean on all four edited files.
- phpcs (`WordPress` standard): **zero new findings** — finding counts are byte-identical to `main` for every edited file (the remaining warnings/1 pre-existing `NotPrepared` error on the ability SQL are baseline, not introduced here and out of scope for this fix).
- Reasoned through `/big-ups-2023-in-review`: aggregated → bulk-checked against `active=1` → matched rule #2900 → dropped from drill/top/patterns output. Same for the other 2026-06-15 redirected slugs (rules 2900–2903).

## Secondary observation from #31 (not addressed here)
The malformed `srcset`-string-logged-as-one-404-URL issue is an image/markup logging bug, separate from this reporting fix; it remains tracked in #31's body (and is noted in the seo PR).