### PR TITLE
feat(analytics): outbound-click tracking

### DIFF
--- a/assets/js/outbound-tracking.js
+++ b/assets/js/outbound-tracking.js
@@ -1,0 +1,90 @@
+( function () {
+	var config = window.ecOutboundTracking;
+	if ( ! config || ! config.endpoint ) {
+		return;
+	}
+
+	// Hosts that belong to the Extra Chill network — a click to any of these is
+	// an INTERNAL hop (already measured by the conversion map), never an
+	// outbound exit. Lower-cased for case-insensitive comparison.
+	var networkHosts = ( config.networkHosts || [] ).map( function ( h ) {
+		return String( h ).toLowerCase();
+	} );
+
+	function isNetworkHost( host ) {
+		host = String( host ).toLowerCase();
+		for ( var i = 0; i < networkHosts.length; i++ ) {
+			var nh = networkHosts[ i ];
+			// Exact match or a subdomain of a network host.
+			if ( host === nh || host.endsWith( '.' + nh ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	function send( destUrl, destHost ) {
+		var payload = {
+			click_type: 'outbound',
+			source_url: window.location.href,
+			destination_url: destUrl,
+			dest_host: destHost,
+		};
+
+		if ( config.visitorId ) {
+			payload.visitor_id = config.visitorId;
+		}
+
+		var data = JSON.stringify( payload );
+
+		if ( navigator.sendBeacon ) {
+			navigator.sendBeacon(
+				config.endpoint,
+				new Blob( [ data ], { type: 'application/json' } )
+			);
+		} else {
+			fetch( config.endpoint, {
+				method: 'POST',
+				body: data,
+				headers: { 'Content-Type': 'application/json' },
+				keepalive: true,
+			} );
+		}
+	}
+
+	// Delegated capture: one listener on the document catches clicks on any
+	// anchor, including ones added after load. Capture phase so we record the
+	// intent before any navigation handler can swallow it.
+	document.addEventListener(
+		'click',
+		function ( event ) {
+			// Resolve the anchor the click landed on (could be a child element).
+			var el = event.target;
+			while ( el && el.nodeName !== 'A' ) {
+				el = el.parentElement;
+			}
+			if ( ! el || ! el.href ) {
+				return;
+			}
+
+			// Only http(s) links resolve to a destination host worth tracking.
+			var url;
+			try {
+				url = new URL( el.href, window.location.href );
+			} catch ( e ) {
+				return;
+			}
+			if ( url.protocol !== 'http:' && url.protocol !== 'https:' ) {
+				return;
+			}
+
+			var host = url.hostname;
+			if ( ! host || isNetworkHost( host ) ) {
+				return;
+			}
+
+			send( url.href, host );
+		},
+		true
+	);
+} )();

--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -30,6 +30,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/events.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/security-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/visitor-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/content-format-classifier.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/outbound-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/mediavine-csv-import.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
@@ -49,6 +50,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-search-ga
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/track-page-view.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-link-page-analytics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-bridge-ctr.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-outbound-clicks.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-retention-stats.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-growth.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-conversion-map.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -24,6 +24,7 @@ add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_404_top_ips_
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_track_page_view_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_get_link_page_analytics_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_bridge_ctr_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_outbound_clicks_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_retention_stats_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_surface_growth_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_conversion_map_ability' );

--- a/inc/core/abilities/get-outbound-clicks.php
+++ b/inc/core/abilities/get-outbound-clicks.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Get Outbound Clicks Ability
+ *
+ * Read-side ability that surfaces first-party, bot-filtered outbound-click
+ * behaviour — where readers EXIT the Extra Chill network to external domains.
+ * It reads the sibling `outbound_click` events written by the outbound-click
+ * instrumentation (assets/js/outbound-tracking.js → /analytics/click → the
+ * track-analytics-event ability), the cross-DOMAIN counterpart to the
+ * cross-SITE conversion map.
+ *
+ * Why this is the bot-filtered exit channel (same guarantee get-bridge-ctr
+ * documents):
+ *
+ *   Each `outbound_click` row is fired client-side with sendBeacon and
+ *   therefore only exists for a real, JS-executing browser. Counting them IS
+ *   the bot filter — every outbound click is a human-with-JS by construction.
+ *   Rows are stamped with the canonical is_bot verdict at write time and
+ *   carry the anonymous first-party visitor_id (NULL under GPC/DNT opt-out,
+ *   excluded from per-visitor cuts exactly like the rest of the system).
+ *
+ * HONEST BY CONSTRUCTION: this event is NEW — it captures going forward only.
+ * Until clicks accumulate, totals will be low or zero, and that low number is
+ * the real (young-data) state, not a broken query. The note field always
+ * carries that caveat plus the exact UTC window.
+ *
+ * OUTPUT surfaces three actionable cuts:
+ *   - by_category    : outbound clicks grouped into spotify/social/ticketing/
+ *                      artist-site/merch/other (the affiliate/ticketing-revenue
+ *                      axis), with each category's share of total exits.
+ *   - by_destination : the top external hosts readers exit to, ranked by clicks.
+ *   - by_source      : the top source pages that drive the most exits, with the
+ *                      outbound clicks each one generated (the "which content
+ *                      drives valuable exits" question, paired with revenue).
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.17.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The canonical event_type for an outbound (off-network) click.
+ */
+if ( ! defined( 'EC_ANALYTICS_EVENT_OUTBOUND_CLICK' ) ) {
+	define( 'EC_ANALYTICS_EVENT_OUTBOUND_CLICK', 'outbound_click' );
+}
+
+/**
+ * Register the get-outbound-clicks ability.
+ */
+function extrachill_analytics_register_outbound_clicks_ability() {
+	wp_register_ability(
+		'extrachill/get-outbound-clicks',
+		array(
+			'label'               => __( 'Get Outbound Clicks', 'extrachill-analytics' ),
+			'description'         => __( 'First-party, bot-filtered outbound-click report: where readers exit the network to external domains, grouped by category, top destination host, and top source page. Deterministic from the sendBeacon outbound_click events.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'         => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of days to look back. 0 for all time.', 'extrachill-analytics' ),
+						'default'     => 28,
+					),
+					'blog_id'      => array(
+						'type'        => 'integer',
+						'description' => __( 'Filter to a specific blog ID. 0 for all sites.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'category'     => array(
+						'type'        => 'string',
+						'description' => __( 'Filter to a single destination category (spotify|social|ticketing|artist-site|merch|other). Empty for all.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'limit'        => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of rows to return for the destination and source rankings.', 'extrachill-analytics' ),
+						'default'     => 25,
+					),
+					'include_bots' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Include rows flagged as bot at write time. Default false (humans only).', 'extrachill-analytics' ),
+						'default'     => false,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'Object with total, by_category, by_destination, by_source, the window, and a data-honesty note.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_outbound_clicks',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-outbound-clicks ability.
+ *
+ * Strategy: pull the in-window `outbound_click` rows (bounded by the
+ * event_type + created_at index) and aggregate in PHP. event_data carries the
+ * dest_host, dest_url, category, and is_bot the capture route stamped — so the
+ * read does not re-derive classification, it just rolls up. Volume is low (a
+ * new event), so a single bounded fetch + PHP aggregation is clearer and
+ * cheaper than three GROUP-BY JSON queries.
+ *
+ * @param array $input Input parameters.
+ * @return array Outbound-click report.
+ */
+function extrachill_analytics_ability_get_outbound_clicks( $input ) {
+	global $wpdb;
+
+	$days         = isset( $input['days'] ) ? (int) $input['days'] : 28;
+	$blog_id      = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+	$category     = isset( $input['category'] ) ? sanitize_key( (string) $input['category'] ) : '';
+	$limit        = isset( $input['limit'] ) ? max( 1, (int) $input['limit'] ) : 25;
+	$include_bots = ! empty( $input['include_bots'] );
+
+	$event_type = defined( 'EC_ANALYTICS_EVENT_OUTBOUND_CLICK' ) ? EC_ANALYTICS_EVENT_OUTBOUND_CLICK : 'outbound_click';
+
+	// Read the in-window outbound_click rows through the canonical events query
+	// helper (it owns the safe, prepared WHERE building) rather than re-rolling
+	// raw SQL here. Pull in pages so the whole window is aggregated without an
+	// arbitrary single-query cap; volume is low (a new event), so this is a
+	// bounded read. event_data comes back already JSON-decoded.
+	$query_args = array(
+		'event_type' => $event_type,
+		'limit'      => 5000,
+		'offset'     => 0,
+	);
+
+	if ( $days > 0 ) {
+		$query_args['date_from'] = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+	}
+
+	if ( $blog_id > 0 ) {
+		$query_args['blog_id'] = $blog_id;
+	}
+
+	$rows = array();
+	do {
+		$page       = extrachill_get_analytics_events( $query_args );
+		$page_count = count( (array) $page );
+		if ( 0 === $page_count ) {
+			break;
+		}
+		$rows                  = array_merge( $rows, $page );
+		$query_args['offset'] += $query_args['limit'];
+	} while ( $page_count === $query_args['limit'] );
+
+	$total          = 0;
+	$by_category    = array();
+	$by_destination = array();
+	$by_source      = array();
+
+	foreach ( (array) $rows as $row ) {
+		// extrachill_get_analytics_events() returns event_data already decoded.
+		$data = is_array( $row->event_data ) ? $row->event_data : array();
+
+		// Honour the write-time bot verdict unless the caller wants everything.
+		if ( ! $include_bots && ! empty( $data['is_bot'] ) ) {
+			continue;
+		}
+
+		$dest_host = isset( $data['dest_host'] ) ? strtolower( (string) $data['dest_host'] ) : '';
+
+		// Prefer the category stamped at write time; fall back to classifying
+		// the host now (older rows, or a row that missed the stamp).
+		$row_category = isset( $data['category'] ) && '' !== $data['category']
+			? sanitize_key( (string) $data['category'] )
+			: ( function_exists( 'extrachill_analytics_classify_outbound_host' )
+				? extrachill_analytics_classify_outbound_host( $dest_host )
+				: 'other' );
+
+		// Optional category filter.
+		if ( '' !== $category && $row_category !== $category ) {
+			continue;
+		}
+
+		++$total;
+
+		if ( ! isset( $by_category[ $row_category ] ) ) {
+			$by_category[ $row_category ] = 0;
+		}
+		++$by_category[ $row_category ];
+
+		if ( '' !== $dest_host ) {
+			if ( ! isset( $by_destination[ $dest_host ] ) ) {
+				$by_destination[ $dest_host ] = array(
+					'clicks'   => 0,
+					'category' => $row_category,
+				);
+			}
+			++$by_destination[ $dest_host ]['clicks'];
+		}
+
+		$source = (string) $row->source_url;
+		if ( '' !== $source ) {
+			if ( ! isset( $by_source[ $source ] ) ) {
+				$by_source[ $source ] = 0;
+			}
+			++$by_source[ $source ];
+		}
+	}
+
+	// Category rollup with share-of-total.
+	$category_rank = array();
+	foreach ( $by_category as $cat => $count ) {
+		$category_rank[] = array(
+			'category' => (string) $cat,
+			'clicks'   => (int) $count,
+			'share'    => $total > 0 ? round( $count / $total, 4 ) : 0.0,
+		);
+	}
+	usort(
+		$category_rank,
+		static function ( $a, $b ) {
+			return $b['clicks'] <=> $a['clicks'];
+		}
+	);
+
+	// Top destination hosts.
+	$destination_rank = array();
+	foreach ( $by_destination as $host => $info ) {
+		$destination_rank[] = array(
+			'dest_host' => (string) $host,
+			'category'  => (string) $info['category'],
+			'clicks'    => (int) $info['clicks'],
+		);
+	}
+	usort(
+		$destination_rank,
+		static function ( $a, $b ) {
+			return $b['clicks'] <=> $a['clicks'];
+		}
+	);
+	$destination_rank = array_slice( $destination_rank, 0, $limit );
+
+	// Top source pages.
+	$source_rank = array();
+	foreach ( $by_source as $src => $count ) {
+		$source_rank[] = array(
+			'source_url' => (string) $src,
+			'clicks'     => (int) $count,
+		);
+	}
+	usort(
+		$source_rank,
+		static function ( $a, $b ) {
+			return $b['clicks'] <=> $a['clicks'];
+		}
+	);
+	$source_rank = array_slice( $source_rank, 0, $limit );
+
+	return array(
+		'total'          => $total,
+		'by_category'    => $category_rank,
+		'by_destination' => $destination_rank,
+		'by_source'      => $source_rank,
+		'days'           => $days,
+		'blog_id'        => $blog_id,
+		'category'       => $category,
+		'period'         => $days > 0
+			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
+			: 'all time',
+		'note'           => 'Outbound clicks fire client-side (sendBeacon) and are humans-with-JS by construction, so this report is bot-filtered by design. The outbound_click event is NEW — it captures exits going forward only, so totals are low/zero until clicks accumulate; that is the young-data state, not a broken query. NULL-visitor rows (GPC/DNT opt-out) are still counted in aggregate volume but excluded from any per-visitor cut, same as the rest of the system.',
+	);
+}

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -211,3 +211,76 @@ function extrachill_analytics_enqueue_view_tracking() {
 	);
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_analytics_enqueue_view_tracking' );
+
+/**
+ * Enqueue outbound-click tracking on every front-end view.
+ *
+ * Unlike pageview tracking (singular only), an outbound exit can happen from
+ * any front-end surface — archives, the homepage, taxonomy listings — so this
+ * runs network-wide on all non-admin views. The handler is a single delegated
+ * click listener (see assets/js/outbound-tracking.js) that fires a sendBeacon
+ * `outbound_click` event when a reader clicks an anchor to an off-network host.
+ *
+ * Because the beacon fires only from a real, JS-executing browser, the data is
+ * bot-filtered by construction — the same guarantee the bridge_click /
+ * pageview beacons rely on. The visitor_id echoed here is the already-resolved
+ * `ec_vid` (present on singular pages where it was minted; empty on other
+ * surfaces or under GPC/DNT opt-out — in which case the click is still recorded
+ * anonymously with a NULL visitor_id, exactly like the rest of the system).
+ *
+ * The network-host list is the canonical multisite map so an INTERNAL hop
+ * (extrachill.com → community.extrachill.com, already covered by the conversion
+ * map) is never miscounted as an outbound exit.
+ */
+function extrachill_analytics_enqueue_outbound_tracking() {
+	if ( is_admin() || is_preview() ) {
+		return;
+	}
+
+	$js_path = EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'assets/js/outbound-tracking.js';
+	if ( ! file_exists( $js_path ) ) {
+		return;
+	}
+
+	// Read-only: never mint here (this runs on non-singular pages too, after
+	// output may have started). Empty when no cookie / opted out — the click is
+	// then recorded anonymously, consistent with the rest of the system.
+	$visitor_id = function_exists( 'extrachill_analytics_read_visitor_id' )
+		? extrachill_analytics_read_visitor_id()
+		: '';
+
+	// Canonical Extra Chill network hosts — a click to any of these is an
+	// internal hop, not an outbound exit. Falls back to the current site host
+	// alone if the multisite helper is unavailable.
+	$network_hosts = function_exists( 'ec_get_allowed_redirect_hosts' )
+		? array_values( ec_get_allowed_redirect_hosts() )
+		: array();
+
+	$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
+	if ( is_string( $home_host ) && '' !== $home_host ) {
+		$network_hosts[] = $home_host;
+	}
+	$network_hosts = array_values( array_unique( array_filter( $network_hosts ) ) );
+
+	wp_enqueue_script(
+		'extrachill-outbound-tracking',
+		EXTRACHILL_ANALYTICS_PLUGIN_URL . 'assets/js/outbound-tracking.js',
+		array(),
+		filemtime( $js_path ),
+		array(
+			'strategy'  => 'defer',
+			'in_footer' => true,
+		)
+	);
+
+	wp_localize_script(
+		'extrachill-outbound-tracking',
+		'ecOutboundTracking',
+		array(
+			'endpoint'     => rest_url( 'extrachill/v1/analytics/click' ),
+			'visitorId'    => $visitor_id,
+			'networkHosts' => $network_hosts,
+		)
+	);
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_analytics_enqueue_outbound_tracking' );

--- a/inc/core/outbound-classifier.php
+++ b/inc/core/outbound-classifier.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Outbound-Click Destination Classifier
+ *
+ * Maps an external (off-network) destination host to a small, fixed set of
+ * actionable categories so outbound-click data can be rolled up by *kind* of
+ * destination rather than only by raw host. This is the server-side
+ * counterpart consumed by the get-outbound-clicks read ability; the client
+ * handler only sends the raw destination host + URL, and classification happens
+ * once, canonically, at read time (and is also stamped at write time by the
+ * capture route so a stored row carries its category).
+ *
+ * Categories (kept deliberately simple and documented — extend the substring
+ * lists below, they are the whole contract):
+ *
+ *   - spotify    : Spotify (open.spotify.com, spotify.com, spoti.fi).
+ *   - social     : the major social platforms a reader exits to.
+ *   - ticketing  : ticketing / live-event commerce.
+ *   - artist-site: bandcamp / linktree-style artist destinations (best-effort —
+ *                  most independent artist sites are bespoke domains we cannot
+ *                  enumerate, so this captures the common aggregators only).
+ *   - merch      : merch / store destinations.
+ *   - other      : everything else (the honest default — most of the long tail).
+ *
+ * The lists are filterable so the patterns are not behaviour-changing magic
+ * literals buried in code: a host substring match (case-insensitive) wins in
+ * the documented order above.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.17.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The ordered category => host-substring map used to classify a destination.
+ *
+ * First matching category (in array order) wins. Matching is a case-insensitive
+ * substring test against the destination host. Filterable via
+ * `extrachill_analytics_outbound_category_patterns`.
+ *
+ * @return array<string, string[]> Ordered map of category => host substrings.
+ */
+function extrachill_analytics_outbound_category_patterns() {
+	$patterns = array(
+		'spotify'     => array(
+			'open.spotify.com',
+			'spotify.com',
+			'spoti.fi',
+		),
+		'social'      => array(
+			'instagram.com',
+			'facebook.com',
+			'fb.com',
+			'twitter.com',
+			'x.com',
+			'tiktok.com',
+			'youtube.com',
+			'youtu.be',
+			'threads.net',
+			'bsky.app',
+			'reddit.com',
+			'snapchat.com',
+			'pinterest.com',
+			'linkedin.com',
+		),
+		'ticketing'   => array(
+			'ticketmaster.com',
+			'livenation.com',
+			'eventbrite.com',
+			'dice.fm',
+			'seetickets.us',
+			'seetickets.com',
+			'axs.com',
+			'etix.com',
+			'ticketweb.com',
+			'showclix.com',
+			'tixr.com',
+			'stubhub.com',
+			'seatgeek.com',
+		),
+		'artist-site' => array(
+			'bandcamp.com',
+			'linktr.ee',
+			'soundcloud.com',
+			'music.apple.com',
+			'tidal.com',
+			'audiomack.com',
+			'bandsintown.com',
+		),
+		'merch'       => array(
+			'shopify.com',
+			'bigcartel.com',
+			'merchbar.com',
+			'teespring.com',
+			'storenvy.com',
+		),
+	);
+
+	/**
+	 * Filter the ordered outbound destination category => host-substring map.
+	 *
+	 * First matching category (in array order) wins; matching is a
+	 * case-insensitive substring test against the destination host.
+	 *
+	 * @param array<string, string[]> $patterns Ordered category => host substrings.
+	 */
+	return apply_filters( 'extrachill_analytics_outbound_category_patterns', $patterns );
+}
+
+/**
+ * Classify an external destination host into an outbound category.
+ *
+ * @param string $dest_host The destination host (e.g. "open.spotify.com"). May
+ *                          be a full URL; the host is extracted defensively.
+ * @return string One of: spotify|social|ticketing|artist-site|merch|other.
+ */
+function extrachill_analytics_classify_outbound_host( $dest_host ) {
+	$dest_host = strtolower( trim( (string) $dest_host ) );
+
+	if ( '' === $dest_host ) {
+		return 'other';
+	}
+
+	// Defensive: if a full URL slipped in, reduce to its host.
+	if ( false !== strpos( $dest_host, '://' ) ) {
+		$parsed    = wp_parse_url( $dest_host );
+		$dest_host = isset( $parsed['host'] ) ? strtolower( $parsed['host'] ) : $dest_host;
+	}
+
+	foreach ( extrachill_analytics_outbound_category_patterns() as $category => $needles ) {
+		foreach ( (array) $needles as $needle ) {
+			if ( '' !== $needle && false !== strpos( $dest_host, strtolower( (string) $needle ) ) ) {
+				return (string) $category;
+			}
+		}
+	}
+
+	return 'other';
+}


### PR DESCRIPTION
## Summary

First-party, **bot-filtered outbound-click capture** — where readers exit the network to external domains. The cross-DOMAIN counterpart to the cross-SITE conversion map, and the missing half of "where do readers go." This is the prerequisite for any affiliate/ticketing revenue strategy: you cannot optimize (or monetize) outbound behavior you can't measure.

Closes #66.

## What's in this PR (extrachill-analytics)

- **`assets/js/outbound-tracking.js`** — one delegated `click` listener (capture phase, catches dynamically-added anchors) fires a `sendBeacon` `outbound_click` event when a reader clicks an `<a>` to an off-network host. It captures source page (current URL), destination host + URL, `ec_vid`, and `blog_id`. Mirrors the existing pageview/bridge beacon exactly.
- **`inc/core/outbound-classifier.php`** — `extrachill_analytics_classify_outbound_host()` maps a destination host to a small, **documented + filterable** category set: `spotify` / `social` / `ticketing` / `artist-site` / `merch` / `other`. First match (in documented order) wins.
- **`inc/core/abilities/get-outbound-clicks.php`** — the read ability `extrachill/get-outbound-clicks`. Surfaces `total`, `by_category` (with share-of-total), top destination hosts, and top source pages. Registered canonically (`wp_abilities_api_init`, `manage_options`/WP-CLI permission, category `extrachill-analytics`, `show_in_rest => false`). Reads the existing events store — **no new table**.
- **`inc/core/assets.php`** — enqueues the outbound script on every front-end view (an exit can happen from any surface, not just singular pages) and localizes the canonical network-host list + read-only `ec_vid`.

## Architecture notes (why it's split into 2 PRs + the CLI)

- **No new store.** The capture path reuses `extrachill_track_analytics_event` with `event_type` `outbound_click` and `event_data {dest_host, dest_url, category, source_url}`, exactly as the issue specifies.
- **No new REST endpoint.** The JS beacon hits the **existing** `/wp-json/extrachill/v1/analytics/click` route in `extrachill-api`, which already routes `share`/`bridge` clicks through the `track-analytics-event` ability. Adding an `outbound` `click_type` there is the layer-faithful move (RULES.md: prove the thing doesn't already exist before building new infra). That route change is a companion PR: **Extra-Chill/extrachill-api#outbound-clicks-66-api**.
- The CLI wrapper (`wp extrachill analytics outbound`) is a third PR in `extrachill-cli`, depending on this ability.

## Honesty

Bot-filtered **by construction** — `sendBeacon` from a JS browser means the row is a human-with-JS. `is_bot` is stamped at write time and excluded by default; NULL-visitor rows (GPC/DNT opt-out) are counted in aggregate volume but excluded from any per-visitor cut, same as the rest of the system. The `outbound_click` event is **new** — it captures exits **going forward only**, so totals are low/zero until clicks accumulate. The ability's `note` says so explicitly; a low number is the young-data state, not a broken query.

## Verification

- `php -l` clean on all changed PHP.
- `node --check` clean on the JS.
- `phpcs --standard=WordPress` — **0 errors, 0 warnings** on all new/changed files.
- Classifier smoke-tested against 11 host cases (spotify/social/ticketing/artist-site/merch/other + full-URL + empty) — all pass.