### PR TITLE
fix(analytics): compute per-destination bridge CTR now that impressions carry dest_site

### DIFF
--- a/inc/core/abilities/get-bridge-ctr.php
+++ b/inc/core/abilities/get-bridge-ctr.php
@@ -20,6 +20,14 @@
  *   engagement signal that can demote the bot-inflated raw `network_bridge`
  *   session count to a diagnostic.
  *
+ * PER-DESTINATION GRAIN: both events now carry `dest_site` in event_data — the
+ * click beacon always did, and the impression beacon does as of
+ * extrachill-analytics#75 (one impression per rendered card instead of one
+ * per pageview). Clicks and impressions therefore share the per-destination
+ * grain, so this ability returns a real per-destination-site CTR breakdown
+ * alongside the network total, rather than pairing a per-pageview denominator
+ * with a per-link numerator.
+ *
  * @package ExtraChill\Analytics
  * @since 0.9.0
  */
@@ -53,7 +61,7 @@ function extrachill_analytics_register_bridge_ctr_ability() {
 			),
 			'output_schema'       => array(
 				'type'        => 'object',
-				'description' => __( 'Object with clicks, impressions, ctr, and per-destination-site breakdown.', 'extrachill-analytics' ),
+				'description' => __( 'Object with network-total clicks, impressions, ctr, and a per-destination-site breakdown (clicks, impressions, ctr per dest_site).', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_bridge_ctr',
 			'permission_callback' => function () {
@@ -74,58 +82,114 @@ function extrachill_analytics_register_bridge_ctr_ability() {
 /**
  * Execute callback for get-bridge-ctr ability.
  *
+ * Strategy: pull the in-window `bridge_click` and `bridge_impression` rows
+ * through the canonical events query helper (it owns the safe, prepared WHERE
+ * building and returns event_data already JSON-decoded) and aggregate in PHP.
+ * Both events now carry `dest_site` in event_data, so the same pass produces
+ * the network total AND the per-destination-site breakdown. Volume is bounded
+ * (these events fire only for humans-with-JS), so a paged fetch + PHP rollup is
+ * clearer than GROUP-BY-on-JSON SQL — and it matches get-outbound-clicks.
+ *
  * @param array $input Input parameters.
  * @return array CTR summary.
  */
 function extrachill_analytics_ability_get_bridge_ctr( $input ) {
-	global $wpdb;
-
 	$days    = isset( $input['days'] ) ? (int) $input['days'] : 28;
 	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
 
-	$table = extrachill_analytics_events_table();
-
-	$where  = array( "event_type IN ('bridge_click', 'bridge_impression')" );
-	$values = array();
+	// Pull both bridge events in pages so the whole window is aggregated
+	// without an arbitrary single-query cap. event_data comes back decoded.
+	$query_args = array(
+		'event_type' => array( 'bridge_click', 'bridge_impression' ),
+		'limit'      => 5000,
+		'offset'     => 0,
+	);
 
 	if ( $days > 0 ) {
-		$where[]  = 'created_at >= %s';
-		$values[] = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+		$query_args['date_from'] = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
 	}
 
 	if ( $blog_id > 0 ) {
-		$where[]  = 'blog_id = %d';
-		$values[] = $blog_id;
+		$query_args['blog_id'] = $blog_id;
 	}
 
-	$where_clause = implode( ' AND ', $where );
-
-	// Totals by event type.
-	$totals_sql = "SELECT event_type, COUNT(*) AS count FROM {$table} WHERE {$where_clause} GROUP BY event_type";
-
-	$totals_rows = empty( $values )
-		? $wpdb->get_results( $totals_sql )
-		: $wpdb->get_results( $wpdb->prepare( $totals_sql, $values ) );
+	$rows = array();
+	do {
+		$page       = extrachill_get_analytics_events( $query_args );
+		$page_count = count( (array) $page );
+		if ( 0 === $page_count ) {
+			break;
+		}
+		$rows                  = array_merge( $rows, $page );
+		$query_args['offset'] += $query_args['limit'];
+	} while ( $page_count === $query_args['limit'] );
 
 	$clicks      = 0;
 	$impressions = 0;
 
-	foreach ( (array) $totals_rows as $row ) {
-		if ( 'bridge_click' === $row->event_type ) {
-			$clicks = (int) $row->count;
-		} elseif ( 'bridge_impression' === $row->event_type ) {
-			$impressions = (int) $row->count;
+	// Per-destination accumulators keyed by dest_site.
+	$by_dest = array();
+
+	foreach ( (array) $rows as $row ) {
+		// extrachill_get_analytics_events() returns event_data already decoded.
+		$data      = is_array( $row->event_data ) ? $row->event_data : array();
+		$dest_site = isset( $data['dest_site'] ) ? (string) $data['dest_site'] : '';
+		$is_click  = ( 'bridge_click' === $row->event_type );
+
+		if ( $is_click ) {
+			++$clicks;
+		} else {
+			++$impressions;
+		}
+
+		if ( ! isset( $by_dest[ $dest_site ] ) ) {
+			$by_dest[ $dest_site ] = array(
+				'clicks'      => 0,
+				'impressions' => 0,
+			);
+		}
+
+		if ( $is_click ) {
+			++$by_dest[ $dest_site ]['clicks'];
+		} else {
+			++$by_dest[ $dest_site ]['impressions'];
 		}
 	}
 
+	// Build the per-destination ranking with a per-dest CTR. dest_site '' means
+	// the event predates the per-card dest_site emit (extrachill-analytics#75)
+	// or carried an untagged card; it is surfaced as '(unknown)' so the legacy
+	// dest-less rows are visible rather than silently dropped.
+	$by_dest_site = array();
+	foreach ( $by_dest as $dest => $counts ) {
+		$dest_clicks      = (int) $counts['clicks'];
+		$dest_impressions = (int) $counts['impressions'];
+		$by_dest_site[]   = array(
+			'dest_site'   => '' === $dest ? '(unknown)' : $dest,
+			'clicks'      => $dest_clicks,
+			'impressions' => $dest_impressions,
+			'ctr'         => $dest_impressions > 0 ? round( $dest_clicks / $dest_impressions, 4 ) : 0.0,
+		);
+	}
+
+	// Rank by impressions (the exposure denominator) so the busiest hops lead.
+	usort(
+		$by_dest_site,
+		static function ( $a, $b ) {
+			return $b['impressions'] <=> $a['impressions'];
+		}
+	);
+
 	return array(
-		'clicks'      => $clicks,
-		'impressions' => $impressions,
-		'ctr'         => $impressions > 0 ? round( $clicks / $impressions, 4 ) : 0.0,
-		'days'        => $days,
-		'period'      => $days > 0
+		'clicks'       => $clicks,
+		'impressions'  => $impressions,
+		'ctr'          => $impressions > 0 ? round( $clicks / $impressions, 4 ) : 0.0,
+		'by_dest_site' => $by_dest_site,
+		'days'         => $days,
+		'blog_id'      => $blog_id,
+		'period'       => $days > 0
 			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
 			: 'all time',
-		'note'        => 'Both events fire client-side (sendBeacon) and are humans-with-JS by construction; this CTR is bot-filtered by design, unlike the raw GA4 network_bridge channel.',
+		'note'         => 'Both events fire client-side (sendBeacon) and are humans-with-JS by construction; this CTR is bot-filtered by design, unlike the raw GA4 network_bridge channel. Clicks and impressions now share the per-destination grain (one impression per rendered card carries dest_site as of extrachill-analytics#75), so by_dest_site pairs each destination\'s clicks to its own impressions. dest_site "(unknown)" rows are legacy page-level impressions emitted before the per-card change (or untagged cards); they shrink as new per-card data accumulates.',
 	);
 }


### PR DESCRIPTION
## Summary

Fixes #75 — the reader half of the bridge-CTR granularity mismatch. Now that bridge impressions carry `dest_site` (sibling PRs: multisite emits one impression per rendered card with its `dest_site`; extrachill-api accepts + stores it), `get-bridge-ctr` can deliver the per-destination-site breakdown its docblock already promised but was structurally unable to compute.

## The bug

The ability counted `bridge_click` and `bridge_impression` by `event_type` only. Impressions were page-level and dest-less (100% NULL `dest_site`), so `CTR = clicks / impressions` could never be split per destination — and even the network CTR paired a per-pageview denominator with a per-link numerator. The docblock promised "per-destination-site breakdown" that the SQL made impossible.

## Change

- Replaced the raw event-type COUNT SQL with a paged fetch via the canonical `extrachill_get_analytics_events()` helper (same pattern as `get-outbound-clicks`). The helper owns the safe prepared WHERE building and returns `event_data` already JSON-decoded, so `dest_site` is readable per row.
- Aggregate in one PHP pass into both the **network total** (clicks, impressions, ctr — unchanged output shape) and a new **`by_dest_site`** breakdown: per-destination clicks, impressions, and that destination's own CTR, ranked by impressions (busiest hop first).
- Legacy dest-less impression rows (page-level, emitted before the per-card change) and untagged cards surface under `dest_site: "(unknown)"` so they're visible rather than silently dropped; that bucket shrinks as new per-card data accumulates.
- Honors the existing `blog_id` filter; added `blog_id` to the output for symmetry with `get-outbound-clicks`.
- Updated the docblock + `output_schema` to describe the now-real per-dest grain.

Bot-free by construction is preserved: both events only fire from real JS browsers (sendBeacon), so no UA filtering is needed here.

## Layer purity

The CTR read stays in extrachill-analytics. JS emit (multisite) and REST receive/store (api) are unchanged ownership, handled in the sibling PRs.

## Verification

- `php -l` clean.
- `phpcs --standard=WordPress` on the changed file: **zero findings**.
- No phpstan config/binary in the repo, so the lint gate is phpcs-only.

Depends on (for live data, not for merge):
- Extra-Chill/extrachill-multisite#73 (emit per-card dest_site)
- Extra-Chill/extrachill-api#96 (store dest_site)

Fixes #75