### PR TITLE
fix(analytics): clear lint findings in crosslink-targets ability

### DIFF
--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -128,7 +128,7 @@ function extrachill_analytics_ability_track_event( $input ) {
 	// reclassify it as 'search_attack' so real search metrics stay clean while
 	// the attack stays visible. This catches any caller (current or future)
 	// that forgets to pre-classify, including community/forum/artist search.
-	if ( $event_type === 'search' && is_array( $event_data ) && ! empty( $event_data['search_term'] ) ) {
+	if ( 'search' === $event_type && is_array( $event_data ) && ! empty( $event_data['search_term'] ) ) {
 		$classification = extrachill_analytics_classify_search_payload( (string) $event_data['search_term'] );
 		if ( null !== $classification ) {
 			$event_type = 'search_attack';

--- a/inc/core/abilities/get-crosslink-targets.php
+++ b/inc/core/abilities/get-crosslink-targets.php
@@ -327,10 +327,7 @@ function extrachill_analytics_crosslink_conversion_read( $days, $session_gap_min
 	}
 
 	if ( function_exists( 'extrachill_analytics_ability_get_conversion_map' ) ) {
-		$result = extrachill_analytics_ability_get_conversion_map( $args );
-		if ( is_array( $result ) ) {
-			return $result;
-		}
+		return extrachill_analytics_ability_get_conversion_map( $args );
 	}
 
 	return new WP_Error(
@@ -366,8 +363,7 @@ function extrachill_analytics_crosslink_link_graph( $force_audit ) {
 		'note'          => 'link graph UNAVAILABLE — DataMachine\\Abilities\\InternalLinkingAbilities not loaded; orphan status could not be established, so no targets could be confirmed',
 	);
 
-	if ( ! class_exists( '\\DataMachine\\Abilities\\InternalLinkingAbilities' )
-		|| ! method_exists( '\\DataMachine\\Abilities\\InternalLinkingAbilities', 'auditInternalLinks' ) ) {
+	if ( ! class_exists( '\\DataMachine\\Abilities\\InternalLinkingAbilities' ) ) {
 		return $unavailable;
 	}
 
@@ -378,9 +374,9 @@ function extrachill_analytics_crosslink_link_graph( $force_audit ) {
 		)
 	);
 
-	if ( ! is_array( $graph ) || isset( $graph['error'] ) ) {
+	if ( isset( $graph['error'] ) ) {
 		$unavailable['note'] = 'link graph audit FAILED ('
-			. ( is_array( $graph ) ? (string) ( $graph['error'] ?? 'unknown error' ) : 'non-array response' )
+			. (string) $graph['error']
 			. ') — orphan status could not be established';
 		return $unavailable;
 	}
@@ -455,7 +451,7 @@ function extrachill_analytics_crosslink_primary_category( $article ) {
 	// categories on the entry blog with correct blog-switching.
 	if ( function_exists( 'extrachill_analytics_conversion_post_categories' ) ) {
 		$cats = extrachill_analytics_conversion_post_categories( $post_id );
-		if ( is_array( $cats ) && ! empty( $cats ) ) {
+		if ( ! empty( $cats ) ) {
 			// First category name (the map is term_id => name).
 			$names = array_values( $cats );
 			return (string) $names[0];


### PR DESCRIPTION
## Summary
Post-merge lint fix-forward for the crosslink-targets ability (#71). The release lint gate surfaced 7 findings (1 PHPCS Yoda + 6 PHPSTAN level-7 redundant-type / always-true checks). All fixed; `homeboy lint` now passes with no findings.

## Changes
- `abilities.php:131` — Yoda condition (`'search' === $event_type`) on a pre-existing line the #71 commit made "changed".
- `get-crosslink-targets.php` — removed PHPSTAN-redundant defensive checks that the declared/inferred array return types make dead code: `is_array()` after `auditInternalLinks` (declared array return), `is_array()` after `get_conversion_map` / `conversion_post_categories` (inferred array), the redundant `method_exists` (the `class_exists` guard fully covers the DM-not-loaded case — the static method is unconditionally defined), and the `?? 'unknown error'` after `isset($graph['error'])`.

The cross-plugin layer-purity behavior is unchanged: still `class_exists`-guards the DM dependency, still consults `auditInternalLinks` read-only with a graceful UNAVAILABLE fallback, still reuses `get-conversion-map`.

## Verify
`php -l` clean; `homeboy lint extrachill-analytics --changed-since v0.17.0` → "lint phase passed with no findings".