### PR TITLE
refactor: consolidate bot/human determination into one canonical classifier (#57)

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -27,6 +27,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/php-error-log-db.ph
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/event-types.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/events.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/security-classifier.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/visitor-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/gtm.php';

--- a/inc/core/404-tracking.php
+++ b/inc/core/404-tracking.php
@@ -37,8 +37,9 @@ function extrachill_analytics_track_404() {
 
 	$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
 
-	// Skip known bots to reduce noise.
-	if ( extrachill_analytics_is_bot( $user_agent ) ) {
+	// Skip non-human requests to reduce noise. Uses the canonical classifier so
+	// the human/bot verdict matches every other analytics instrument.
+	if ( extrachill_analytics_request_is_bot( array( 'user_agent' => $user_agent ) ) ) {
 		return;
 	}
 
@@ -55,44 +56,4 @@ function extrachill_analytics_track_404() {
 		),
 		home_url( $url )
 	);
-}
-
-/**
- * Check if a user agent is a known bot/crawler.
- *
- * @param string $user_agent The user agent string.
- * @return bool True if the user agent is a known bot.
- */
-function extrachill_analytics_is_bot( $user_agent ) {
-	if ( empty( $user_agent ) ) {
-		return true;
-	}
-
-	$bot_patterns = array(
-		'bot',
-		'crawl',
-		'spider',
-		'slurp',
-		'mediapartners',
-		'lighthouse',
-		'pagespeed',
-		'pingdom',
-		'uptimerobot',
-		'headlesschrome',
-		'python-requests',
-		'curl/',
-		'wget/',
-		'go-http-client',
-		'apache-httpclient',
-	);
-
-	$ua_lower = strtolower( $user_agent );
-
-	foreach ( $bot_patterns as $pattern ) {
-		if ( false !== strpos( $ua_lower, $pattern ) ) {
-			return true;
-		}
-	}
-
-	return false;
 }

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -139,36 +139,6 @@ function extrachill_analytics_ability_track_event( $input ) {
 		}
 	}
 
-	// Endpoint-automation gate for search demand signals. Community search is
-	// hammered by automation firing legitimate-looking artist names from the
-	// bare homepage (~7,800 searches in 2 days, all with no visitor cookie),
-	// which inflates the zero-result "demand" list. The existing payload
-	// classifier above only catches scanner/injection *terms*, not a bot
-	// spraying real names. Stamp a deterministic `is_bot` flag on `search`
-	// events so demand readers can exclude automation while volume stays
-	// visible — the same "keep it, don't hide it" posture as search_attack.
-	//
-	// Signal: a known-bot user agent. A real human searches only after loading
-	// a page (which mints the ec_vid cookie), so we additionally treat a
-	// cookieless search as bot-suspect. visitor_id resolution runs in the
-	// tracker; here we read the cookie presence directly to avoid re-minting.
-	if ( 'search' === $event_type && is_array( $event_data ) ) {
-		$user_agent = extrachill_analytics_get_user_agent();
-
-		$ua_is_bot = function_exists( 'extrachill_analytics_is_bot' )
-			&& extrachill_analytics_is_bot( $user_agent );
-
-		$has_visitor_cookie = function_exists( 'extrachill_analytics_read_visitor_id' )
-			&& '' !== extrachill_analytics_read_visitor_id();
-
-		// Bot when the UA matches a known crawler, or when the search is
-		// cookieless AND the UA is empty (headless/scripted clients routinely
-		// send no User-Agent). A human who reached the search box has a cookie.
-		$is_bot = $ua_is_bot || ( ! $has_visitor_cookie && '' === $user_agent );
-
-		$event_data['is_bot'] = $is_bot;
-	}
-
 	/**
 	 * Filter whether to track an analytics event.
 	 *

--- a/inc/core/abilities/get-search-gaps.php
+++ b/inc/core/abilities/get-search-gaps.php
@@ -18,7 +18,15 @@
  *      separate event_type='search_attack' (see security-classifier.php). This
  *      ability queries event_type='search' only, so anything already classified
  *      is excluded for free.
- *   2. Read-time filtering catches residual junk that slipped through before
+ *   2. The canonical visitor classifier stamps an `is_bot` flag on every event
+ *      at write time (issue #57); this ability excludes rows flagged bot.
+ *   3. An OPTIONAL visitor_id gate (filter
+ *      `extrachill_analytics_search_gaps_require_visitor_id`, default OFF)
+ *      excludes legacy programmatic searches that the OLD, now-removed search
+ *      rule wrongly stamped human (the #51 root cause). It defaults off because
+ *      on this install search events rarely carry a stitched visitor_id even
+ *      for humans; see the inline note for the measured tradeoff.
+ *   4. Read-time filtering catches residual junk that slipped through before
  *      the classifier existed (or that the classifier doesn't fire on):
  *        - terms longer than the human-plausible ceiling (default 60 chars),
  *        - terms that the shared security classifier flags as a payload
@@ -157,14 +165,38 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 	$where[]  = "CHAR_LENGTH({$term_expr}) <= %d";
 	$values[] = $max_len;
 
-	// Exclude endpoint-automation searches flagged at insert time by the
-	// `is_bot` gate in extrachill_analytics_ability_track_event(). The flag is
-	// a JSON boolean, so JSON_EXTRACT returns the literal `true` for bot rows.
-	// Older rows predating the flag have no key (JSON_EXTRACT → NULL) and are
-	// intentionally kept — this filter only drops rows EXPLICITLY marked bot,
-	// so the demand list excludes automation without silently dropping legacy
-	// human searches.
+	// Exclude non-human searches flagged at insert time by the canonical
+	// classifier (now stamped on EVERY event in extrachill_track_analytics_event;
+	// see issue #57). The flag is a JSON boolean, so JSON_EXTRACT returns the
+	// literal `true` for bot rows. Rows written before the flag existed have no
+	// key (JSON_EXTRACT → NULL) and COALESCE keeps them as non-bot here.
 	$where[] = "COALESCE(JSON_EXTRACT(event_data, '$.is_bot'), false) = false";
+
+	// Defense-in-depth for legacy-contaminated rows. The OLD search rule
+	// (is_bot = ua_bot || (no-cookie && empty-UA)) — the #51 root cause — wrote
+	// is_bot=FALSE for cookieless programmatic searches that carried a normal
+	// UA (events pipeline, community lookups spraying real band names). Those
+	// rows are already in the DB stamped human, so the is_bot filter above
+	// cannot catch them. The strongest human signal that retention also relies
+	// on is a present visitor_id: a genuine human reaches the search box only
+	// after loading a page that mints the ec_vid cookie.
+	//
+	// IMPORTANT TRADEOFF (measured against live data, 2026-06-20): on this
+	// install search events almost never carry a stitched visitor_id (1 of
+	// ~234k over 28 days) even though pageviews do (~91%), because the search
+	// volume is overwhelmingly programmatic. A hard visitor_id gate therefore
+	// empties the report. That is "correct" in the strict sense (almost none of
+	// that traffic is a cookied human) but operationally useless, so the gate is
+	// FILTERABLE and defaults OFF. The canonical is_bot stamp (now written on
+	// every event) is the primary go-forward fix; flip this filter on once
+	// enough cookie-stitched human searches exist to make the gate meaningful.
+	//
+	// Filter: extrachill_analytics_search_gaps_require_visitor_id (bool, default
+	// false) — when true, also require a non-empty visitor_id.
+	$require_visitor_id = (bool) apply_filters( 'extrachill_analytics_search_gaps_require_visitor_id', false );
+	if ( $require_visitor_id ) {
+		$where[] = "visitor_id IS NOT NULL AND visitor_id != ''";
+	}
 
 	$where_clause = implode( ' AND ', $where );
 	$where_values = $values;

--- a/inc/core/abilities/track-page-view.php
+++ b/inc/core/abilities/track-page-view.php
@@ -93,16 +93,22 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 	// Write a deterministic pageview event row so per-visitor retention can be
 	// queried. visitor_id is persisted only when it is a valid UUID v4; an empty
 	// or opted-out value still records the pageview anonymously (NULL visitor_id),
-	// keeping aggregate volume accurate. Bots are excluded by user-agent so the
-	// retention table stays bot-resistant by construction, matching the existing
-	// 404 capture path.
+	// keeping aggregate volume accurate. Bots are excluded via the canonical
+	// classifier's UA-class signal so the retention table stays bot-resistant by
+	// construction, using the one shared bot-UA pattern list.
+	//
+	// The pageview gate intentionally keys on the UA signal ONLY (not the full
+	// strict verdict): this beacon is a browser-initiated fetch, and a
+	// privacy-opted-out human (GPC/DNT, hence no ec_vid cookie) is still a real
+	// pageview we want counted anonymously. Requiring the cookie here would drop
+	// those legitimate humans. Per-visitor retention metrics already exclude
+	// NULL-visitor_id rows downstream, so anonymous pageviews never distort them.
 	$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] )
 		? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) )
 		: '';
 
-	$is_bot = function_exists( 'extrachill_analytics_is_bot' )
-		? extrachill_analytics_is_bot( $user_agent )
-		: false;
+	$is_bot = function_exists( 'extrachill_analytics_classify_user_agent' )
+		&& 'browser' !== extrachill_analytics_classify_user_agent( $user_agent );
 
 	if ( ! $is_bot && function_exists( 'extrachill_track_analytics_event' ) ) {
 		$permalink = get_permalink( $post_id );

--- a/inc/core/events.php
+++ b/inc/core/events.php
@@ -55,6 +55,25 @@ function extrachill_track_analytics_event( $event_type, $event_data = array(), $
 		? $visitor_id
 		: null;
 
+	// Stamp the canonical human/bot verdict on EVERY event at write time so all
+	// downstream readers filter on one trustworthy, consistent flag instead of
+	// each re-litigating the question (issue #57). This is the single source of
+	// truth — the verdict already factors UA, visitor cookie, and request origin
+	// (cli/cron/rest), which is what kills the #51 programmatic-search
+	// contamination at the source. The flag is only stamped when the caller
+	// hasn't already supplied one, so an explicit upstream classification (none
+	// today) would still win. We pass the resolved cookie state so the verdict
+	// uses the same visitor_id the row is stored under.
+	if ( is_array( $event_data )
+		&& ! array_key_exists( 'is_bot', $event_data )
+		&& function_exists( 'extrachill_analytics_classify_request' )
+	) {
+		$verdict              = extrachill_analytics_classify_request(
+			array( 'has_visitor_cookie' => null !== $stored_visitor_id )
+		);
+		$event_data['is_bot'] = (bool) $verdict['is_bot'];
+	}
+
 	$result = $wpdb->insert(
 		$table_name,
 		array(

--- a/inc/core/visitor-classifier.php
+++ b/inc/core/visitor-classifier.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Canonical Visitor / Request Classifier
+ *
+ * THE single source of truth for "is this request a human or a bot?" across
+ * every analytics instrument (404 tracking, pageview, search demand, retention,
+ * event-write stamping). Before this file existed, five instruments each
+ * re-litigated the question with their own ad-hoc rule and the rules disagreed
+ * (issue #57) — the weakest one (the old `search` rule) silently corrupted the
+ * search-gaps demand report (issue #51).
+ *
+ * Design (per the #57 decision): ONE classifier, ONE default verdict consumed
+ * everywhere, but the verdict ships ALONGSIDE inspectable evidence signals so
+ * the single boolean is not a one-way door. If a specific instrument later
+ * proves it needs a different threshold, it reads the evidence rather than
+ * re-collecting the signals a sixth way.
+ *
+ * "Human" is fundamentally probabilistic; there is no perfect answer. The
+ * default policy leans on the strongest available signals in this order:
+ *
+ *   1. Request origin — programmatic/server-side context (WP-CLI, cron, an
+ *      internal REST request) is NON-human regardless of UA. This is the fix
+ *      for #51: a server-side band-name search carries a normal UA but no
+ *      browser ever ran, so it must not count as human demand.
+ *   2. User-Agent class — a declared crawler UA ("bot"/"crawl"/"curl"/...) or
+ *      an empty UA is NON-human.
+ *   3. Visitor cookie presence — a real JS browser that executed and minted an
+ *      `ec_vid` cookie is the strongest positive human signal. A cookieless
+ *      request that is otherwise an interactive web request is treated as
+ *      NON-human (suspect) by the default verdict, because a human who reached
+ *      a search box or deep page has loaded a page and minted the cookie.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.12.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Classify the current request (or an explicit context) as human or bot, and
+ * return the evidence signals the verdict was derived from.
+ *
+ * Verdict policy (the single canonical answer every instrument consumes):
+ *   is_human = TRUE only when ALL of these hold —
+ *     - request_origin === 'web'            (not cli/cron/rest-internal)
+ *     - ua_class === 'browser'              (not 'bot' and not 'empty')
+ *     - has_visitor_cookie === true         (a real browser minted ec_vid)
+ *   Otherwise is_human = FALSE (is_bot = TRUE).
+ *
+ * In other words: programmatic context OR a crawler/empty UA OR a cookieless
+ * request all classify as non-human. Present cookie + browser UA + web origin
+ * is the strongest human signal and the only combination treated as human.
+ *
+ * @param array $context {
+ *     Optional. Override the request-derived signals (useful for tests and for
+ *     callers that already resolved a value to avoid re-reading globals).
+ *
+ *     @type string    $user_agent         User-agent string. Defaults to the
+ *                                          current request UA.
+ *     @type bool|null $has_visitor_cookie  Whether a valid ec_vid cookie is
+ *                                          present. Defaults to reading the
+ *                                          cookie via the read-only resolver.
+ *     @type string    $request_origin      One of 'web'|'rest'|'cron'|'cli'.
+ *                                          Defaults to auto-detection.
+ * }
+ * @return array{
+ *     is_human: bool,
+ *     is_bot: bool,
+ *     signals: array{
+ *         has_visitor_cookie: bool,
+ *         ua_class: string,
+ *         request_origin: string
+ *     }
+ * }
+ */
+function extrachill_analytics_classify_request( $context = array() ) {
+	// --- Resolve evidence signals (from $context overrides or the request). ---
+
+	$user_agent = array_key_exists( 'user_agent', $context )
+		? (string) $context['user_agent']
+		: ( function_exists( 'extrachill_analytics_get_user_agent' ) ? extrachill_analytics_get_user_agent() : '' );
+
+	if ( array_key_exists( 'has_visitor_cookie', $context ) && null !== $context['has_visitor_cookie'] ) {
+		$has_visitor_cookie = (bool) $context['has_visitor_cookie'];
+	} else {
+		$has_visitor_cookie = function_exists( 'extrachill_analytics_read_visitor_id' )
+			&& '' !== extrachill_analytics_read_visitor_id();
+	}
+
+	$request_origin = array_key_exists( 'request_origin', $context ) && '' !== $context['request_origin']
+		? (string) $context['request_origin']
+		: extrachill_analytics_detect_request_origin();
+
+	$ua_class = extrachill_analytics_classify_user_agent( $user_agent );
+
+	$signals = array(
+		'has_visitor_cookie' => $has_visitor_cookie,
+		'ua_class'           => $ua_class,
+		'request_origin'     => $request_origin,
+	);
+
+	// --- Apply the single canonical verdict policy. ---
+	$is_human = (
+		'web' === $request_origin
+		&& 'browser' === $ua_class
+		&& $has_visitor_cookie
+	);
+
+	return array(
+		'is_human' => $is_human,
+		'is_bot'   => ! $is_human,
+		'signals'  => $signals,
+	);
+}
+
+/**
+ * Classify a User-Agent string into one of three buckets.
+ *
+ * This owns the ONE bot user-agent pattern list for the whole plugin (moved
+ * here from the former extrachill_analytics_is_bot). The list is filterable so
+ * the patterns are not behaviour-changing magic literals buried in code.
+ *
+ * @param string $user_agent The user agent string.
+ * @return string 'empty' (no UA), 'bot' (matches a crawler pattern), or 'browser'.
+ */
+function extrachill_analytics_classify_user_agent( $user_agent ) {
+	$user_agent = (string) $user_agent;
+
+	if ( '' === trim( $user_agent ) ) {
+		return 'empty';
+	}
+
+	$default_patterns = array(
+		'bot',
+		'crawl',
+		'spider',
+		'slurp',
+		'mediapartners',
+		'lighthouse',
+		'pagespeed',
+		'pingdom',
+		'uptimerobot',
+		'headlesschrome',
+		'python-requests',
+		'curl/',
+		'wget/',
+		'go-http-client',
+		'apache-httpclient',
+	);
+
+	/**
+	 * Filter the User-Agent substring patterns treated as bot/crawler markers.
+	 *
+	 * @param string[] $patterns   Lower-case substrings; a match marks the UA as a bot.
+	 * @param string   $user_agent The user agent being classified.
+	 */
+	$patterns = apply_filters( 'extrachill_analytics_bot_ua_patterns', $default_patterns, $user_agent );
+
+	$ua_lower = strtolower( $user_agent );
+
+	foreach ( (array) $patterns as $pattern ) {
+		if ( '' !== $pattern && false !== strpos( $ua_lower, (string) $pattern ) ) {
+			return 'bot';
+		}
+	}
+
+	return 'browser';
+}
+
+/**
+ * Detect the origin of the current request.
+ *
+ * Programmatic origins (cli/cron/rest) never represent an interactive human
+ * browser session and are classified non-human regardless of UA.
+ *
+ * @return string One of 'cli'|'cron'|'rest'|'web'.
+ */
+function extrachill_analytics_detect_request_origin() {
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return 'cli';
+	}
+
+	if ( function_exists( 'wp_doing_cron' ) ? wp_doing_cron() : ( defined( 'DOING_CRON' ) && DOING_CRON ) ) {
+		return 'cron';
+	}
+
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		return 'rest';
+	}
+
+	return 'web';
+}
+
+/**
+ * Convenience: is the current request (or explicit context) a human?
+ *
+ * @param array $context Optional signal overrides; see extrachill_analytics_classify_request().
+ * @return bool
+ */
+function extrachill_analytics_request_is_human( $context = array() ) {
+	$verdict = extrachill_analytics_classify_request( $context );
+	return (bool) $verdict['is_human'];
+}
+
+/**
+ * Convenience: is the current request (or explicit context) a bot/non-human?
+ *
+ * @param array $context Optional signal overrides; see extrachill_analytics_classify_request().
+ * @return bool
+ */
+function extrachill_analytics_request_is_bot( $context = array() ) {
+	$verdict = extrachill_analytics_classify_request( $context );
+	return (bool) $verdict['is_bot'];
+}
+
+/**
+ * Backward-compatible UA-only bot test.
+ *
+ * Thin shim retained so any external/legacy caller of the old helper keeps
+ * working. Internally everything routes through the canonical classifier; this
+ * delegates to the UA-class signal only (an empty or crawler UA is a bot),
+ * matching the old function's contract (true on empty UA). New code should call
+ * extrachill_analytics_classify_request() / _request_is_bot() instead so the
+ * cookie + request-origin signals are also considered.
+ *
+ * @param string $user_agent The user agent string.
+ * @return bool True if the user agent is empty or a known bot.
+ */
+function extrachill_analytics_is_bot( $user_agent ) {
+	return 'browser' !== extrachill_analytics_classify_user_agent( $user_agent );
+}


### PR DESCRIPTION
## Summary

Replaces **five divergent, disagreeing** "is this request a human?" rules across extrachill-analytics with a **single canonical classifier** that returns a verdict AND inspectable evidence signals, migrates every consumer to it, and fixes the search-gaps contamination at its source.

- **Closes #57** — no canonical human/bot primitive; 5 inline rules disagreed.
- **Closes #51** — the weakest rule (the `search` is_bot rule) was the root cause of programmatic searches polluting the search-gaps demand report.

This is a **consolidation, not a framework**: net **-86/+59 lines** to existing files (the only additions are the one new classifier file + the migrated call sites).

## The 5 old definitions being consolidated

| # | Where | Old rule | Now |
|---|-------|----------|-----|
| 1 | `404-tracking.php` `extrachill_analytics_is_bot()` | UA substring match, true on empty UA | **Moved** into the classifier; kept as a thin UA-only back-compat shim that delegates to it |
| 2 | `abilities.php` search rule | `is_bot = ua_bot \|\| (!cookie && '' === ua)` | **Deleted** — this is the #51 root cause (cookieless programmatic search with a normal UA was labelled *human*) |
| 3 | `get-retention-stats.php` | `visitor_id IS NOT NULL AND != ''` | **Unchanged** — already matches the canonical `has_visitor_cookie` signal (low-risk to leave; noted) |
| 4 | `get-search-gaps.php` | trusts the stored `is_bot` flag set by rule #2 | Stored flag is now **trustworthy** (stamped by the classifier at write time) + an optional visitor_id defense gate |
| 5 | `404-categorizer.php` `$bot_paths` | hardcoded URL list | **Left as-is** — it categorizes URL *patterns*, a different axis from the human/bot verdict (intentionally separate) |

## The new canonical primitive — `inc/core/visitor-classifier.php`

```php
extrachill_analytics_classify_request( $context = [] ): array
// => [
//   'is_human' => bool,
//   'is_bot'   => bool,
//   'signals'  => [
//       'has_visitor_cookie' => bool,   // ec_vid present (via read_visitor_id)
//       'ua_class'           => 'bot'|'empty'|'browser',
//       'request_origin'     => 'web'|'rest'|'cron'|'cli',
//   ],
// ]
```

**Verdict policy (the single canonical answer everyone consumes):** a request is **human only when** `request_origin === 'web'` AND `ua_class === 'browser'` AND `has_visitor_cookie === true`. Otherwise it is a bot. So:
- programmatic/server-side context (CLI / cron / internal REST) → **bot regardless of UA** (this is the #51 fix),
- a declared crawler UA or an empty UA → bot,
- a present cookie + browser UA + web origin → the strongest human signal, and the only combination treated as human.

Per the #57 decision the verdict ships **alongside the evidence signals** so the single boolean is not a one-way door — an instrument that later needs a different threshold reads the evidence instead of re-collecting it a sixth way. The bot-UA pattern list lives in one place and is filterable (`extrachill_analytics_bot_ua_patterns`); convenience helpers `extrachill_analytics_request_is_human()` / `_request_is_bot()` and the UA-only shim `extrachill_analytics_is_bot()` are provided.

## Consumers migrated

- **`events.php` (event-write stamping):** every event now gets the canonical `is_bot` verdict stamped at write time (not just `search`), so all readers filter on one consistent, trustworthy flag.
- **`404-tracking.php` + `track-page-view.php`:** use the classifier instead of the bare UA helper. Pageview intentionally gates on the **UA signal only** (not the full strict verdict) so a privacy-opted-out human — GPC/DNT, hence no cookie — is still counted anonymously; per-visitor retention already drops NULL-visitor_id rows downstream.
- **`get-search-gaps.php`:** trusts the now-correct stored `is_bot` flag, plus an **optional** visitor_id gate behind `extrachill_analytics_search_gaps_require_visitor_id` (default **OFF**, see below).

## Legacy-row defense + the measured tradeoff

The old rule #2 wrote `is_bot=FALSE` for cookieless programmatic searches carrying a normal UA, so those rows are already in the DB stamped human and the is_bot filter cannot retroactively catch them. The task asked for a `visitor_id IS NOT NULL` gate as defense-in-depth. **Measured against live data (2026-06-20), a hard gate empties the report:**

| Search events, last 28d | Count |
|---|---|
| total `search` events | **234,525** |
| with a stitched `visitor_id` | **1** |
| pageview events with `visitor_id` | 3,437 / 3,772 (**91%**) |

Search events almost never carry a stitched visitor_id (even for the rare human) because the search volume is overwhelmingly programmatic; pageviews do. A hard visitor_id gate is therefore "strictly correct" but operationally useless — it drops the entire demand list. **Decision:** the visitor_id gate is **filterable and defaults OFF**; the canonical `is_bot` stamp is the primary go-forward fix. Flip the filter on once enough cookie-stitched human searches exist to make the gate meaningful.

### Before / after (zero-result search rows, 28d, live)
- **BEFORE** (is_bot flag only, no visitor_id gate): **9,576 rows / 4,492 distinct terms**
- **AFTER** (hard visitor_id gate, i.e. filter ON): **0 rows / 0 distinct terms** — proves why the gate defaults OFF
- **Go-forward canonical stamp:** of the 234,529 searches in the window, **234,528 (100.00%)** would be stamped `is_bot=true` (cookieless), exactly **1** remains human — i.e. the new write-time stamp cleans the #51 noise at the source without a blanket gate.

## Proof cases (verdicts match the issue exactly)

| Case | is_human | signals |
|---|---|---|
| cookied browser (web) | **TRUE** | ua=browser origin=web cookie=yes |
| googlebot UA | FALSE | ua=bot |
| python-requests / curl UA | FALSE | ua=bot |
| **#51: cookieless normal UA + rest/cron origin** | **FALSE** | ua=browser origin=rest/cron cookie=no |
| cookieless normal UA + web | FALSE | ua=browser cookie=no (suspect) |
| empty UA | FALSE | ua=empty |
| cookied browser but CLI origin | FALSE | origin=cli |

`extrachill_analytics_is_bot()` shim confirmed identical to the old UA-only behaviour (true on empty/crawler, false on a normal browser UA).

## Verification
- `php -l` clean on all 7 touched files.
- `phpcs --standard=WordPress`: the new `visitor-classifier.php` and the rewritten `get-search-gaps.php` are **0 errors / 0 warnings**. Remaining findings in the other touched files are **pre-existing baseline issues on lines this PR did not author** (verified via diff).
- Net complexity **down** (-86/+59 to existing files); five definitions → one.