### PR TITLE
feat(analytics): content-category revenue + RPM lens

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -22,12 +22,15 @@ define( 'EXTRACHILL_ANALYTICS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 // Database table management.
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/events-db.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/php-error-log-db.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/mediavine-revenue-db.php';
 
 // Core functionality (network-wide).
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/event-types.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/events.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/security-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/visitor-classifier.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/content-format-classifier.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/mediavine-csv-import.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/gtm.php';
@@ -49,6 +52,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-bridge-ct
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-retention-stats.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-growth.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-activation-funnel.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-content-revenue.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-php-error-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/check-fatal-alarm.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/404-categorizer.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -27,6 +27,7 @@ add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_bridge_ctr_a
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_retention_stats_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_surface_growth_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_activation_funnel_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_content_revenue_ability' );
 
 /**
  * Register analytics ability category.

--- a/inc/core/abilities/get-content-revenue.php
+++ b/inc/core/abilities/get-content-revenue.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Get Content Revenue Ability
+ *
+ * The revenue sibling of datamachine/content-performance. Joins per-URL Mediavine
+ * ad revenue (imported from the Pages CSV — Mediavine has no per-page API) to
+ * WordPress content metadata (category, content format, post age) and rolls it
+ * up by category AND by content format, reporting the metrics the manual stitch
+ * surfaced: pages, views, revenue, RPM, and — the honest one — $/page.
+ *
+ * Why $/page is the load-bearing metric, not RPM: RPM (revenue per 1k views) is
+ * a MULTIPLIER, not a volume measure. A trivia format can post a high RPM ($33)
+ * yet a tiny $/page ($24) because it has almost no views — "high RPM on tiny
+ * volume = pennies." $/page (total revenue / page count) is the only honest
+ * answer to "is this format worth producing." Both are reported; $/page is the
+ * one to rank on.
+ *
+ * Lifetime vs recent: high LIFETIME revenue can just mean a page is OLD and
+ * accumulated earnings over years — not that it earns NOW. The ability accepts a
+ * window (period_start/period_end) that filters to snapshots imported for that
+ * window, so an all-time export and a last-30-days export produce distinct
+ * "earned ever" vs "earning now" rollups from the same store.
+ *
+ * Source-of-truth note: Mediavine RPM is the ONLY view of ad income — GA and the
+ * first-party events table cannot see ad revenue. So revenue here is exactly what
+ * was imported; this ability never estimates it.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.16.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-content-revenue ability.
+ */
+function extrachill_analytics_register_content_revenue_ability() {
+	wp_register_ability(
+		'extrachill/get-content-revenue',
+		array(
+			'label'               => __( 'Get Content Revenue Lens', 'extrachill-analytics' ),
+			'description'         => __( 'Join imported Mediavine per-URL ad revenue to WordPress content metadata (category, content format, age) and roll it up by category AND by content format. Reports pages, views, revenue, RPM, and $/page (revenue/pages) — $/page is the honest "worth producing" metric because RPM alone misleads (high RPM on tiny volume = pennies). Accepts a window (period_start/period_end) to distinguish lifetime-accumulated revenue from earning-now. Revenue is exactly what was imported from the Mediavine Pages CSV (Mediavine has no per-page API); this ability never estimates ad income.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'group_by'     => array(
+						'type'        => 'string',
+						'description' => __( 'Rollup axis: "format" (default), "category", or "both".', 'extrachill-analytics' ),
+						'default'     => 'format',
+					),
+					'period_start' => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive window start (Y-m-d). With period_end, restricts to snapshots imported for that window (the recent lens). Empty = all snapshots (lifetime).', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'period_end'   => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive window end (Y-m-d). See period_start.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'import_batch' => array(
+						'type'        => 'string',
+						'description' => __( 'Restrict to one import batch so multiple imports are never double-counted. Empty = all batches.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'blog_id'      => array(
+						'type'        => 'integer',
+						'description' => __( 'Blog ID whose revenue to read. 0 = current blog.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'hostname'     => array(
+						'type'        => 'string',
+						'description' => __( 'Hostname for resolving any still-unresolved slugs to posts (default: extrachill.com).', 'extrachill-analytics' ),
+						'default'     => 'extrachill.com',
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'Rollups keyed by axis, each with pages, views, revenue, rpm, dollars_per_page, plus totals and caveats.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_content_revenue',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-content-revenue ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Rollup data.
+ */
+function extrachill_analytics_ability_get_content_revenue( $input ) {
+	$group_by     = isset( $input['group_by'] ) ? (string) $input['group_by'] : 'format';
+	$period_start = isset( $input['period_start'] ) ? (string) $input['period_start'] : '';
+	$period_end   = isset( $input['period_end'] ) ? (string) $input['period_end'] : '';
+	$import_batch = isset( $input['import_batch'] ) ? (string) $input['import_batch'] : '';
+	$blog_id      = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : get_current_blog_id();
+	$hostname     = ! empty( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com';
+
+	if ( ! in_array( $group_by, array( 'format', 'category', 'both' ), true ) ) {
+		$group_by = 'format';
+	}
+
+	$rows = extrachill_analytics_revenue_get_rows(
+		array(
+			'blog_id'      => $blog_id,
+			'import_batch' => $import_batch,
+			'period_start' => $period_start,
+			'period_end'   => $period_end,
+		)
+	);
+
+	if ( empty( $rows ) ) {
+		return array(
+			'success' => true,
+			'rows'    => 0,
+			'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end ),
+			'rollups' => array(),
+			'totals'  => array(
+				'pages'            => 0,
+				'views'            => 0,
+				'revenue'          => 0.0,
+				'rpm'              => 0.0,
+				'dollars_per_page' => 0.0,
+			),
+			'caveat'  => __( 'No revenue snapshots for this blog/window. Import a Mediavine Pages CSV first: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' ),
+		);
+	}
+
+	// Accumulators keyed by bucket label, per axis.
+	$by_format   = array();
+	$by_category = array();
+
+	$total_pages   = 0;
+	$total_views   = 0;
+	$total_revenue = 0.0;
+
+	// De-dupe pages across multiple URL variants of the same post within this
+	// window so a post is counted once per bucket (its revenue is summed).
+	$seen_post = array();
+
+	foreach ( $rows as $row ) {
+		$post_id = (int) $row->post_id;
+		if ( 0 === $post_id && '' !== $row->slug ) {
+			$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
+		}
+
+		$views   = (int) $row->views;
+		$revenue = (float) $row->revenue;
+
+		$format     = 'legacy-html';
+		$categories = array( 'legacy-html' );
+
+		if ( $post_id > 0 ) {
+			$format = extrachill_analytics_classify_format( $post_id );
+			$terms  = get_the_terms( $post_id, 'category' );
+			if ( is_array( $terms ) && ! empty( $terms ) ) {
+				$categories = wp_list_pluck( $terms, 'slug' );
+			} else {
+				$categories = array( 'uncategorized' );
+			}
+		} else {
+			// Unresolved: bucket by legacy-html if .html, else uncategorized.
+			$format     = preg_match( '/\.html(?:[\/?#]|$)/i', (string) $row->url ) ? 'legacy-html' : 'uncategorized';
+			$categories = array( $format );
+		}
+
+		// A page (post) is counted once per format bucket; revenue/views still sum.
+		$page_key               = $post_id > 0 ? 'p' . $post_id : 'u' . md5( $row->slug );
+		$count_page             = empty( $seen_post[ $page_key ] );
+		$seen_post[ $page_key ] = true;
+
+		extrachill_analytics_revenue_accumulate( $by_format, $format, $views, $revenue, $count_page );
+
+		foreach ( $categories as $cat ) {
+			extrachill_analytics_revenue_accumulate( $by_category, $cat, $views, $revenue, $count_page );
+		}
+
+		$total_views   += $views;
+		$total_revenue += $revenue;
+		if ( $count_page ) {
+			++$total_pages;
+		}
+	}
+
+	$rollups = array();
+	if ( 'format' === $group_by || 'both' === $group_by ) {
+		$rollups['by_format'] = extrachill_analytics_revenue_finalize( $by_format );
+	}
+	if ( 'category' === $group_by || 'both' === $group_by ) {
+		$rollups['by_category'] = extrachill_analytics_revenue_finalize( $by_category );
+	}
+
+	return array(
+		'success'  => true,
+		'rows'     => count( $rows ),
+		'blog_id'  => $blog_id,
+		'group_by' => $group_by,
+		'window'   => extrachill_analytics_revenue_window_label( $period_start, $period_end ),
+		'rollups'  => $rollups,
+		'totals'   => array(
+			'pages'            => $total_pages,
+			'views'            => $total_views,
+			'revenue'          => round( $total_revenue, 2 ),
+			'rpm'              => $total_views > 0 ? round( $total_revenue / ( $total_views / 1000 ), 2 ) : 0.0,
+			'dollars_per_page' => $total_pages > 0 ? round( $total_revenue / $total_pages, 2 ) : 0.0,
+		),
+		'caveat'   => __( '$/page is the honest "worth producing" metric — RPM alone misleads (high RPM on tiny volume = pennies). High LIFETIME revenue can just mean a page is old and accumulated; use a window for the earning-NOW lens. Revenue is Mediavine-imported (the only source of ad income); never estimated.', 'extrachill-analytics' ),
+	);
+}
+
+/**
+ * Accumulate one snapshot into a bucket.
+ *
+ * @param array  $bucket     Accumulator (by reference).
+ * @param string $key        Bucket key (format or category slug).
+ * @param int    $views      Views to add.
+ * @param float  $revenue    Revenue to add.
+ * @param bool   $count_page Whether this contributes a new page to the count.
+ */
+function extrachill_analytics_revenue_accumulate( array &$bucket, $key, $views, $revenue, $count_page ) {
+	if ( ! isset( $bucket[ $key ] ) ) {
+		$bucket[ $key ] = array(
+			'pages'   => 0,
+			'views'   => 0,
+			'revenue' => 0.0,
+		);
+	}
+
+	$bucket[ $key ]['views']   += $views;
+	$bucket[ $key ]['revenue'] += $revenue;
+	if ( $count_page ) {
+		++$bucket[ $key ]['pages'];
+	}
+}
+
+/**
+ * Finalize an accumulator into sorted rows with derived RPM + $/page.
+ *
+ * Sorted by $/page DESC — the honest ranking. RPM is reported alongside but is
+ * never the sort key, on purpose.
+ *
+ * @param array $bucket Accumulator.
+ * @return array<int, array<string, mixed>>
+ */
+function extrachill_analytics_revenue_finalize( array $bucket ) {
+	$rows = array();
+
+	foreach ( $bucket as $key => $agg ) {
+		$pages   = (int) $agg['pages'];
+		$views   = (int) $agg['views'];
+		$revenue = (float) $agg['revenue'];
+
+		$rows[] = array(
+			'bucket'           => $key,
+			'pages'            => $pages,
+			'views'            => $views,
+			'revenue'          => round( $revenue, 2 ),
+			'rpm'              => $views > 0 ? round( $revenue / ( $views / 1000 ), 2 ) : 0.0,
+			'dollars_per_page' => $pages > 0 ? round( $revenue / $pages, 2 ) : 0.0,
+		);
+	}
+
+	usort(
+		$rows,
+		static function ( $a, $b ) {
+			return $b['dollars_per_page'] <=> $a['dollars_per_page'];
+		}
+	);
+
+	return $rows;
+}
+
+/**
+ * Human label for the requested window.
+ *
+ * @param string $period_start Window start (Y-m-d) or ''.
+ * @param string $period_end   Window end (Y-m-d) or ''.
+ * @return string
+ */
+function extrachill_analytics_revenue_window_label( $period_start, $period_end ) {
+	if ( '' !== $period_start && '' !== $period_end ) {
+		return $period_start . ' → ' . $period_end . ' (recent lens)';
+	}
+
+	return 'lifetime (all imported snapshots)';
+}

--- a/inc/core/abilities/get-content-revenue.php
+++ b/inc/core/abilities/get-content-revenue.php
@@ -39,37 +39,47 @@ function extrachill_analytics_register_content_revenue_ability() {
 		'extrachill/get-content-revenue',
 		array(
 			'label'               => __( 'Get Content Revenue Lens', 'extrachill-analytics' ),
-			'description'         => __( 'Join imported Mediavine per-URL ad revenue to WordPress content metadata (category, content format, age) and roll it up by category AND by content format. Reports pages, views, revenue, RPM, and $/page (revenue/pages) — $/page is the honest "worth producing" metric because RPM alone misleads (high RPM on tiny volume = pennies). Accepts a window (period_start/period_end) to distinguish lifetime-accumulated revenue from earning-now. Revenue is exactly what was imported from the Mediavine Pages CSV (Mediavine has no per-page API); this ability never estimates ad income.', 'extrachill-analytics' ),
+			'description'         => __( 'Join imported Mediavine per-URL ad revenue to WordPress content metadata (category, content format, age) and roll it up by category, by content format, or as a TIME-SERIES revenue arc. group_by=timeseries sums revenue/views per time bucket chronologically (month-over-month, the HCU cliff in dollars) — the first-class capability, since each monthly Mediavine export is one point on the arc. group_by=format/category/both reports pages, views, revenue, RPM, and $/page (revenue/pages) — $/page is the honest "worth producing" metric because RPM alone misleads (high RPM on tiny volume = pennies); scope these to one bucket with period=YYYY-MM. Revenue is exactly what was imported from the Mediavine Pages CSV (Mediavine has no per-page revenue API, only ad-config); this ability never estimates ad income. NOTE: the flat lifetime export is time-blind (no date column, one cumulative total per URL) and undercounts the 2022-2023 peak — import date-ranged monthly CSVs for the real arc.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'group_by'     => array(
+					'group_by'        => array(
 						'type'        => 'string',
-						'description' => __( 'Rollup axis: "format" (default), "category", or "both".', 'extrachill-analytics' ),
+						'description' => __( 'Rollup axis: "format" (default), "category", "both", or "timeseries" (the revenue ARC — revenue/views per time bucket, chronologically, to see month-over-month and the HCU cliff in dollars).', 'extrachill-analytics' ),
 						'default'     => 'format',
 					),
-					'period_start' => array(
+					'period'          => array(
+						'type'        => 'string',
+						'description' => __( 'Scope the category/format rollup to one time bucket, e.g. "2026-05" or "all-time". Empty = every bucket combined. Ignored for the timeseries axis (which spans all buckets).', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'period_start'    => array(
 						'type'        => 'string',
 						'description' => __( 'Inclusive window start (Y-m-d). With period_end, restricts to snapshots imported for that window (the recent lens). Empty = all snapshots (lifetime).', 'extrachill-analytics' ),
 						'default'     => '',
 					),
-					'period_end'   => array(
+					'period_end'      => array(
 						'type'        => 'string',
 						'description' => __( 'Inclusive window end (Y-m-d). See period_start.', 'extrachill-analytics' ),
 						'default'     => '',
 					),
-					'import_batch' => array(
+					'include_alltime' => array(
+						'type'        => 'boolean',
+						'description' => __( 'For the timeseries axis, include the cumulative "all-time" flat-file bucket (default false — it is a lifetime total, not a point on the arc).', 'extrachill-analytics' ),
+						'default'     => false,
+					),
+					'import_batch'    => array(
 						'type'        => 'string',
 						'description' => __( 'Restrict to one import batch so multiple imports are never double-counted. Empty = all batches.', 'extrachill-analytics' ),
 						'default'     => '',
 					),
-					'blog_id'      => array(
+					'blog_id'         => array(
 						'type'        => 'integer',
 						'description' => __( 'Blog ID whose revenue to read. 0 = current blog.', 'extrachill-analytics' ),
 						'default'     => 0,
 					),
-					'hostname'     => array(
+					'hostname'        => array(
 						'type'        => 'string',
 						'description' => __( 'Hostname for resolving any still-unresolved slugs to posts (default: extrachill.com).', 'extrachill-analytics' ),
 						'default'     => 'extrachill.com',
@@ -103,21 +113,32 @@ function extrachill_analytics_register_content_revenue_ability() {
  * @return array Rollup data.
  */
 function extrachill_analytics_ability_get_content_revenue( $input ) {
-	$group_by     = isset( $input['group_by'] ) ? (string) $input['group_by'] : 'format';
-	$period_start = isset( $input['period_start'] ) ? (string) $input['period_start'] : '';
-	$period_end   = isset( $input['period_end'] ) ? (string) $input['period_end'] : '';
-	$import_batch = isset( $input['import_batch'] ) ? (string) $input['import_batch'] : '';
-	$blog_id      = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : get_current_blog_id();
-	$hostname     = ! empty( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com';
+	$group_by        = isset( $input['group_by'] ) ? (string) $input['group_by'] : 'format';
+	$period          = isset( $input['period'] ) ? (string) $input['period'] : '';
+	$period_start    = isset( $input['period_start'] ) ? (string) $input['period_start'] : '';
+	$period_end      = isset( $input['period_end'] ) ? (string) $input['period_end'] : '';
+	$import_batch    = isset( $input['import_batch'] ) ? (string) $input['import_batch'] : '';
+	$include_alltime = ! empty( $input['include_alltime'] );
+	$blog_id         = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : get_current_blog_id();
+	$hostname        = ! empty( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com';
 
-	if ( ! in_array( $group_by, array( 'format', 'category', 'both' ), true ) ) {
+	if ( ! in_array( $group_by, array( 'format', 'category', 'both', 'timeseries' ), true ) ) {
 		$group_by = 'format';
+	}
+
+	// The revenue ARC: a pure SUM-by-time-bucket read, chronologically. This is
+	// the first-class time-series capability — it does NOT join categories, it
+	// answers "what did we earn month-over-month" so the HCU cliff shows in
+	// dollars. Each monthly CSV the operator imports becomes one point.
+	if ( 'timeseries' === $group_by ) {
+		return extrachill_analytics_revenue_timeseries_response( $blog_id, $include_alltime );
 	}
 
 	$rows = extrachill_analytics_revenue_get_rows(
 		array(
 			'blog_id'      => $blog_id,
 			'import_batch' => $import_batch,
+			'period_label' => $period,
 			'period_start' => $period_start,
 			'period_end'   => $period_end,
 		)
@@ -127,7 +148,7 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 		return array(
 			'success' => true,
 			'rows'    => 0,
-			'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end ),
+			'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
 			'rollups' => array(),
 			'totals'  => array(
 				'pages'            => 0,
@@ -209,7 +230,7 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 		'rows'     => count( $rows ),
 		'blog_id'  => $blog_id,
 		'group_by' => $group_by,
-		'window'   => extrachill_analytics_revenue_window_label( $period_start, $period_end ),
+		'window'   => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
 		'rollups'  => $rollups,
 		'totals'   => array(
 			'pages'            => $total_pages,
@@ -289,12 +310,98 @@ function extrachill_analytics_revenue_finalize( array $bucket ) {
  *
  * @param string $period_start Window start (Y-m-d) or ''.
  * @param string $period_end   Window end (Y-m-d) or ''.
+ * @param string $period       Period-label filter (e.g. "2026-05"), or ''.
  * @return string
  */
-function extrachill_analytics_revenue_window_label( $period_start, $period_end ) {
+function extrachill_analytics_revenue_window_label( $period_start, $period_end, $period = '' ) {
+	if ( '' !== $period && 'all-time' !== $period ) {
+		return $period . ' (period bucket)';
+	}
+
 	if ( '' !== $period_start && '' !== $period_end ) {
 		return $period_start . ' → ' . $period_end . ' (recent lens)';
 	}
 
 	return 'lifetime (all imported snapshots)';
+}
+
+/**
+ * Build the revenue-ARC (time-series) response.
+ *
+ * SUMs revenue/views per period_label chronologically, then derives RPM and
+ * $/page per point plus a month-over-month delta so the arc — and the HCU cliff
+ * — is readable in dollars. The flat "all-time" cumulative bucket is excluded by
+ * default (it is a lifetime total, not a point on the arc).
+ *
+ * @param int  $blog_id         Blog ID.
+ * @param bool $include_alltime Include the cumulative "all-time" bucket.
+ * @return array Ability response with a `series` array.
+ */
+function extrachill_analytics_revenue_timeseries_response( $blog_id, $include_alltime ) {
+	$points = extrachill_analytics_revenue_get_timeseries(
+		array(
+			'blog_id'         => $blog_id,
+			'include_alltime' => $include_alltime,
+		)
+	);
+
+	$series        = array();
+	$prev_revenue  = null;
+	$total_revenue = 0.0;
+	$total_views   = 0;
+	$peak_revenue  = 0.0;
+	$peak_label    = '';
+
+	foreach ( $points as $p ) {
+		$revenue = (float) $p->revenue;
+		$views   = (int) $p->views;
+		$pages   = (int) $p->pages;
+
+		$mom_delta = null;
+		$mom_pct   = null;
+		if ( null !== $prev_revenue ) {
+			$mom_delta = round( $revenue - $prev_revenue, 2 );
+			$mom_pct   = $prev_revenue > 0 ? round( ( ( $revenue - $prev_revenue ) / $prev_revenue ) * 100, 1 ) : null;
+		}
+
+		$series[] = array(
+			'period'           => $p->period_label,
+			'period_start'     => $p->period_start,
+			'period_end'       => $p->period_end,
+			'pages'            => $pages,
+			'views'            => $views,
+			'revenue'          => round( $revenue, 2 ),
+			'rpm'              => $views > 0 ? round( $revenue / ( $views / 1000 ), 2 ) : 0.0,
+			'dollars_per_page' => $pages > 0 ? round( $revenue / $pages, 2 ) : 0.0,
+			'mom_delta'        => $mom_delta,
+			'mom_pct'          => $mom_pct,
+		);
+
+		$prev_revenue   = $revenue;
+		$total_revenue += $revenue;
+		$total_views   += $views;
+		if ( $revenue > $peak_revenue ) {
+			$peak_revenue = $revenue;
+			$peak_label   = $p->period_label;
+		}
+	}
+
+	return array(
+		'success'  => true,
+		'rows'     => count( $points ),
+		'blog_id'  => $blog_id,
+		'group_by' => 'timeseries',
+		'window'   => 'revenue arc (per-period, chronological)',
+		'series'   => $series,
+		'peak'     => array(
+			'period'  => $peak_label,
+			'revenue' => round( $peak_revenue, 2 ),
+		),
+		'totals'   => array(
+			'periods' => count( $series ),
+			'views'   => $total_views,
+			'revenue' => round( $total_revenue, 2 ),
+		),
+		'caveat'   => __( 'The revenue ARC needs DATE-RANGED (monthly) Mediavine exports — import each with --period=YYYY-MM. The flat lifetime export is one cumulative "all-time" total per URL (no dates) and is excluded here by default; on its own it is time-blind and undercounts the 2022-2023 peak, whose revenue ran on old URL structures. Revenue is Mediavine-imported (the only source of ad income); never estimated.', 'extrachill-analytics' ),
+	);
 }

--- a/inc/core/content-format-classifier.php
+++ b/inc/core/content-format-classifier.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Content Format Classifier
+ *
+ * Deterministic, single-label mapping of a WordPress post to a CONTENT FORMAT —
+ * the editorial archetype the revenue lens rolls up by (song-meaning, listicle,
+ * charleston-local, explainer, interview, trivia, guitar-history, legacy-html,
+ * uncategorized). This is the format axis the manual Mediavine-CSV-to-category
+ * stitch joined on; the classifier makes that stitch repeatable.
+ *
+ * Why a NEW classifier and not "reuse the one in content-flags": the shipped
+ * ContentFlags/ContentPerformance abilities do NOT classify by format. They take
+ * a category slug as input and operate within that one category — there is no
+ * post->format function to reuse anywhere in the codebase. So this is the gap,
+ * and it is scoped to exactly the gap (RULES.md: build the small thing, not a
+ * parallel system). The category slugs are the source of truth; URL/structure
+ * heuristics only break ties the category can't.
+ *
+ * Determinism contract: the same post always yields the same single format. The
+ * order of the checks below IS the precedence — the first match wins, most
+ * specific first. The mapping is intentionally legible (slug membership) rather
+ * than ML so the rollups can be defended as "this came from the taxonomy," not
+ * a black box.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.16.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Category-slug membership for each content format.
+ *
+ * The first format (top of the array) whose slug set intersects a post's
+ * categories wins. Slugs are matched case-insensitively. Edit this map — not the
+ * classifier code — to retune which categories roll up into which format.
+ *
+ * @return array<string, array<int, string>> Format => list of category slugs.
+ */
+function extrachill_analytics_format_category_map() {
+	$map = array(
+		// Song meanings / lyric explainers — the HCU-dead but high-$/page legacy.
+		'song-meaning'     => array( 'song-meanings', 'song-meaning', 'lyrics', 'lyric-meanings' ),
+		// Music history / artist history / guitar history deep-dives.
+		'guitar-history'   => array( 'guitar-history', 'guitars', 'gear' ),
+		'music-history'    => array( 'music-history', 'history' ),
+		// Charleston / local scene — the defensible moat with an events funnel.
+		'charleston-local' => array( 'charleston', 'charleston-music', 'local', 'local-music', 'sc-music', 'south-carolina', 'columbia', 'savannah' ),
+		// Interviews / artist Q&As.
+		'interview'        => array( 'interviews', 'interview', 'q-a', 'qa' ),
+		// Trivia / quizzes / facts.
+		'trivia'           => array( 'trivia', 'quiz', 'quizzes', 'facts', 'did-you-know' ),
+		// Listicles / rankings / roundups.
+		'listicle'         => array( 'lists', 'listicles', 'rankings', 'best-of', 'roundups', 'top-10', 'playlists' ),
+		// Explainers / how-tos / guides.
+		'explainer'        => array( 'explainers', 'explainer', 'guides', 'how-to', 'how-tos', 'music-theory', 'education' ),
+		// News / festival-wire reactive coverage.
+		'news'             => array( 'news', 'festival-wire', 'festivals', 'live-music', 'shows', 'concerts', 'reviews' ),
+	);
+
+	/**
+	 * Filter the content-format -> category-slug map used by the revenue lens.
+	 *
+	 * @param array $map Format => list of category slugs (precedence top-down).
+	 */
+	return apply_filters( 'extrachill_analytics_format_category_map', $map );
+}
+
+/**
+ * Classify a post (or post ID) into a single content format.
+ *
+ * Precedence:
+ *   1. legacy-html — the URL ends in ".html" (the 963 ghost pages still
+ *      ranking). Checked first because legacy .html is a distribution fact that
+ *      cross-cuts categories and the issue calls it out as its own bucket.
+ *   2. category membership — first format in the map whose slugs intersect the
+ *      post's categories (most-specific format first).
+ *   3. trivia/listicle title fallback — a light title-shape heuristic only when
+ *      the taxonomy gave no answer, so quiz/list posts that were never
+ *      categorized still land somewhere honest.
+ *   4. uncategorized — nothing matched.
+ *
+ * @param int|WP_Post $post Post ID or object.
+ * @return string Format label (one of the map keys, 'legacy-html', or 'uncategorized').
+ */
+function extrachill_analytics_classify_format( $post ) {
+	$post = get_post( $post );
+	if ( ! $post instanceof WP_Post ) {
+		return 'uncategorized';
+	}
+
+	// 1. Legacy .html URLs — a structural fact, not a taxonomy one.
+	$permalink = get_permalink( $post );
+	if ( is_string( $permalink ) && preg_match( '/\.html(?:[\/?#]|$)/i', $permalink ) ) {
+		return 'legacy-html';
+	}
+
+	// 2. Category membership (precedence = map order).
+	$terms = get_the_terms( $post->ID, 'category' );
+	$slugs = array();
+	if ( is_array( $terms ) ) {
+		foreach ( $terms as $term ) {
+			$slugs[] = strtolower( $term->slug );
+		}
+	}
+
+	if ( ! empty( $slugs ) ) {
+		foreach ( extrachill_analytics_format_category_map() as $format => $format_slugs ) {
+			foreach ( $format_slugs as $candidate ) {
+				if ( in_array( strtolower( $candidate ), $slugs, true ) ) {
+					return $format;
+				}
+			}
+		}
+	}
+
+	// 3. Title-shape fallback only when the taxonomy was silent.
+	$title = strtolower( (string) $post->post_title );
+	if ( preg_match( '/\b(quiz|trivia|how well do you know)\b/', $title ) ) {
+		return 'trivia';
+	}
+	if ( preg_match( '/^\s*\d+\s+/', $title ) || preg_match( '/\b(best|top)\s+\d+\b/', $title ) ) {
+		return 'listicle';
+	}
+
+	return 'uncategorized';
+}
+
+/**
+ * Resolve a Mediavine CSV slug/url to a post ID on the current blog.
+ *
+ * The Mediavine "Pages" export keys rows by page path (sometimes a full URL,
+ * sometimes a host-relative path, sometimes a bare slug). url_to_postid() wants
+ * a full URL, so normalize first. Legacy .html paths won't resolve via
+ * url_to_postid() (no matching rewrite), so they correctly return 0 and the
+ * caller treats them as the legacy-html bucket without a post join.
+ *
+ * @param string $slug_or_url Raw CSV identifier.
+ * @param string $hostname    Hostname pages map to (default: extrachill.com).
+ * @return int Post ID, or 0 if unresolved.
+ */
+function extrachill_analytics_revenue_resolve_post_id( $slug_or_url, $hostname = 'extrachill.com' ) {
+	$value = trim( (string) $slug_or_url );
+	if ( '' === $value ) {
+		return 0;
+	}
+
+	// Strip query/hash.
+	$value = strtok( $value, '?#' );
+
+	// Already a full URL?
+	if ( preg_match( '#^https?://#i', $value ) ) {
+		$url = $value;
+	} else {
+		// Treat as host-relative path / bare slug.
+		$path = '/' . ltrim( $value, '/' );
+		$url  = 'https://' . $hostname . $path;
+	}
+
+	$post_id = (int) url_to_postid( $url );
+
+	// Bare-slug fallback: url_to_postid can miss when the path lacks a trailing
+	// slash on a /%postname%/ permalink. Retry with a trailing slash.
+	if ( 0 === $post_id && ! preg_match( '#/$#', $url ) && ! preg_match( '/\.html$/i', $url ) ) {
+		$post_id = (int) url_to_postid( $url . '/' );
+	}
+
+	return $post_id;
+}

--- a/inc/core/mediavine-csv-import.php
+++ b/inc/core/mediavine-csv-import.php
@@ -91,7 +91,9 @@ function extrachill_analytics_revenue_parse_number( $value ) {
  * @param array  $args {
  *     Import options.
  *
- *     @type int    $blog_id      Blog the pages belong to (default: current blog).
+ *     @type int    $blog_id      Blog the pages belong to (default: current blog). Slug->post
+ *                                resolution runs against this blog (switch_to_blog) so the stamped
+ *                                blog_id and resolved post_id agree on a multisite.
  *     @type string $hostname     Hostname for slug->post resolution (default: extrachill.com).
  *     @type string $period       Period token: "YYYY-MM", "YYYY", or '' (lifetime). Default ''.
  *     @type string $period_start Explicit window start (Y-m-d) override, or '' (default: '').
@@ -180,6 +182,19 @@ function extrachill_analytics_revenue_import_csv( $file, array $args = array() )
 	$unresolved = 0;
 	$samples    = array();
 
+	// Slug->post resolution (url_to_postid) always runs against the CURRENT blog,
+	// but rows are stamped with $blog_id. On a multisite, importing for a blog
+	// other than the current one would resolve every slug against the wrong post
+	// table. Switch into the target blog for the duration of resolution so the
+	// stamped blog_id and the resolved post_id always agree. Revenue is blog 1 and
+	// the CLI runs there, so this is normally a no-op, but it makes a cross-blog
+	// import correct instead of a latent footgun.
+	$switched = false;
+	if ( $blog_id > 0 && function_exists( 'switch_to_blog' ) && get_current_blog_id() !== $blog_id ) {
+		switch_to_blog( $blog_id );
+		$switched = true;
+	}
+
 	$cell = static function ( $line, $columns, $field ) {
 		if ( ! isset( $columns[ $field ] ) ) {
 			return '';
@@ -250,6 +265,10 @@ function extrachill_analytics_revenue_import_csv( $file, array $args = array() )
 	}
 
 	fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose -- paired with the streaming fopen above.
+
+	if ( $switched ) {
+		restore_current_blog();
+	}
 
 	return array(
 		'success'    => true,

--- a/inc/core/mediavine-csv-import.php
+++ b/inc/core/mediavine-csv-import.php
@@ -80,14 +80,22 @@ function extrachill_analytics_revenue_parse_number( $value ) {
 /**
  * Import a Mediavine Pages CSV into the revenue store.
  *
+ * Time-awareness: the flat Mediavine pages export has NO date column — it is one
+ * cumulative LIFETIME total per URL. So the operator supplies the period at
+ * import time. Pass `period` ("YYYY-MM" for a monthly export, "YYYY" for a year,
+ * or '' for the flat lifetime file) and it becomes the canonical period_label
+ * the revenue ARC groups by; without it, rows land in the "all-time" bucket.
+ * Explicit period_start/period_end override the derived date range.
+ *
  * @param string $file  Absolute path to the CSV.
  * @param array  $args {
  *     Import options.
  *
  *     @type int    $blog_id      Blog the pages belong to (default: current blog).
  *     @type string $hostname     Hostname for slug->post resolution (default: extrachill.com).
- *     @type string $period_start Window start (Y-m-d) for these snapshots, or '' (default: '').
- *     @type string $period_end   Window end (Y-m-d) for these snapshots, or '' (default: '').
+ *     @type string $period       Period token: "YYYY-MM", "YYYY", or '' (lifetime). Default ''.
+ *     @type string $period_start Explicit window start (Y-m-d) override, or '' (default: '').
+ *     @type string $period_end   Explicit window end (Y-m-d) override, or '' (default: '').
  *     @type string $import_batch Batch label (default: auto from filename + timestamp).
  *     @type bool   $dry_run      Parse + resolve but do not write (default: false).
  * }
@@ -100,19 +108,29 @@ function extrachill_analytics_revenue_parse_number( $value ) {
  *     @type int    $resolved   Rows whose slug resolved to a post.
  *     @type int    $unresolved Rows that did not resolve to a post.
  *     @type string $batch      Import batch label used.
+ *     @type string $period     Resolved period_label the rows were stamped with.
  *     @type array  $samples    First few resolved rows (slug, post_id, revenue).
  *     @type string $error      Error message on failure.
  * }
  */
 function extrachill_analytics_revenue_import_csv( $file, array $args = array() ) {
-	$blog_id      = isset( $args['blog_id'] ) ? (int) $args['blog_id'] : get_current_blog_id();
-	$hostname     = ! empty( $args['hostname'] ) ? (string) $args['hostname'] : 'extrachill.com';
-	$period_start = isset( $args['period_start'] ) ? (string) $args['period_start'] : '';
-	$period_end   = isset( $args['period_end'] ) ? (string) $args['period_end'] : '';
-	$dry_run      = ! empty( $args['dry_run'] );
-	$batch        = ! empty( $args['import_batch'] )
+	$blog_id  = isset( $args['blog_id'] ) ? (int) $args['blog_id'] : get_current_blog_id();
+	$hostname = ! empty( $args['hostname'] ) ? (string) $args['hostname'] : 'extrachill.com';
+	$dry_run  = ! empty( $args['dry_run'] );
+
+	// Resolve the operator-supplied period token into a canonical label + range.
+	$resolved     = extrachill_analytics_revenue_resolve_period(
+		isset( $args['period'] ) ? (string) $args['period'] : '',
+		isset( $args['period_start'] ) ? (string) $args['period_start'] : '',
+		isset( $args['period_end'] ) ? (string) $args['period_end'] : ''
+	);
+	$period_label = $resolved['label'];
+	$period_start = $resolved['start'];
+	$period_end   = $resolved['end'];
+
+	$batch = ! empty( $args['import_batch'] )
 		? (string) $args['import_batch']
-		: sanitize_key( basename( $file ) ) . '-' . gmdate( 'YmdHis' );
+		: sanitize_key( basename( $file ) ) . '-' . sanitize_key( $period_label );
 
 	if ( ! is_readable( $file ) ) {
 		return array(
@@ -208,6 +226,7 @@ function extrachill_analytics_revenue_import_csv( $file, array $args = array() )
 			'viewability'              => extrachill_analytics_revenue_parse_number( $cell( $line, $columns, 'viewability' ) ),
 			'fill_rate'                => extrachill_analytics_revenue_parse_number( $cell( $line, $columns, 'fill_rate' ) ),
 			'impressions_per_pageview' => extrachill_analytics_revenue_parse_number( $cell( $line, $columns, 'impressions_per_pageview' ) ),
+			'period_label'             => $period_label,
 			'period_start'             => $period_start,
 			'period_end'               => $period_end,
 			'import_batch'             => $batch,
@@ -239,6 +258,7 @@ function extrachill_analytics_revenue_import_csv( $file, array $args = array() )
 		'resolved'   => $resolved,
 		'unresolved' => $unresolved,
 		'batch'      => $batch,
+		'period'     => $period_label,
 		'dry_run'    => $dry_run,
 		'samples'    => $samples,
 	);

--- a/inc/core/mediavine-csv-import.php
+++ b/inc/core/mediavine-csv-import.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Mediavine Pages CSV Importer
+ *
+ * Ingests a Mediavine Dashboard "Pages" export into the revenue store. Mediavine
+ * has no per-page revenue API (its Control Panel plugin only pulls ad-script
+ * settings), so this CSV import is the canonical path from "Mediavine knows what
+ * each page earned" to "we can join that to content categories."
+ *
+ * Expected columns (header names are matched case-insensitively and loosely, so
+ * minor dashboard-export renames still map):
+ *   slug | views | revenue | rpm | cpm | viewability | fillRate | impressionsPerPageview
+ *
+ * The slug column may carry a bare slug, a host-relative path, or a full URL —
+ * the resolver normalizes all three. Each imported row is stamped with the
+ * import batch + optional period so a recent export and an all-time export can
+ * coexist for the recent-vs-lifetime lens.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.16.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Canonical header => store-field map.
+ *
+ * Keys are normalized header tokens (lowercased, non-alphanumerics stripped);
+ * the matcher normalizes each CSV header the same way before lookup so
+ * "Page RPM", "rpm", and "RPM" all collapse to "rpm".
+ *
+ * @return array<string, string>
+ */
+function extrachill_analytics_revenue_csv_header_map() {
+	return array(
+		'slug'                   => 'slug',
+		'url'                    => 'slug',
+		'page'                   => 'slug',
+		'pagepath'               => 'slug',
+		'path'                   => 'slug',
+		'views'                  => 'views',
+		'pageviews'              => 'views',
+		'sessions'               => 'views',
+		'revenue'                => 'revenue',
+		'earnings'               => 'revenue',
+		'estimatedrevenue'       => 'revenue',
+		'rpm'                    => 'rpm',
+		'pagerpm'                => 'rpm',
+		'cpm'                    => 'cpm',
+		'viewability'            => 'viewability',
+		'fillrate'               => 'fill_rate',
+		'impressionsperpageview' => 'impressions_per_pageview',
+		'impressionsperpv'       => 'impressions_per_pageview',
+	);
+}
+
+/**
+ * Normalize a header token for loose matching.
+ *
+ * @param string $header Raw header cell.
+ * @return string
+ */
+function extrachill_analytics_revenue_normalize_header( $header ) {
+	return preg_replace( '/[^a-z0-9]/', '', strtolower( trim( (string) $header ) ) );
+}
+
+/**
+ * Parse a money/number cell into a float (strips $, commas, %).
+ *
+ * @param string $value Raw cell.
+ * @return float
+ */
+function extrachill_analytics_revenue_parse_number( $value ) {
+	$value = (string) $value;
+	$value = preg_replace( '/[^0-9.\-]/', '', $value );
+
+	return '' === $value ? 0.0 : (float) $value;
+}
+
+/**
+ * Import a Mediavine Pages CSV into the revenue store.
+ *
+ * @param string $file  Absolute path to the CSV.
+ * @param array  $args {
+ *     Import options.
+ *
+ *     @type int    $blog_id      Blog the pages belong to (default: current blog).
+ *     @type string $hostname     Hostname for slug->post resolution (default: extrachill.com).
+ *     @type string $period_start Window start (Y-m-d) for these snapshots, or '' (default: '').
+ *     @type string $period_end   Window end (Y-m-d) for these snapshots, or '' (default: '').
+ *     @type string $import_batch Batch label (default: auto from filename + timestamp).
+ *     @type bool   $dry_run      Parse + resolve but do not write (default: false).
+ * }
+ * @return array {
+ *     Import result.
+ *
+ *     @type bool   $success
+ *     @type int    $rows       Rows parsed.
+ *     @type int    $imported   Rows written (0 on dry-run).
+ *     @type int    $resolved   Rows whose slug resolved to a post.
+ *     @type int    $unresolved Rows that did not resolve to a post.
+ *     @type string $batch      Import batch label used.
+ *     @type array  $samples    First few resolved rows (slug, post_id, revenue).
+ *     @type string $error      Error message on failure.
+ * }
+ */
+function extrachill_analytics_revenue_import_csv( $file, array $args = array() ) {
+	$blog_id      = isset( $args['blog_id'] ) ? (int) $args['blog_id'] : get_current_blog_id();
+	$hostname     = ! empty( $args['hostname'] ) ? (string) $args['hostname'] : 'extrachill.com';
+	$period_start = isset( $args['period_start'] ) ? (string) $args['period_start'] : '';
+	$period_end   = isset( $args['period_end'] ) ? (string) $args['period_end'] : '';
+	$dry_run      = ! empty( $args['dry_run'] );
+	$batch        = ! empty( $args['import_batch'] )
+		? (string) $args['import_batch']
+		: sanitize_key( basename( $file ) ) . '-' . gmdate( 'YmdHis' );
+
+	if ( ! is_readable( $file ) ) {
+		return array(
+			'success' => false,
+			'error'   => "CSV not readable: {$file}",
+		);
+	}
+
+	$handle = fopen( $file, 'r' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen -- CSV is stream-parsed line-by-line via fgetcsv; WP_Filesystem has no streaming reader.
+	if ( false === $handle ) {
+		return array(
+			'success' => false,
+			'error'   => "Could not open CSV: {$file}",
+		);
+	}
+
+	$header_map = extrachill_analytics_revenue_csv_header_map();
+	$columns    = array();
+	$headers    = fgetcsv( $handle );
+
+	if ( false === $headers ) {
+		fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose -- paired with the streaming fopen above.
+		return array(
+			'success' => false,
+			'error'   => 'CSV is empty (no header row).',
+		);
+	}
+
+	foreach ( $headers as $index => $raw ) {
+		$key = extrachill_analytics_revenue_normalize_header( $raw );
+		if ( isset( $header_map[ $key ] ) ) {
+			$columns[ $header_map[ $key ] ] = $index;
+		}
+	}
+
+	if ( ! isset( $columns['slug'] ) ) {
+		fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose -- paired with the streaming fopen above.
+		return array(
+			'success' => false,
+			'error'   => 'CSV has no slug/url/page column. Headers seen: ' . implode( ', ', array_map( 'sanitize_text_field', $headers ) ),
+		);
+	}
+
+	$rows       = 0;
+	$imported   = 0;
+	$resolved   = 0;
+	$unresolved = 0;
+	$samples    = array();
+
+	$cell = static function ( $line, $columns, $field ) {
+		if ( ! isset( $columns[ $field ] ) ) {
+			return '';
+		}
+		$idx = $columns[ $field ];
+		return isset( $line[ $idx ] ) ? $line[ $idx ] : '';
+	};
+
+	// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- idiomatic fgetcsv streaming loop.
+	while ( false !== ( $line = fgetcsv( $handle ) ) ) {
+		$raw_slug = trim( (string) $cell( $line, $columns, 'slug' ) );
+		if ( '' === $raw_slug ) {
+			continue;
+		}
+
+		++$rows;
+
+		$post_id = extrachill_analytics_revenue_resolve_post_id( $raw_slug, $hostname );
+		if ( $post_id > 0 ) {
+			++$resolved;
+		} else {
+			++$unresolved;
+		}
+
+		// Normalize the slug to a stable key: prefer the post's slug when
+		// resolved, else the path's last segment.
+		if ( $post_id > 0 ) {
+			$post = get_post( $post_id );
+			$slug = $post instanceof WP_Post ? $post->post_name : $raw_slug;
+		} else {
+			$path = strtok( $raw_slug, '?#' );
+			$slug = trim( (string) $path, '/' );
+		}
+
+		$record = array(
+			'blog_id'                  => $blog_id,
+			'slug'                     => $slug,
+			'url'                      => $raw_slug,
+			'post_id'                  => $post_id,
+			'views'                    => (int) extrachill_analytics_revenue_parse_number( $cell( $line, $columns, 'views' ) ),
+			'revenue'                  => extrachill_analytics_revenue_parse_number( $cell( $line, $columns, 'revenue' ) ),
+			'rpm'                      => extrachill_analytics_revenue_parse_number( $cell( $line, $columns, 'rpm' ) ),
+			'cpm'                      => extrachill_analytics_revenue_parse_number( $cell( $line, $columns, 'cpm' ) ),
+			'viewability'              => extrachill_analytics_revenue_parse_number( $cell( $line, $columns, 'viewability' ) ),
+			'fill_rate'                => extrachill_analytics_revenue_parse_number( $cell( $line, $columns, 'fill_rate' ) ),
+			'impressions_per_pageview' => extrachill_analytics_revenue_parse_number( $cell( $line, $columns, 'impressions_per_pageview' ) ),
+			'period_start'             => $period_start,
+			'period_end'               => $period_end,
+			'import_batch'             => $batch,
+		);
+
+		if ( ! $dry_run ) {
+			$ok = extrachill_analytics_revenue_upsert( $record );
+			if ( false !== $ok ) {
+				++$imported;
+			}
+		}
+
+		if ( count( $samples ) < 5 ) {
+			$samples[] = array(
+				'slug'    => $slug,
+				'post_id' => $post_id,
+				'revenue' => round( $record['revenue'], 2 ),
+				'views'   => $record['views'],
+			);
+		}
+	}
+
+	fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose -- paired with the streaming fopen above.
+
+	return array(
+		'success'    => true,
+		'rows'       => $rows,
+		'imported'   => $imported,
+		'resolved'   => $resolved,
+		'unresolved' => $unresolved,
+		'batch'      => $batch,
+		'dry_run'    => $dry_run,
+		'samples'    => $samples,
+	);
+}

--- a/inc/database/mediavine-revenue-db.php
+++ b/inc/database/mediavine-revenue-db.php
@@ -50,6 +50,13 @@ function extrachill_analytics_revenue_create_table() {
 	// Mediavine export has NO date column, so the operator supplies the period at
 	// import time (--period=YYYY-MM) and it is recorded here. The unique key makes
 	// a re-import of the same period idempotent (REPLACE INTO updates in place).
+	//
+	// post_id, period_start and period_end are genuinely NULLABLE: an unresolved
+	// (legacy .html) row stores post_id = NULL, and the flat lifetime file (no
+	// dates) stores period_start/end = NULL. The upsert writer emits a literal SQL
+	// NULL for these rather than letting $wpdb->prepare() coerce a PHP null into 0
+	// / "" / "0000-00-00", so the schema's DEFAULT NULL is honored and the table
+	// behaves identically on strict-mode MySQL.
 	$sql = "CREATE TABLE {$table_name} (
 		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 		blog_id int(11) NOT NULL DEFAULT 1,
@@ -127,34 +134,58 @@ function extrachill_analytics_revenue_upsert( array $row ) {
 
 	$table = extrachill_analytics_revenue_table();
 
-	$data = array(
-		'blog_id'                  => isset( $row['blog_id'] ) ? (int) $row['blog_id'] : get_current_blog_id(),
-		'slug'                     => isset( $row['slug'] ) ? (string) $row['slug'] : '',
-		'url'                      => isset( $row['url'] ) ? (string) $row['url'] : '',
-		'post_id'                  => ! empty( $row['post_id'] ) ? (int) $row['post_id'] : null,
-		'views'                    => isset( $row['views'] ) ? max( 0, (int) $row['views'] ) : 0,
-		'revenue'                  => isset( $row['revenue'] ) ? (float) $row['revenue'] : 0.0,
-		'rpm'                      => isset( $row['rpm'] ) ? (float) $row['rpm'] : 0.0,
-		'cpm'                      => isset( $row['cpm'] ) ? (float) $row['cpm'] : 0.0,
-		'viewability'              => isset( $row['viewability'] ) ? (float) $row['viewability'] : 0.0,
-		'fill_rate'                => isset( $row['fill_rate'] ) ? (float) $row['fill_rate'] : 0.0,
-		'impressions_per_pageview' => isset( $row['impressions_per_pageview'] ) ? (float) $row['impressions_per_pageview'] : 0.0,
-		'period_label'             => ! empty( $row['period_label'] ) ? (string) $row['period_label'] : 'all-time',
-		'period_start'             => ! empty( $row['period_start'] ) ? $row['period_start'] : null,
-		'period_end'               => ! empty( $row['period_end'] ) ? $row['period_end'] : null,
-		'import_batch'             => isset( $row['import_batch'] ) ? (string) $row['import_batch'] : '',
-		'imported_at'              => current_time( 'mysql', true ),
+	// Nullable columns (post_id, period_start, period_end) MUST store a real SQL
+	// NULL when absent, never a coerced 0 / "" / "0000-00-00". $wpdb->prepare()
+	// turns a PHP null into 0 for %d and "" for %s (which a DATE column then
+	// stores as the 0000-00-00 zero-date on non-strict MySQL, and ERRORS on a
+	// strict-mode install). That coercion is what corrupts the unresolved
+	// (legacy .html) cohort: COUNT(DISTINCT IFNULL(post_id, slug)) needs post_id
+	// to be NULL to fall back to the slug, so a stored 0 collapses every
+	// unresolved page in a bucket into one. So we emit those columns as a literal
+	// NULL in the SQL and bind only the non-null values through prepare().
+	$post_id      = ! empty( $row['post_id'] ) ? (int) $row['post_id'] : null;
+	$period_start = ! empty( $row['period_start'] ) ? (string) $row['period_start'] : null;
+	$period_end   = ! empty( $row['period_end'] ) ? (string) $row['period_end'] : null;
+
+	// Ordered (column, placeholder-or-NULL, bind-value?) tuples. A null third
+	// element means the column binds nothing — its placeholder is the literal
+	// NULL — so prepare() never sees the value and can't coerce it.
+	$fields = array(
+		array( 'blog_id', '%d', isset( $row['blog_id'] ) ? (int) $row['blog_id'] : get_current_blog_id() ),
+		array( 'slug', '%s', isset( $row['slug'] ) ? (string) $row['slug'] : '' ),
+		array( 'url', '%s', isset( $row['url'] ) ? (string) $row['url'] : '' ),
+		array( 'post_id', null === $post_id ? 'NULL' : '%d', $post_id ),
+		array( 'views', '%d', isset( $row['views'] ) ? max( 0, (int) $row['views'] ) : 0 ),
+		array( 'revenue', '%f', isset( $row['revenue'] ) ? (float) $row['revenue'] : 0.0 ),
+		array( 'rpm', '%f', isset( $row['rpm'] ) ? (float) $row['rpm'] : 0.0 ),
+		array( 'cpm', '%f', isset( $row['cpm'] ) ? (float) $row['cpm'] : 0.0 ),
+		array( 'viewability', '%f', isset( $row['viewability'] ) ? (float) $row['viewability'] : 0.0 ),
+		array( 'fill_rate', '%f', isset( $row['fill_rate'] ) ? (float) $row['fill_rate'] : 0.0 ),
+		array( 'impressions_per_pageview', '%f', isset( $row['impressions_per_pageview'] ) ? (float) $row['impressions_per_pageview'] : 0.0 ),
+		array( 'period_label', '%s', ! empty( $row['period_label'] ) ? (string) $row['period_label'] : 'all-time' ),
+		array( 'period_start', null === $period_start ? 'NULL' : '%s', $period_start ),
+		array( 'period_end', null === $period_end ? 'NULL' : '%s', $period_end ),
+		array( 'import_batch', '%s', isset( $row['import_batch'] ) ? (string) $row['import_batch'] : '' ),
+		array( 'imported_at', '%s', current_time( 'mysql', true ) ),
 	);
 
-	$formats = array( '%d', '%s', '%s', '%d', '%d', '%f', '%f', '%f', '%f', '%f', '%f', '%s', '%s', '%s', '%s', '%s' );
+	$columns      = array();
+	$placeholders = array();
+	$values       = array();
+	foreach ( $fields as $field ) {
+		list( $column, $placeholder, $value ) = $field;
+		$columns[]                            = $column;
+		$placeholders[]                       = $placeholder;
+		if ( 'NULL' !== $placeholder ) {
+			$values[] = $value;
+		}
+	}
 
 	// REPLACE INTO honors the UNIQUE KEY: same snapshot overwrites in place.
-	$columns      = implode( ', ', array_keys( $data ) );
-	$placeholders = implode( ', ', $formats );
-	$sql          = "REPLACE INTO {$table} ({$columns}) VALUES ({$placeholders})";
+	$sql = 'REPLACE INTO ' . $table . ' (' . implode( ', ', $columns ) . ') VALUES (' . implode( ', ', $placeholders ) . ')';
 
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- columns/placeholders are static; values prepared below.
-	$prepared = $wpdb->prepare( $sql, array_values( $data ) );
+	$prepared = $wpdb->prepare( $sql, $values );
 	$result   = $wpdb->query( $prepared ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 	return false === $result ? false : (int) $wpdb->insert_id;
@@ -277,15 +308,24 @@ function extrachill_analytics_revenue_get_timeseries( array $args = array() ) {
 
 	$where_clause = implode( ' AND ', $where );
 
+	// Distinct-page count must be storage-agnostic: a resolved row is keyed by
+	// its post_id, an unresolved (legacy .html) row by its slug. We mirror the
+	// PHP join in get-content-revenue.php ($page_key = post_id>0 ? "p".post_id :
+	// "u".slug) in SQL with a CASE — NOT IFNULL(post_id, slug), which silently
+	// collapses every unresolved page to one bucket if any row ever stored
+	// post_id as 0 instead of NULL (the exact bug that under-counted the 963
+	// legacy .html ghost pages). post_id is now stored as a true NULL, but the
+	// CASE is correct regardless of how it was stored.
+	//
 	// Order chronologically left-to-right. The cumulative "all-time" flat-file
-	// bucket has no real period_start (stored as the 0000-00-00 zero-date, since
-	// the column is a NOT-NULL date), so it must sort LAST — it is a lifetime
-	// total, not a point on the arc. Both the explicit all-time label and any
-	// zero-date are pushed to the end.
+	// bucket has no period_start (stored as a true NULL — the flat lifetime
+	// export carries no dates), so it must sort LAST: it is a lifetime total, not
+	// a point on the arc. The explicit all-time label and any NULL/zero-date are
+	// pushed to the end (zero-date guard kept for any legacy pre-fix rows).
 	$sql = "SELECT period_label,
 			MIN(period_start) AS period_start,
 			MAX(period_end) AS period_end,
-			COUNT(DISTINCT IFNULL(post_id, slug)) AS pages,
+			COUNT(DISTINCT CASE WHEN post_id > 0 THEN CONCAT('p', post_id) ELSE CONCAT('u', slug) END) AS pages,
 			SUM(views) AS views,
 			SUM(revenue) AS revenue
 		FROM {$table}

--- a/inc/database/mediavine-revenue-db.php
+++ b/inc/database/mediavine-revenue-db.php
@@ -23,7 +23,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION', '1.0' );
+define( 'EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION', '1.1' );
 define( 'EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION_OPTION', 'extrachill_analytics_revenue_db_version' );
 
 /**
@@ -44,9 +44,12 @@ function extrachill_analytics_revenue_create_table() {
 
 	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-	// One row per (blog_id, slug, period_start, period_end, import_batch). The
-	// unique key makes a re-import of the same export idempotent (REPLACE INTO
-	// updates in place instead of stacking duplicate snapshots).
+	// One row per (blog_id, slug, period_label, import_batch). period_label is the
+	// canonical time bucket ("2026-05" for a monthly export, "all-time" for the
+	// flat lifetime file) and is what the revenue ARC groups by — the flat
+	// Mediavine export has NO date column, so the operator supplies the period at
+	// import time (--period=YYYY-MM) and it is recorded here. The unique key makes
+	// a re-import of the same period idempotent (REPLACE INTO updates in place).
 	$sql = "CREATE TABLE {$table_name} (
 		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 		blog_id int(11) NOT NULL DEFAULT 1,
@@ -60,15 +63,17 @@ function extrachill_analytics_revenue_create_table() {
 		viewability decimal(7,4) NOT NULL DEFAULT 0,
 		fill_rate decimal(7,4) NOT NULL DEFAULT 0,
 		impressions_per_pageview decimal(10,4) NOT NULL DEFAULT 0,
+		period_label varchar(32) NOT NULL DEFAULT 'all-time',
 		period_start date DEFAULT NULL,
 		period_end date DEFAULT NULL,
 		import_batch varchar(64) NOT NULL DEFAULT '',
 		imported_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		PRIMARY KEY  (id),
-		UNIQUE KEY snapshot (blog_id, slug(191), period_start, period_end, import_batch),
+		UNIQUE KEY snapshot (blog_id, slug(191), period_label, import_batch),
 		KEY slug_idx (slug(191)),
 		KEY post_id_idx (post_id),
 		KEY blog_id_idx (blog_id),
+		KEY period_label_idx (period_label),
 		KEY period_idx (period_start, period_end),
 		KEY import_batch_idx (import_batch)
 	) {$charset_collate};";
@@ -110,6 +115,7 @@ function extrachill_analytics_revenue_table() {
  *     @type float  $viewability              Viewability ratio/percent.
  *     @type float  $fill_rate                Fill rate ratio/percent.
  *     @type float  $impressions_per_pageview Impressions per pageview.
+ *     @type string $period_label             Time bucket ("2026-05" or "all-time"). Default "all-time".
  *     @type string $period_start             Window start (Y-m-d) or ''.
  *     @type string $period_end               Window end (Y-m-d) or ''.
  *     @type string $import_batch             Import batch identifier.
@@ -133,13 +139,14 @@ function extrachill_analytics_revenue_upsert( array $row ) {
 		'viewability'              => isset( $row['viewability'] ) ? (float) $row['viewability'] : 0.0,
 		'fill_rate'                => isset( $row['fill_rate'] ) ? (float) $row['fill_rate'] : 0.0,
 		'impressions_per_pageview' => isset( $row['impressions_per_pageview'] ) ? (float) $row['impressions_per_pageview'] : 0.0,
+		'period_label'             => ! empty( $row['period_label'] ) ? (string) $row['period_label'] : 'all-time',
 		'period_start'             => ! empty( $row['period_start'] ) ? $row['period_start'] : null,
 		'period_end'               => ! empty( $row['period_end'] ) ? $row['period_end'] : null,
 		'import_batch'             => isset( $row['import_batch'] ) ? (string) $row['import_batch'] : '',
 		'imported_at'              => current_time( 'mysql', true ),
 	);
 
-	$formats = array( '%d', '%s', '%s', '%d', '%d', '%f', '%f', '%f', '%f', '%f', '%f', '%s', '%s', '%s', '%s' );
+	$formats = array( '%d', '%s', '%s', '%d', '%d', '%f', '%f', '%f', '%f', '%f', '%f', '%s', '%s', '%s', '%s', '%s' );
 
 	// REPLACE INTO honors the UNIQUE KEY: same snapshot overwrites in place.
 	$columns      = implode( ', ', array_keys( $data ) );
@@ -167,6 +174,7 @@ function extrachill_analytics_revenue_upsert( array $row ) {
  *
  *     @type int    $blog_id      Blog ID (default: current blog).
  *     @type string $import_batch Restrict to one import batch (default: '' = any).
+ *     @type string $period_label Restrict to one time bucket, e.g. "2026-05" or "all-time" (default: '' = any).
  *     @type string $period_start Inclusive window start (Y-m-d), or '' for any.
  *     @type string $period_end   Inclusive window end (Y-m-d), or '' for any.
  * }
@@ -178,6 +186,7 @@ function extrachill_analytics_revenue_get_rows( array $args = array() ) {
 	$table        = extrachill_analytics_revenue_table();
 	$blog_id      = isset( $args['blog_id'] ) ? (int) $args['blog_id'] : get_current_blog_id();
 	$import_batch = isset( $args['import_batch'] ) ? (string) $args['import_batch'] : '';
+	$period_label = isset( $args['period_label'] ) ? (string) $args['period_label'] : '';
 	$period_start = isset( $args['period_start'] ) ? (string) $args['period_start'] : '';
 	$period_end   = isset( $args['period_end'] ) ? (string) $args['period_end'] : '';
 
@@ -187,6 +196,13 @@ function extrachill_analytics_revenue_get_rows( array $args = array() ) {
 	if ( '' !== $import_batch ) {
 		$where[]  = 'import_batch = %s';
 		$values[] = $import_batch;
+	}
+
+	if ( '' !== $period_label ) {
+		// Exact time-bucket match — the precise, drift-free way to scope to one
+		// monthly export (vs the date-range overlap below).
+		$where[]  = 'period_label = %s';
+		$values[] = $period_label;
 	}
 
 	if ( '' !== $period_start && '' !== $period_end ) {
@@ -208,7 +224,7 @@ function extrachill_analytics_revenue_get_rows( array $args = array() ) {
  * List distinct import batches for a blog, newest first.
  *
  * @param int $blog_id Blog ID (default: current blog).
- * @return array<int, object> Rows with import_batch, period_start, period_end, rows, imported_at.
+ * @return array<int, object> Rows with import_batch, period_label, period_start, period_end, rows, imported_at.
  */
 function extrachill_analytics_revenue_list_batches( $blog_id = 0 ) {
 	global $wpdb;
@@ -216,12 +232,123 @@ function extrachill_analytics_revenue_list_batches( $blog_id = 0 ) {
 	$table   = extrachill_analytics_revenue_table();
 	$blog_id = $blog_id > 0 ? (int) $blog_id : get_current_blog_id();
 
-	$sql = "SELECT import_batch, period_start, period_end, COUNT(*) AS rows_count, MAX(imported_at) AS imported_at,
+	$sql = "SELECT import_batch, period_label, period_start, period_end, COUNT(*) AS rows_count, MAX(imported_at) AS imported_at,
 		SUM(revenue) AS revenue, SUM(views) AS views
 		FROM {$table} WHERE blog_id = %d
-		GROUP BY import_batch, period_start, period_end
+		GROUP BY import_batch, period_label, period_start, period_end
 		ORDER BY imported_at DESC";
 
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	return (array) $wpdb->get_results( $wpdb->prepare( $sql, $blog_id ) );
+}
+
+/**
+ * The revenue ARC: revenue/views totals per time bucket, chronologically.
+ *
+ * This is the first-class time-series read. It SUMs each period_label's rows so
+ * a sequence of monthly exports renders the real revenue arc — month-over-month,
+ * the HCU cliff in dollars, earning-now vs old-accumulated. The flat lifetime
+ * file lands in a single "all-time" bucket and is excluded here by default
+ * (it is a cumulative total, not a point on the arc, so charting it alongside
+ * monthly points would be a category error).
+ *
+ * @param array $args {
+ *     Query args.
+ *
+ *     @type int  $blog_id        Blog ID (default: current blog).
+ *     @type bool $include_alltime Include the cumulative "all-time" bucket (default: false).
+ * }
+ * @return array<int, object> Rows: period_label, period_start, period_end, pages, views, revenue.
+ */
+function extrachill_analytics_revenue_get_timeseries( array $args = array() ) {
+	global $wpdb;
+
+	$table           = extrachill_analytics_revenue_table();
+	$blog_id         = isset( $args['blog_id'] ) ? (int) $args['blog_id'] : get_current_blog_id();
+	$include_alltime = ! empty( $args['include_alltime'] );
+
+	$where  = array( 'blog_id = %d' );
+	$values = array( $blog_id );
+
+	if ( ! $include_alltime ) {
+		$where[]  = 'period_label <> %s';
+		$values[] = 'all-time';
+	}
+
+	$where_clause = implode( ' AND ', $where );
+
+	// Order chronologically left-to-right. The cumulative "all-time" flat-file
+	// bucket has no real period_start (stored as the 0000-00-00 zero-date, since
+	// the column is a NOT-NULL date), so it must sort LAST — it is a lifetime
+	// total, not a point on the arc. Both the explicit all-time label and any
+	// zero-date are pushed to the end.
+	$sql = "SELECT period_label,
+			MIN(period_start) AS period_start,
+			MAX(period_end) AS period_end,
+			COUNT(DISTINCT IFNULL(post_id, slug)) AS pages,
+			SUM(views) AS views,
+			SUM(revenue) AS revenue
+		FROM {$table}
+		WHERE {$where_clause}
+		GROUP BY period_label
+		ORDER BY ( period_label = 'all-time' OR MIN(period_start) IS NULL OR MIN(period_start) = '0000-00-00' ) ASC,
+			MIN(period_start) ASC, period_label ASC";
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	return (array) $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+}
+
+/**
+ * Resolve an operator-supplied period token into a canonical label + date range.
+ *
+ * The flat Mediavine pages export has NO date column, so the operator passes the
+ * period at import time. Accepts:
+ *   - "YYYY-MM"            -> label "YYYY-MM", range = that whole month.
+ *   - "YYYY"              -> label "YYYY",    range = that whole year.
+ *   - "" (empty)           -> label "all-time", null range (the time-blind flat
+ *                             lifetime file — a cumulative total, not a period).
+ * Explicit --start/--end always override the derived range; if a label was also
+ * given it is kept, else a "start..end" label is synthesized.
+ *
+ * @param string $period Period token (YYYY-MM, YYYY, or '').
+ * @param string $start  Explicit start (Y-m-d) override, or ''.
+ * @param string $end    Explicit end (Y-m-d) override, or ''.
+ * @return array{label:string,start:string,end:string} Resolved label + range ('' range = none).
+ */
+function extrachill_analytics_revenue_resolve_period( $period = '', $start = '', $end = '' ) {
+	$period = trim( (string) $period );
+	$start  = trim( (string) $start );
+	$end    = trim( (string) $end );
+
+	$label         = 'all-time';
+	$derived_start = '';
+	$derived_end   = '';
+
+	if ( preg_match( '/^(\d{4})-(\d{2})$/', $period, $m ) ) {
+		$label         = $period;
+		$derived_start = sprintf( '%04d-%02d-01', (int) $m[1], (int) $m[2] );
+		$derived_end   = gmdate( 'Y-m-t', strtotime( $derived_start ) );
+	} elseif ( preg_match( '/^(\d{4})$/', $period, $m ) ) {
+		$label         = $period;
+		$derived_start = $m[1] . '-01-01';
+		$derived_end   = $m[1] . '-12-31';
+	} elseif ( '' !== $period ) {
+		// A free-form label (e.g. "2022-peak"); keep it, range comes from start/end.
+		$label = sanitize_text_field( $period );
+	}
+
+	// Explicit start/end override the derived range.
+	$resolved_start = '' !== $start ? $start : $derived_start;
+	$resolved_end   = '' !== $end ? $end : $derived_end;
+
+	// If only explicit dates were given (no period token), synthesize a label.
+	if ( 'all-time' === $label && ( '' !== $resolved_start || '' !== $resolved_end ) ) {
+		$label = trim( $resolved_start . '..' . $resolved_end, '.' );
+	}
+
+	return array(
+		'label' => $label,
+		'start' => $resolved_start,
+		'end'   => $resolved_end,
+	);
 }

--- a/inc/database/mediavine-revenue-db.php
+++ b/inc/database/mediavine-revenue-db.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Mediavine Revenue Store
+ *
+ * Per-URL ad-revenue snapshots imported from the Mediavine Dashboard "Pages"
+ * CSV export. Mediavine exposes NO per-page revenue API — the Control Panel
+ * plugin only fetches ad-script settings from scripts.mediavine.com/tags/ — so
+ * a manual CSV import is the only path to per-URL revenue. This table makes the
+ * one-off "join a Mediavine pages CSV to content categories" stitch repeatable.
+ *
+ * Each row is one (slug, import batch) snapshot: the metrics Mediavine reports
+ * for that page over the date range the operator selected in the dashboard. The
+ * `period_start`/`period_end` columns record that range so a "recent vs
+ * lifetime" lens is possible — an all-time export and a last-30-days export can
+ * coexist and be queried separately by window.
+ *
+ * Network-wide table (base_prefix) to mirror the events table, but every row
+ * carries the blog_id it was imported for so multisite revenue never collides.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.16.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION', '1.0' );
+define( 'EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION_OPTION', 'extrachill_analytics_revenue_db_version' );
+
+/**
+ * Create or update the Mediavine revenue table when the DB version changes.
+ *
+ * Uses base_prefix for a network-wide table shared across all sites.
+ */
+function extrachill_analytics_revenue_create_table() {
+	$current_db_version = get_site_option( EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION_OPTION );
+
+	if ( EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION === $current_db_version ) {
+		return;
+	}
+
+	global $wpdb;
+	$charset_collate = $wpdb->get_charset_collate();
+	$table_name      = extrachill_analytics_revenue_table();
+
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+	// One row per (blog_id, slug, period_start, period_end, import_batch). The
+	// unique key makes a re-import of the same export idempotent (REPLACE INTO
+	// updates in place instead of stacking duplicate snapshots).
+	$sql = "CREATE TABLE {$table_name} (
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		blog_id int(11) NOT NULL DEFAULT 1,
+		slug varchar(400) NOT NULL DEFAULT '',
+		url varchar(2083) NOT NULL DEFAULT '',
+		post_id bigint(20) unsigned DEFAULT NULL,
+		views bigint(20) unsigned NOT NULL DEFAULT 0,
+		revenue decimal(12,4) NOT NULL DEFAULT 0,
+		rpm decimal(10,4) NOT NULL DEFAULT 0,
+		cpm decimal(10,4) NOT NULL DEFAULT 0,
+		viewability decimal(7,4) NOT NULL DEFAULT 0,
+		fill_rate decimal(7,4) NOT NULL DEFAULT 0,
+		impressions_per_pageview decimal(10,4) NOT NULL DEFAULT 0,
+		period_start date DEFAULT NULL,
+		period_end date DEFAULT NULL,
+		import_batch varchar(64) NOT NULL DEFAULT '',
+		imported_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY  (id),
+		UNIQUE KEY snapshot (blog_id, slug(191), period_start, period_end, import_batch),
+		KEY slug_idx (slug(191)),
+		KEY post_id_idx (post_id),
+		KEY blog_id_idx (blog_id),
+		KEY period_idx (period_start, period_end),
+		KEY import_batch_idx (import_batch)
+	) {$charset_collate};";
+
+	dbDelta( $sql );
+
+	update_site_option( EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION_OPTION, EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION );
+}
+
+add_action( 'admin_init', 'extrachill_analytics_revenue_create_table' );
+
+/**
+ * Get the Mediavine revenue table name.
+ *
+ * @return string Table name with base prefix.
+ */
+function extrachill_analytics_revenue_table() {
+	global $wpdb;
+	return $wpdb->base_prefix . 'extrachill_analytics_mediavine_revenue';
+}
+
+/**
+ * Insert (or replace) a single revenue snapshot row.
+ *
+ * REPLACE-on-conflict against the unique (blog_id, slug, period, batch) key, so
+ * re-importing the same export is idempotent rather than additive.
+ *
+ * @param array $row {
+ *     Snapshot data.
+ *
+ *     @type int    $blog_id                  Blog the page belongs to.
+ *     @type string $slug                     Normalized slug (path), e.g. "some-post".
+ *     @type string $url                      Original URL/path from the CSV.
+ *     @type int    $post_id                  Resolved post ID, or 0/null.
+ *     @type int    $views                    Pageviews.
+ *     @type float  $revenue                  Ad revenue in dollars.
+ *     @type float  $rpm                      Revenue per mille (per 1k views).
+ *     @type float  $cpm                      Cost per mille.
+ *     @type float  $viewability              Viewability ratio/percent.
+ *     @type float  $fill_rate                Fill rate ratio/percent.
+ *     @type float  $impressions_per_pageview Impressions per pageview.
+ *     @type string $period_start             Window start (Y-m-d) or ''.
+ *     @type string $period_end               Window end (Y-m-d) or ''.
+ *     @type string $import_batch             Import batch identifier.
+ * }
+ * @return int|false Inserted row ID, or false on failure.
+ */
+function extrachill_analytics_revenue_upsert( array $row ) {
+	global $wpdb;
+
+	$table = extrachill_analytics_revenue_table();
+
+	$data = array(
+		'blog_id'                  => isset( $row['blog_id'] ) ? (int) $row['blog_id'] : get_current_blog_id(),
+		'slug'                     => isset( $row['slug'] ) ? (string) $row['slug'] : '',
+		'url'                      => isset( $row['url'] ) ? (string) $row['url'] : '',
+		'post_id'                  => ! empty( $row['post_id'] ) ? (int) $row['post_id'] : null,
+		'views'                    => isset( $row['views'] ) ? max( 0, (int) $row['views'] ) : 0,
+		'revenue'                  => isset( $row['revenue'] ) ? (float) $row['revenue'] : 0.0,
+		'rpm'                      => isset( $row['rpm'] ) ? (float) $row['rpm'] : 0.0,
+		'cpm'                      => isset( $row['cpm'] ) ? (float) $row['cpm'] : 0.0,
+		'viewability'              => isset( $row['viewability'] ) ? (float) $row['viewability'] : 0.0,
+		'fill_rate'                => isset( $row['fill_rate'] ) ? (float) $row['fill_rate'] : 0.0,
+		'impressions_per_pageview' => isset( $row['impressions_per_pageview'] ) ? (float) $row['impressions_per_pageview'] : 0.0,
+		'period_start'             => ! empty( $row['period_start'] ) ? $row['period_start'] : null,
+		'period_end'               => ! empty( $row['period_end'] ) ? $row['period_end'] : null,
+		'import_batch'             => isset( $row['import_batch'] ) ? (string) $row['import_batch'] : '',
+		'imported_at'              => current_time( 'mysql', true ),
+	);
+
+	$formats = array( '%d', '%s', '%s', '%d', '%d', '%f', '%f', '%f', '%f', '%f', '%f', '%s', '%s', '%s', '%s' );
+
+	// REPLACE INTO honors the UNIQUE KEY: same snapshot overwrites in place.
+	$columns      = implode( ', ', array_keys( $data ) );
+	$placeholders = implode( ', ', $formats );
+	$sql          = "REPLACE INTO {$table} ({$columns}) VALUES ({$placeholders})";
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- columns/placeholders are static; values prepared below.
+	$prepared = $wpdb->prepare( $sql, array_values( $data ) );
+	$result   = $wpdb->query( $prepared ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	return false === $result ? false : (int) $wpdb->insert_id;
+}
+
+/**
+ * Fetch revenue snapshot rows for a blog, optionally scoped to a window.
+ *
+ * When both $period_start and $period_end are supplied, only snapshots whose
+ * recorded window matches (or falls within) the requested window are returned —
+ * this is what separates a "recent" lens from the all-time lens. When the window
+ * is omitted, every snapshot for the blog is returned (lifetime view): callers
+ * that mix multiple imports should pass an import_batch to avoid double-counting.
+ *
+ * @param array $args {
+ *     Query args.
+ *
+ *     @type int    $blog_id      Blog ID (default: current blog).
+ *     @type string $import_batch Restrict to one import batch (default: '' = any).
+ *     @type string $period_start Inclusive window start (Y-m-d), or '' for any.
+ *     @type string $period_end   Inclusive window end (Y-m-d), or '' for any.
+ * }
+ * @return array<int, object> Snapshot rows.
+ */
+function extrachill_analytics_revenue_get_rows( array $args = array() ) {
+	global $wpdb;
+
+	$table        = extrachill_analytics_revenue_table();
+	$blog_id      = isset( $args['blog_id'] ) ? (int) $args['blog_id'] : get_current_blog_id();
+	$import_batch = isset( $args['import_batch'] ) ? (string) $args['import_batch'] : '';
+	$period_start = isset( $args['period_start'] ) ? (string) $args['period_start'] : '';
+	$period_end   = isset( $args['period_end'] ) ? (string) $args['period_end'] : '';
+
+	$where  = array( 'blog_id = %d' );
+	$values = array( $blog_id );
+
+	if ( '' !== $import_batch ) {
+		$where[]  = 'import_batch = %s';
+		$values[] = $import_batch;
+	}
+
+	if ( '' !== $period_start && '' !== $period_end ) {
+		// Snapshot window must sit inside the requested window.
+		$where[]  = 'period_start >= %s';
+		$values[] = $period_start;
+		$where[]  = 'period_end <= %s';
+		$values[] = $period_end;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+	$sql          = "SELECT * FROM {$table} WHERE {$where_clause}";
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	return (array) $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+}
+
+/**
+ * List distinct import batches for a blog, newest first.
+ *
+ * @param int $blog_id Blog ID (default: current blog).
+ * @return array<int, object> Rows with import_batch, period_start, period_end, rows, imported_at.
+ */
+function extrachill_analytics_revenue_list_batches( $blog_id = 0 ) {
+	global $wpdb;
+
+	$table   = extrachill_analytics_revenue_table();
+	$blog_id = $blog_id > 0 ? (int) $blog_id : get_current_blog_id();
+
+	$sql = "SELECT import_batch, period_start, period_end, COUNT(*) AS rows_count, MAX(imported_at) AS imported_at,
+		SUM(revenue) AS revenue, SUM(views) AS views
+		FROM {$table} WHERE blog_id = %d
+		GROUP BY import_batch, period_start, period_end
+		ORDER BY imported_at DESC";
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	return (array) $wpdb->get_results( $wpdb->prepare( $sql, $blog_id ) );
+}


### PR DESCRIPTION
## Summary

Makes the one-off manual "join a Mediavine pages CSV to content categories" stitch a repeatable instrument. Adds the revenue sibling of the shipped `content-performance`/`content-flags` abilities: per-URL ad revenue joined to WordPress content metadata, rolled up by **content format** and **category**, with the honest **$/page** metric.

Closes #60.

## What's in here

- **Revenue store** (`inc/database/mediavine-revenue-db.php`) — network-wide `{base_prefix}_extrachill_analytics_mediavine_revenue` table. One row per (blog, slug, period, import batch). REPLACE-on-conflict so re-importing the same export is idempotent. Stamps each snapshot with `period_start`/`period_end` + `import_batch` so an all-time export and a recent export coexist.
- **Content-format classifier** (`inc/core/content-format-classifier.php`) — deterministic single-label post→format mapping (song-meaning / guitar-history / music-history / charleston-local / interview / trivia / listicle / explainer / news / legacy-html / uncategorized). Category-slug membership is the source of truth (filterable map, precedence = map order); legacy `.html` URLs and a light title-shape fallback break ties the taxonomy can't.
- **CSV importer** (`inc/core/mediavine-csv-import.php`) — ingests the Mediavine Pages export (`slug,views,revenue,rpm,cpm,viewability,fillRate,impressionsPerPageview`; headers matched loosely). Resolves each slug/url/path to a post via `url_to_postid`.
- **Ability** `extrachill/get-content-revenue` — the join + rollup. Per bucket: pages, views, revenue, RPM, **$/page**. Accepts a window for the recent lens.

## The CSV-vs-API investigation result

**Mediavine has no per-page revenue API.** The active Mediavine Control Panel plugin (`mediavine-control-panel`) is purely an ad-settings / ads.txt manager — its only outbound call (`src/Upstream.php`) fetches **ad-script settings** from `https://scripts.mediavine.com/tags/`, never revenue. So **CSV import is the only path** to per-URL revenue, and that's what this builds. (If Mediavine ever ships a reporting API, it can register an alternate importer behind the same store + ability — nothing here assumes CSV beyond the importer itself.)

## Why $/page, not RPM

RPM (revenue per 1k views) is a **multiplier**, not a volume measure. A format can post a high RPM yet a tiny $/page because it has almost no views — *high RPM on tiny volume = pennies*. `$/page` (total revenue / page count) is the only honest answer to "is this format worth producing," so rollups **sort by $/page DESC**. RPM is reported alongside, never as the sort key. (Issue validation: trivia shows $33 RPM but only $24/page — exactly the trap $/page is built to expose.)

## Lifetime vs earning-now

High *lifetime* revenue often just means a page is OLD and accumulated earnings over years. The ability takes a `period_start`/`period_end` window that filters to snapshots imported for that window, so the same store yields distinct "earned ever" (lifetime) vs "earning now" (recent) rollups. Mediavine RPM is the **only** source of ad income (GA / first-party can't see it), so revenue is exactly what was imported — never estimated.

## Verification

- `php -l` clean on all files; `phpcs --standard=WordPress` clean (0/0) on the store, classifier, importer, and ability. (The CSV importer's `fopen`/`fclose` are annotated — `fgetcsv` streaming has no `WP_Filesystem` equivalent.)
- **Pure-logic smoke (17/17):** reproduces the issue's validation numbers — song-meaning $129/page, charleston-local $14 RPM, trivia $33 RPM but $24/page, legacy-html $33k/963 pages — plus $/page-DESC ranking and window labels.
- **Live end-to-end** (real WP bootstrap, real DB): table creates; 3 real published slugs resolve via `url_to_postid` to real post IDs; a `.html` ghost page correctly falls to the `legacy-html` bucket; rollups compute correct $/page + RPM on both axes. Test rows cleaned up after.

## CLI

The `wp extrachill analytics revenue` command (import / rollup / batches) lives in a companion extrachill-cli PR. **Merge order: this PR first** (it owns the ability + importer the CLI calls).