### PR TITLE
feat: surface artist activation funnel friction signals

### DIFF
--- a/inc/core/abilities/get-activation-funnel.php
+++ b/inc/core/abilities/get-activation-funnel.php
@@ -24,6 +24,15 @@
  * DISTINCT person, then computes step-to-step and overall conversion plus the
  * single biggest abandon step.
  *
+ * Friction / anomaly signals
+ * --------------------------
+ * Alongside the happy-path steps it also surfaces an `anomalies` section that
+ * counts the activation FRICTION events (`EC_ANALYTICS_ARTIST_ACTIVATION_
+ * FRICTION_EVENTS` — duplicate profile creation and re-registration attempts)
+ * by DISTINCT person over the SAME window and dedup key. These make funnel
+ * leaks visible: instead of a person silently vanishing between two steps, the
+ * anomaly count records the thrash that explains the drop-off.
+ *
  * Identity / dedup key
  * --------------------
  * Every funnel step is a logged-in action, so the dedicated `user_id` column
@@ -72,7 +81,7 @@ function extrachill_analytics_register_activation_funnel_ability() {
 			),
 			'output_schema'       => array(
 				'type'        => 'object',
-				'description' => __( 'Object with an ordered steps array (event_type, label, people, conversion_from_prev, conversion_from_top), the biggest_abandon_step, and the exact UTC window.', 'extrachill-analytics' ),
+				'description' => __( 'Object with an ordered steps array (event_type, people, conversion_from_prev, conversion_from_top), the biggest_abandon_step, an anomalies array of friction signals (duplicate profile creation, re-registration attempts) each with DISTINCT people and raw event counts, and the exact UTC window.', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_activation_funnel',
 			'permission_callback' => function () {
@@ -207,10 +216,47 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 	$last_count         = ! empty( $step_rows ) ? end( $step_rows )['people'] : 0;
 	$overall_conversion = $top_count > 0 ? round( $last_count / $top_count, 4 ) : 0.0;
 
+	// Friction / anomaly signals — failure modes that run ALONGSIDE the ordered
+	// happy-path steps but are not steps themselves (a member creating a second
+	// artist profile, or a known person re-registering a fresh account). These
+	// make funnel leaks visible: instead of a person silently vanishing between
+	// two steps, an anomaly count records the thrash. Counted by DISTINCT person
+	// over the SAME window and dedup key as the steps so they reconcile exactly.
+	$friction_events = defined( 'EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS' )
+		? EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS
+		: array( 'artist_profile_duplicate_created', 'user_reregistration_attempt' );
+
+	$anomalies = array();
+
+	foreach ( $friction_events as $event_type ) {
+		$where  = array( 'event_type = %s', "{$person_key} IS NOT NULL AND {$person_key} != ''" );
+		$values = array( sanitize_key( $event_type ) );
+
+		if ( ! empty( $window_where ) ) {
+			$where  = array_merge( $where, $window_where );
+			$values = array_merge( $values, $window_values );
+		}
+
+		$where_clause = implode( ' AND ', $where );
+
+		// Count DISTINCT people who hit this friction signal (people, not rows:
+		// a member who created three duplicate profiles is one thrashing person)
+		// AND the raw row volume (how much thrash that cohort generated).
+		$people_sql = "SELECT COUNT(DISTINCT {$person_key}) FROM {$table} WHERE {$where_clause}";
+		$events_sql = "SELECT COUNT(*) FROM {$table} WHERE {$where_clause}";
+
+		$anomalies[] = array(
+			'event_type' => $event_type,
+			'people'     => (int) $wpdb->get_var( $wpdb->prepare( $people_sql, $values ) ),
+			'events'     => (int) $wpdb->get_var( $wpdb->prepare( $events_sql, $values ) ),
+		);
+	}
+
 	return array(
 		'steps'                => $steps_out,
 		'overall_conversion'   => $overall_conversion,
 		'biggest_abandon_step' => $biggest_abandon,
+		'anomalies'            => $anomalies,
 		'days'                 => $days,
 		'blog_id'              => $blog_id,
 		'period'               => $days > 0
@@ -220,6 +266,6 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 		// same created_at >= since bound used by get-analytics-summary.
 		'since'                => $since,
 		'as_of'                => $now_utc,
-		'note'                 => 'Per-person funnel: each step is COUNT(DISTINCT COALESCE(NULLIF(user_id,0), visitor_id)), so multiple emits per person (e.g. re-views of the create form emitting artist_signup_started) collapse to one. Rows with neither identity are excluded. Counts here are intentionally NOT comparable to get-analytics-summary COUNT(*) raw volume.',
+		'note'                 => 'Per-person funnel: each step is COUNT(DISTINCT COALESCE(NULLIF(user_id,0), visitor_id)), so multiple emits per person (e.g. re-views of the create form emitting artist_signup_started) collapse to one. Rows with neither identity are excluded. Counts here are intentionally NOT comparable to get-analytics-summary COUNT(*) raw volume. The anomalies array reports activation friction signals (duplicate profile creation, re-registration attempts) over the same window: people is DISTINCT persons hitting that signal, events is raw row volume.',
 	);
 }

--- a/inc/core/event-types.php
+++ b/inc/core/event-types.php
@@ -69,11 +69,34 @@ const EC_ANALYTICS_EVENT_ROADIE_TOOL_INVOKED      = 'roadie_tool_invoked';
  * The access-gate events (`artist_access_requested` / `_approved`) sit
  * upstream of this funnel for users who must request access first.
  */
-const EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED     = 'artist_access_requested';
-const EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED      = 'artist_access_approved';
-const EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED       = 'artist_signup_started';
-const EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED      = 'artist_profile_created';
+const EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED      = 'artist_access_requested';
+const EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED       = 'artist_access_approved';
+const EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED        = 'artist_signup_started';
+const EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED       = 'artist_profile_created';
 const EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH = 'artist_profile_first_publish';
+
+/**
+ * Artist-funnel FRICTION events — the failure/thrash modes that sit alongside
+ * the ordered happy-path steps above but are NOT themselves steps.
+ *
+ * These make onboarding funnel leaks visible: instead of a person silently
+ * vanishing between two happy-path steps, an anomaly emit records WHY the
+ * funnel thrashed. They carry the same `visitor_id` (top-level ability arg)
+ * AND `user_id` (event_data) stitching as the steps, so a friction event
+ * attributes to the same person the funnel reader already counts.
+ *
+ *   artist_profile_duplicate_created — a member who already has an artist
+ *     profile created ANOTHER one (a dead-end thrash: the second profile is
+ *     not the activation the funnel is measuring, it is wasted motion).
+ *   user_reregistration_attempt — an already-known person tried to register a
+ *     fresh account (a duplicate-account / re-registration signal: the top of
+ *     the funnel is leaking returning users into new identities).
+ *
+ * The emit CALLS live in extrachill-artist-platform / extrachill-users
+ * (separate PRs); this contract gives those emits a canonical name to write.
+ */
+const EC_ANALYTICS_EVENT_ARTIST_PROFILE_DUPLICATE_CREATED = 'artist_profile_duplicate_created';
+const EC_ANALYTICS_EVENT_USER_REREGISTRATION_ATTEMPT      = 'user_reregistration_attempt';
 
 /**
  * The team-experience event set surfaced by the cohort rollup
@@ -118,4 +141,18 @@ const EC_ANALYTICS_ARTIST_ACTIVATION_STEPS = array(
 	EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED,
 	EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED,
 	EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH,
+);
+
+/**
+ * The activation FRICTION event set — failure/thrash signals that run
+ * alongside the ordered activation steps but are not steps themselves. The
+ * funnel reader counts each of these by DISTINCT person to surface a
+ * measurable thrash/abandon signal next to the happy-path conversion. Order
+ * is NOT significant (these are independent anomalies, not a sequence).
+ *
+ * @var string[]
+ */
+const EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS = array(
+	EC_ANALYTICS_EVENT_ARTIST_PROFILE_DUPLICATE_CREATED,
+	EC_ANALYTICS_EVENT_USER_REREGISTRATION_ATTEMPT,
 );


### PR DESCRIPTION
## Summary

Makes onboarding funnel leaks **visible**. The artist activation funnel already emits the happy path (`artist_signup_started → artist_profile_created → artist_profile_first_publish`) and the reader counts each step by DISTINCT person. This PR adds the **friction signals** that explain *why* people fall out — instead of a member silently vanishing between two steps, an anomaly count records the thrash.

Purely additive: **no new tables, no new infrastructure.** It defines the name contract + reader support; the actual emit calls live in `extrachill-artist-platform` / `extrachill-users` (separate PRs, see cross-refs).

## Changes

**`inc/core/event-types.php`** — two new friction event-type constants, following the exact declaration + grouping style of the existing funnel constants:
- `EC_ANALYTICS_EVENT_ARTIST_PROFILE_DUPLICATE_CREATED = 'artist_profile_duplicate_created'` — a member who already has a profile creates *another* (dead-end thrash).
- `EC_ANALYTICS_EVENT_USER_REREGISTRATION_ATTEMPT = 'user_reregistration_attempt'` — a known person tries to register a fresh account (top-of-funnel leaking returning users into new identities).
- `EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS` group constant (order not significant — independent anomalies).

**`inc/core/abilities/get-activation-funnel.php`** — new `anomalies` array in the funnel output. Each entry reports:
- `people` — DISTINCT persons hitting that friction signal (so one member who created three duplicate profiles is one thrashing person).
- `events` — raw row volume (how much thrash that cohort generated).

Counted over the **same window and dedup key** (`COALESCE(NULLIF(user_id,0), visitor_id)`) as the steps so they reconcile exactly. The existing happy-path output (`steps`, `overall_conversion`, `biggest_abandon_step`, window fields) is **unchanged** — this is strictly an additive field.

## Verification

- `php -l` clean on both files.
- `phpcs --standard=WordPress` clean on `event-types.php` (alignment auto-fixed with phpcbf). The funnel reader's only remaining findings are the pre-existing `$wpdb->prepare()` / direct-DB-call warnings that the original step query already triggered on `main` — the new anomaly queries follow that identical established pattern rather than diverging from it.

## Cross-references

The emit sites that will call these new event names:
- Extra-Chill/extrachill-artist-platform#80 (duplicate profile creation emit)
- Extra-Chill/extrachill-artist-platform#83 (re-registration / duplicate-account emit)

Fixes #78