### PR TITLE
fix: correct no-op is_bot filter in get-search-gaps (MariaDB JSON-boolean)

### DIFF
--- a/inc/core/abilities/get-search-gaps.php
+++ b/inc/core/abilities/get-search-gaps.php
@@ -114,6 +114,8 @@ function extrachill_analytics_register_search_gaps_ability() {
  *     'zero_result'      => [ ['term' => ..., 'count' => N], ... ],
  *     'low_result'       => [ ['term' => ..., 'count' => N], ... ],  // only when max_results > 0
  *     'total_searches'   => int,   // all human search events in window
+ *     'classified_human' => int,   // subset stamped is_bot:false by the classifier
+ *     'unclassified'     => int,   // subset with NULL/no-flag is_bot (legacy, kept as human)
  *     'zero_result_total'=> int,   // distinct-agnostic count of zero-result human searches
  *     'zero_result_rate' => float, // percentage 0..100
  *     'excluded_bot'     => int,   // search events filtered out as bot/payload
@@ -168,9 +170,25 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 	// Exclude non-human searches flagged at insert time by the canonical
 	// classifier (now stamped on EVERY event in extrachill_track_analytics_event;
 	// see issue #57). The flag is a JSON boolean, so JSON_EXTRACT returns the
-	// literal `true` for bot rows. Rows written before the flag existed have no
-	// key (JSON_EXTRACT → NULL) and COALESCE keeps them as non-bot here.
-	$where[] = "COALESCE(JSON_EXTRACT(event_data, '$.is_bot'), false) = false";
+	// JSON literal `true` for bot rows and `null` (SQL NULL) for legacy rows
+	// written before the flag existed.
+	//
+	// MariaDB CORRECTNESS (issue #85): the previous form,
+	// `COALESCE(JSON_EXTRACT(event_data, '$.is_bot'), false) = false`, was a
+	// NO-OP — it passed confirmed `is_bot:true` rows straight through, inflating
+	// the demand headline ~23x. JSON_EXTRACT returns a *JSON* value, and on this
+	// MariaDB server comparing that JSON value to the SQL boolean `false` via
+	// COALESCE never matched the bot rows. The correct, ternary-aware form is
+	// `IS NOT TRUE`: it excludes rows whose JSON value is `true` while keeping
+	// both explicit `false` AND NULL/no-flag legacy rows (which `IS NOT TRUE`
+	// treats as not-true) as human — exactly the intended behavior.
+	//
+	// Verified live against c8c_extrachill_analytics_events (28d, event_type
+	// 'search', created_at >= 2026-05-30): old predicate 271,548 rows vs new
+	// 241,666 — the 29,883 explicitly-true bots are now dropped, and all 227,175
+	// NULL/no-flag legacy rows are retained. (`CAST('true' AS JSON)` errored on
+	// this server, so it is intentionally avoided.)
+	$where[] = "JSON_EXTRACT(event_data, '$.is_bot') IS NOT TRUE";
 
 	// Defense-in-depth for legacy-contaminated rows. The OLD search rule
 	// (is_bot = ua_bot || (no-cookie && empty-UA)) — the #51 root cause — wrote
@@ -218,6 +236,23 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 	$total_searches = empty( $where_values )
 		? (int) $wpdb->get_var( $total_sql )
 		: (int) $wpdb->get_var( $wpdb->prepare( $total_sql, $where_values ) );
+
+	// Of those human-counted searches, how many are pre-classifier NULL/no-flag
+	// rows kept as human by design vs. explicitly stamped is_bot:false by the
+	// canonical classifier (issue #85). On this install the overwhelming
+	// majority of search traffic is programmatic and predates the classifier, so
+	// most of total_searches is unclassified legacy. Surfacing the split lets a
+	// caller judge how much of the "human" demand read is actually confirmed
+	// human vs. legacy NULL that the old pipeline never stamped — without
+	// changing the (default-off) visitor_id gate.
+	$unclassified_where     = $where;
+	$unclassified_where[]   = "JSON_EXTRACT(event_data, '$.is_bot') IS NULL";
+	$unclassified_clause    = implode( ' AND ', $unclassified_where );
+	$unclassified_sql       = "SELECT COUNT(*) FROM {$table} WHERE {$unclassified_clause}";
+	$unclassified_searches  = empty( $where_values )
+		? (int) $wpdb->get_var( $unclassified_sql )
+		: (int) $wpdb->get_var( $wpdb->prepare( $unclassified_sql, $where_values ) );
+	$classified_human       = max( 0, $total_searches - $unclassified_searches );
 
 	// Grouped gap terms. Each term is bucketed by its BEST result (MIN): a term
 	// is "zero-result" if it ever returned nothing, "low-result" otherwise. The
@@ -307,6 +342,8 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 		'zero_result'          => $zero_result,
 		'zero_result_distinct' => $zero_result_distinct,
 		'total_searches'       => $total_searches,
+		'classified_human'     => $classified_human,
+		'unclassified'         => $unclassified_searches,
 		'zero_result_total'    => $zero_total,
 		'zero_result_rate'     => $zero_result_rate,
 		'excluded_bot'         => $excluded_bot,


### PR DESCRIPTION
## Summary
The primary `is_bot` SQL filter in `get-search-gaps` was a **no-op on MariaDB**: it passed confirmed `is_bot:true` rows straight into the report, inflating the zero-result demand headline ~23x and making the "N bot terms excluded" CLI line read 0. This replaces the broken predicate with a ternary-aware form and (low-risk extra) surfaces the confirmed-human vs legacy-NULL split.

## Root cause (MariaDB JSON-boolean comparison no-op)
`inc/core/abilities/get-search-gaps.php:173`:
```php
$where[] = "COALESCE(JSON_EXTRACT(event_data, '$.is_bot'), false) = false";
```
`JSON_EXTRACT()` returns a *JSON* value. On this MariaDB server, `COALESCE(<json true>, false) = false` does **not** evaluate the way the code assumed — confirmed-bot rows survive the filter. Net effect: zero of the explicitly-stamped bot rows were excluded.

## The fix
```php
$where[] = "JSON_EXTRACT(event_data, '$.is_bot') IS NOT TRUE";
```
Why this is MariaDB-correct: `IS NOT TRUE` is SQL three-valued-logic aware. It excludes rows whose JSON value is `true`, while keeping:
- explicit `is_bot:false` rows (not true → retained), and
- NULL / no-flag legacy rows written before the classifier existed (`JSON_EXTRACT` → SQL NULL, and `NULL IS NOT TRUE` → true → retained).

This preserves the original intent (drop confirmed bots, keep legacy NULLs as human). `CAST('true' AS JSON)` **errored** on this server and is intentionally avoided.

The predicate stays in the shared `$where`, so it trims both the denominator (`total_searches`) and the gap buckets identically — `zero_result_rate` stays honest, and `excluded_bot` / the CLI "N bot terms excluded" line becomes nonzero.

## Live count proof (c8c_extrachill_analytics_events, 28d, event_type='search', created_at >= 2026-05-30)
| predicate | rows counted as human |
|---|---|
| old (broken) `COALESCE(...,false)=false` | **271,548** |
| new `JSON_EXTRACT(...) IS NOT TRUE` | **241,666** |
| delta (now excluded) | **29,882** |

Breakdown verifying behavior:
- explicit `is_bot:true` rows: **29,883** → now **excluded** ✅
- NULL/no-flag rows: **227,175** → all still **retained** (`... IS NULL AND ... IS NOT TRUE` = 227,175) ✅
- explicit `is_bot:false` rows: **14,491** → retained ✅
- retained total: 14,491 + 227,175 = **241,666** ✅ (matches new predicate)

(Counts run live just now; off by ~30 from issue #85's snapshot because the rolling 28d window advanced.)

## NULL/no-flag rows still treated as human
Confirmed above: all 227,175 NULL/no-flag legacy rows survive the new predicate. Behavior for legacy rows is unchanged — only confirmed `is_bot:true` rows are now dropped.

## Also (judgment call — issue #85 "worth deciding")
I did **not** change the `extrachill_analytics_search_gaps_require_visitor_id` gate default (left OFF — flipping it empties the report on this install, per the existing inline tradeoff note). Instead, the low-risk option: the report now returns two new fields so a caller can see the human-confirmed vs legacy-NULL split without any behavior change:
- `classified_human` — searches the canonical classifier explicitly stamped `is_bot:false`
- `unclassified` — NULL/no-flag legacy searches kept as human by design

This is one extra `COUNT(*)` over the same window/$where; it does not alter any existing field or the gate.

## Verification
- `php -l` clean.
- Live DB counts above prove bots are excluded and NULL rows retained.

closes Extra-Chill/extrachill-analytics#85