### PR TITLE
fix: scope ec_vid visitor cookie to network root (cross-subdomain identity)

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -15,6 +15,56 @@ defined( 'ABSPATH' ) || exit;
 define( 'EXTRACHILL_ANALYTICS_VISITOR_COOKIE', 'ec_vid' );
 
 /**
+ * Resolve the cookie domain the visitor cookie must be scoped to.
+ *
+ * On this subdomain multisite, an empty/host-scoped cookie domain mints a NEW
+ * visitor id on every subdomain (extrachill.com vs events.extrachill.com vs
+ * community.extrachill.com), making cross-site retention structurally
+ * unmeasurable. Scoping the cookie to the NETWORK ROOT with a leading dot
+ * (`.extrachill.com`) lets ONE id span every subdomain.
+ *
+ * Resolution order (first that fits wins):
+ *   1. The WP `COOKIE_DOMAIN` constant — on this install it is already defined
+ *      as the network root with a leading dot, which is exactly what we want.
+ *   2. A multisite-derived value: a leading dot prefixed to the network's
+ *      primary domain (`.` . get_network()->domain). The leading dot is what
+ *      makes the cookie span subdomains.
+ *
+ * The whole thing is filterable so the value is never a bare hardcoded literal
+ * buried in setcookie() and so single-site / non-standard installs can override.
+ *
+ * @return string The cookie domain (e.g. `.extrachill.com`), or '' when no
+ *                 network-root domain can be derived (host-scoped fallback).
+ */
+function extrachill_analytics_visitor_cookie_domain() {
+	$domain = '';
+
+	// 1. Prefer WP's COOKIE_DOMAIN when defined and non-empty. On this network
+	// it is the leading-dot network root already.
+	if ( defined( 'COOKIE_DOMAIN' ) && is_string( COOKIE_DOMAIN ) && '' !== COOKIE_DOMAIN ) {
+		$domain = COOKIE_DOMAIN;
+	} elseif ( function_exists( 'get_network' ) ) {
+		// 2. Multisite-derived: leading dot + network primary domain so the
+		// cookie spans every subdomain.
+		$network = get_network();
+		if ( $network && ! empty( $network->domain ) ) {
+			$network_domain = ltrim( $network->domain, '.' );
+			if ( '' !== $network_domain ) {
+				$domain = '.' . $network_domain;
+			}
+		}
+	}
+
+	/**
+	 * Filter the visitor cookie domain.
+	 *
+	 * @param string $domain Resolved cookie domain (leading-dot network root, or
+	 *                       '' for host-scoped fallback).
+	 */
+	return (string) apply_filters( 'extrachill_analytics_visitor_cookie_domain', $domain );
+}
+
+/**
  * Detect whether the current request signals an opt-out of tracking.
  *
  * Honors Global Privacy Control (`Sec-GPC: 1`) and the legacy Do Not Track
@@ -125,6 +175,9 @@ function extrachill_analytics_get_or_mint_visitor_id() {
 
 	// Set the cookie for ~1 year. Secure + HttpOnly + SameSite=Lax: first-party
 	// analytics only, not readable by JS, not sent on cross-site sub-requests.
+	// Scoped to the network root (leading-dot domain) so ONE visitor id spans
+	// every subdomain on this multisite — without it each subdomain mints its
+	// own id and cross-site retention is unmeasurable.
 	// Guarded against headers_sent() as defense-in-depth; the early
 	// template_redirect hook below is what actually makes this succeed.
 	if ( ! headers_sent() ) {
@@ -134,7 +187,7 @@ function extrachill_analytics_get_or_mint_visitor_id() {
 			array(
 				'expires'  => time() + YEAR_IN_SECONDS,
 				'path'     => '/',
-				'domain'   => '',
+				'domain'   => extrachill_analytics_visitor_cookie_domain(),
 				'secure'   => true,
 				'httponly' => true,
 				'samesite' => 'Lax',


### PR DESCRIPTION
## Root cause

`inc/core/assets.php` minted the `ec_vid` first-party visitor cookie with `domain => ''`. An empty domain is **host-scoped**, so on this **subdomain multisite** the same human gets a brand-new visitor id on every subdomain (`extrachill.com` vs `events.extrachill.com` vs `community.extrachill.com`). Cross-site retention/traversal is therefore structurally unmeasurable.

DB proof: of 3,232 bot-filtered visitors, **0** touch ≥2 blogs — exactly zero — while GA `path_sequence` shows ~121 real crossings. The zero is an artifact of the cookie resetting per host, not real behavior.

## The fix

Scope the cookie to the **network root with a leading dot** (`.extrachill.com`) so ONE id spans every subdomain. The domain is **derived, not hardcoded**, via a new filterable helper `extrachill_analytics_visitor_cookie_domain()`:

1. **`COOKIE_DOMAIN` constant** (used here). On this install it is already defined as `.extrachill.com` — the leading-dot network root, exactly what we need. This is the cleanest source and is the first-choice path.
2. **Multisite fallback** — `.` + `get_network()->domain` (leading dot prefixed to the network primary domain) when `COOKIE_DOMAIN` is undefined/empty. The leading dot is what makes the cookie span subdomains.
3. **Filterable** — the whole resolution is wrapped in `apply_filters( 'extrachill_analytics_visitor_cookie_domain', $domain )`, so the value is never a bare hardcoded literal buried in `setcookie()` and single-site / non-standard installs can override.

### Before / after

| | value | derivation |
|---|---|---|
| before | `'domain' => ''` | bare empty literal → host-scoped |
| after | `'domain' => extrachill_analytics_visitor_cookie_domain()` | resolves to `.extrachill.com` from `COOKIE_DOMAIN` (multisite-derived fallback, filterable) |

All other cookie attributes are unchanged: `expires` 1yr, `path /`, `secure`, `httponly`, `samesite=Lax`.

### Call sites

There is exactly **one** `setcookie` call site for `ec_vid` (the `template_redirect` mint path); a repo-wide `grep` for `setcookie` / `ec_vid` confirms no second standalone render path exists. The footer/outbound paths are read-only (`extrachill_analytics_read_visitor_id()`) and need no change — they read whatever the mint path set. The line ~232 comment about internal hops "already covered by the conversion map" concerns outbound-vs-internal click classification, not the cookie domain, so it remains accurate and is left as-is.

## Migration behavior (young-data caveat)

Existing per-host ids age out over the cookie year. Cross-site metrics will **ramp** as the new network-wide-id cohort accumulates — early post-deploy numbers undercount cross-site traversal until enough visitors carry a network-scoped id. Read cross-site retention as young data for roughly the first cookie cycle.

## Verification

- `php -l inc/core/assets.php` → clean.
- Confirmed on this install: `COOKIE_DOMAIN` = `.extrachill.com`, `get_network()->domain` = `extrachill.com`.
- Read back: resolved domain is the network root with a leading dot; the single setcookie call site uses the resolver; all other attributes unchanged.

closes Extra-Chill/extrachill-analytics#83