### PR TITLE
fix: guard visitor-cookie setcookie() against empty name (Fixes #80)

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -126,8 +126,11 @@ function extrachill_analytics_get_or_mint_visitor_id() {
 	// Set the cookie for ~1 year. Secure + HttpOnly + SameSite=Lax: first-party
 	// analytics only, not readable by JS, not sent on cross-site sub-requests.
 	// Guarded against headers_sent() as defense-in-depth; the early
-	// template_redirect hook below is what actually makes this succeed.
-	if ( ! headers_sent() ) {
+	// template_redirect hook below is what actually makes this succeed. The
+	// non-empty $cookie_name guard is belt-and-suspenders: an empty name throws
+	// an uncaught ValueError on PHP 8 (setcookie() rejects an empty $name), so
+	// we never call setcookie() unless we have a real cookie name to set.
+	if ( '' !== $cookie_name && ! headers_sent() ) {
 		setcookie(
 			$cookie_name,
 			$visitor_id,


### PR DESCRIPTION
## Summary

Adds a non-empty `$cookie_name` guard around the visitor-id mint `setcookie()` call in `inc/core/assets.php` so an empty/undefined cookie name can never throw an uncaught `ValueError` on PHP 8 again — defense-in-depth on top of the already-correct root-cause fix.

Fixes #80.

## Root-cause finding (the important part)

The fatal was **real but already fixed and no longer firing.** The "11,891 over 2 days / ~6,000/day" figure in the issue is a **stale-debug.log artifact** — the entire burst happened inside a single ~3.4-hour window and stopped the moment the fix deployed. The 122 MB log simply still retains that historical burst.

Timeline (all UTC, from `git log` commit times + `wp-content/debug.log` timestamps):

| Time (20-Jun) | Event |
|---|---|
| `00:33:26` | `release: v0.14.0` lands (shipped the broken mint path) |
| `00:33:49` | **First fatal** — 23s after the v0.14.0 deploy |
| `03:54:19` | `b212102` *"fix: assign $cookie_name before setcookie in visitor-id mint (closes #46)"* committed |
| `03:55:46` | `release: v0.14.1` |
| `03:56:07` | **Last fatal** — ~21s into the v0.14.1 deploy window |
| 20-Jun → now | **Zero fatals** across 2+ days and 6 subsequent releases |

`grep -c "must not be empty" wp-content/debug.log` = **11,891**, all between `00:33:49` and `03:56:07` on 20-Jun.

### What the original bug was, and what b212102 missed

The production stack trace proves the broken code, not the current code:

```
PHP Fatal error: Uncaught ValueError: setcookie(): Argument #1 ($name) must not be empty in .../assets.php:130
PHP Warning:  Undefined variable $cookie_name in .../assets.php on line 131
PHP Deprecated: setcookie(): Passing null to parameter #1 ($name) ... on line 130
```

The companion **`Undefined variable $cookie_name`** warning is the tell: in the v0.14.0 code, `extrachill_analytics_get_or_mint_visitor_id()` called `setcookie( $cookie_name, ... )` **without ever assigning `$cookie_name`**, so PHP 8 received `null`/empty and threw. (Issue #46 had reported the same class of bug on a different path.)

**b212102 did NOT miss anything** — it correctly added `$cookie_name = EXTRACHILL_ANALYTICS_VISITOR_COOKIE;` before the `setcookie()` call, exactly matching the sibling reader `extrachill_analytics_read_visitor_id()`. That fix is present and correct on `main` today (line 123). The issue's premise that it "regressed or was never fully fixed" is based on reading the old burst in the retained log as if it were ongoing — it isn't.

I also confirmed there is **no competing definition**: a network-wide grep of `wp-content` for `EXTRACHILL_ANALYTICS_VISITOR_COOKIE` finds it **only** in this one file (the `define()` at line 15 and the two consumers). No second `define()`, no empty assignment, no partial-include path where the function is callable without the top-of-file `define()` having run. So the constant cannot resolve empty under the current code.

## The fix in this PR (defense-in-depth)

Since the root cause is already fixed, the valuable change is making this class of bug **structurally impossible to fatal** again:

```php
if ( '' !== $cookie_name && ! headers_sent() ) {
    setcookie( $cookie_name, ... );
    $_COOKIE[ $cookie_name ] = $visitor_id;
}
```

If a future refactor ever drops the `$cookie_name` assignment (or the constant resolves empty for any reason), we silently skip the cookie write instead of throwing an uncaught `ValueError` that 500s the request and buries real errors in the log. The `$_COOKIE` write is now also inside the guard, so it can never write to an empty key either.

## Verification
- `php -l inc/core/assets.php` → no syntax errors.
- Confirmed the file has exactly one real `setcookie()` call (line 134) and it is now behind the guard.
- Confirmed `b212102`'s `$cookie_name` assignment is present on `main`.
- Confirmed zero `must not be empty` fatals in `debug.log` since 20-Jun 03:56:07.

## Notes
- Conventional commit (`fix:`). No CHANGELOG edit, no version bump (homeboy owns both).
- Sibling double-define bug in the events repo (#81) is out of scope and untouched.