### PR TITLE
feat: stamp originating search surface on search analytics events

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -29,6 +29,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/event-types.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/events.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/security-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/visitor-classifier.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/search-source-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/content-format-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/outbound-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/mediavine-csv-import.php';

--- a/inc/core/abilities/get-search-gaps.php
+++ b/inc/core/abilities/get-search-gaps.php
@@ -116,6 +116,7 @@ function extrachill_analytics_register_search_gaps_ability() {
  *     'total_searches'   => int,   // all human search events in window
  *     'zero_result_total'=> int,   // distinct-agnostic count of zero-result human searches
  *     'zero_result_rate' => float, // percentage 0..100
+ *     'by_source'        => [ ['source' => 'nav', 'count' => N, 'zero_result_count' => M], ... ], // per-surface split (issue #86)
  *     'excluded_bot'     => int,   // search events filtered out as bot/payload
  *     'max_results'      => int,
  *     'days'             => int,
@@ -154,6 +155,11 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 	// Extract result_count and search_term once; reuse across queries.
 	$result_count_expr = "CAST(JSON_EXTRACT(event_data, '$.result_count') AS SIGNED)";
 	$term_expr         = "JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.search_term'))";
+	// Originating search surface (issue #86), stamped on new rows at write time
+	// (see search-source-classifier.php). Rows written before the field existed
+	// have no key (JSON_EXTRACT → NULL) and surface as 'unknown' in the
+	// breakdown below.
+	$source_expr = "JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.source'))";
 
 	// First-pass SQL bot filter: cheap, deterministic exclusions that don't need
 	// the full regex catalog. Drops absurdly long terms and obvious payload
@@ -245,7 +251,31 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 		? $wpdb->get_results( $gap_sql )
 		: $wpdb->get_results( $wpdb->prepare( $gap_sql, $gap_values ) );
 
+	// Per-source breakdown (issue #86): how the in-window search volume splits
+	// across surfaces (nav / archive / bbpress_forum / unknown), and how many
+	// of each surface's searches returned zero results. Reuses the same $where
+	// (window + blog + length + is_bot) so the breakdown is consistent with the
+	// totals. Rows predating the `source` field bucket as 'unknown'.
+	$zero_for_source = "SUM(CASE WHEN {$result_count_expr} = 0 THEN 1 ELSE 0 END)";
+	$by_source_sql   = "SELECT COALESCE({$source_expr}, 'unknown') AS source, "
+		. "COUNT(*) AS cnt, {$zero_for_source} AS zero_cnt "
+		. "FROM {$table} WHERE {$where_clause} "
+		. 'GROUP BY source ORDER BY cnt DESC';
+
+	$by_source_rows = empty( $where_values )
+		? $wpdb->get_results( $by_source_sql )
+		: $wpdb->get_results( $wpdb->prepare( $by_source_sql, $where_values ) );
+
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	$by_source = array();
+	foreach ( (array) $by_source_rows as $row ) {
+		$by_source[] = array(
+			'source'            => (string) $row->source,
+			'count'             => (int) $row->cnt,
+			'zero_result_count' => (int) $row->zero_cnt,
+		);
+	}
 
 	$zero_result  = array();
 	$low_result   = array();
@@ -309,6 +339,7 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 		'total_searches'       => $total_searches,
 		'zero_result_total'    => $zero_total,
 		'zero_result_rate'     => $zero_result_rate,
+		'by_source'            => $by_source,
 		'excluded_bot'         => $excluded_bot,
 		'max_results'          => $max_results,
 		'days'                 => $days,

--- a/inc/core/events.php
+++ b/inc/core/events.php
@@ -74,6 +74,24 @@ function extrachill_track_analytics_event( $event_type, $event_data = array(), $
 		$event_data['is_bot'] = (bool) $verdict['is_bot'];
 	}
 
+	// Stamp the originating search SURFACE on every `search` event at write
+	// time so downstream readers can tell a nav/header search from an
+	// archive/results-page refinement from the bbPress in-forum search (issue
+	// #86). Like the is_bot stamp above, this is derived server-side from the
+	// request context the search write already has — the source_url on the
+	// payload plus the live request URI/query vars — so EVERY new search row
+	// carries a `source` without any cross-plugin capture change. Only stamped
+	// for `search` events, only when the caller hasn't already supplied an
+	// explicit source (a future upstream caller threading its own surface
+	// still wins), and only when the classifier is loaded.
+	if ( 'search' === $event_type
+		&& is_array( $event_data )
+		&& ! array_key_exists( 'source', $event_data )
+		&& function_exists( 'extrachill_analytics_classify_search_source' )
+	) {
+		$event_data['source'] = extrachill_analytics_classify_search_source( $source_url );
+	}
+
 	$result = $wpdb->insert(
 		$table_name,
 		array(

--- a/inc/core/search-source-classifier.php
+++ b/inc/core/search-source-classifier.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Search Source (Surface) Classifier
+ *
+ * Owns the ONE place that decides which search SURFACE fired a `search`
+ * analytics event — the nav/header box, an archive/results-page search box,
+ * the bbPress in-forum search, etc. The verdict is a stable, low-cardinality
+ * identifier stamped into `event_data` under the `source` key at write time
+ * (see extrachill_track_analytics_event() in events.php), mirroring how the
+ * canonical human/bot `is_bot` flag is stamped on every event.
+ *
+ * WHY STAMP AT WRITE TIME (not at the upstream capture site)
+ * ----------------------------------------------------------
+ * Every `search` event currently flows through a single capture listener in
+ * the extrachill-search plugin (extrachill_search_performed →
+ * track_search_analytics), which lives OUTSIDE this plugin. Threading an
+ * explicit `source` through that caller is the cleanest long-term shape, but
+ * it cannot be done from this plugin without editing extrachill-search. By
+ * deriving the surface here — from the request context the search write
+ * already has (the `source_url` on the payload, the current request host and
+ * URI, and the bbPress `bbp_search` query var) — EVERY new `search` event
+ * carries a `source` going forward regardless of which surface fired it, with
+ * no cross-plugin change required. Callers that already know their surface can
+ * still pass an explicit `event_data['source']`; that always wins.
+ *
+ * The identifiers are intentionally low-cardinality so get-search-gaps and
+ * other readers can GROUP BY them cleanly:
+ *   - `nav`           — search box on a normal (non-results) page: the
+ *                       homepage / header / nav search. The dominant surface
+ *                       (e.g. source_url is a bare site root).
+ *   - `archive`       — search fired from a search-results / archive / paged
+ *                       listing page (source_url carries ?s= / &s= / /search/
+ *                       / /page/). The user refined a query from a results
+ *                       page.
+ *   - `bbpress_forum` — community in-forum bbPress search (the request carries
+ *                       the `bbp_search` query var).
+ *   - `unknown`       — no usable signal. Field is still present (never NULL on
+ *                       new rows) so readers get one consistent shape.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.21.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Classify which search surface fired a `search` event.
+ *
+ * Pure given its inputs: pass an explicit `$source_url` and (optionally) the
+ * request URI so the function is testable without a live request. When
+ * `$request_uri` is null it reads `$_SERVER['REQUEST_URI']` (read-only).
+ *
+ * @param string      $source_url  The page the user was on before searching
+ *                                 (the `source_url` already attached to the
+ *                                 search event). May be empty.
+ * @param string|null $request_uri Optional request URI override for testing.
+ *                                 Defaults to the live request URI.
+ * @return string One of: 'nav', 'archive', 'bbpress_forum', 'unknown'.
+ */
+function extrachill_analytics_classify_search_source( $source_url = '', $request_uri = null ) {
+	$source_url = (string) $source_url;
+
+	if ( null === $request_uri ) {
+		$request_uri = isset( $_SERVER['REQUEST_URI'] )
+			? (string) wp_unslash( $_SERVER['REQUEST_URI'] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+			: '';
+	}
+
+	// bbPress in-forum search: the strongest, most specific signal. The forum
+	// filter-bar search submits a `bbp_search` query var, so when it's present
+	// on the live request the search originated in the community forum search
+	// box rather than the network nav/results search.
+	if ( ! empty( $_GET['bbp_search'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return 'bbpress_forum';
+	}
+	if ( '' !== $request_uri && false !== stripos( $request_uri, 'bbp_search' ) ) {
+		return 'bbpress_forum';
+	}
+
+	// Beyond bbPress, the originating surface is read off the source_url — the
+	// page the user submitted the search FROM. With no source_url there is no
+	// signal to distinguish surfaces.
+	if ( '' === trim( $source_url ) ) {
+		return 'unknown';
+	}
+
+	// A search submitted FROM a results/archive/paged page is a refinement on
+	// an existing results view, not a fresh nav search. Detect the canonical
+	// search/archive markers in the originating URL.
+	if ( extrachill_analytics_url_is_search_surface( $source_url ) ) {
+		return 'archive';
+	}
+
+	// Otherwise the search was launched from a normal content page — the
+	// header/nav search box. This is the dominant human-search surface.
+	return 'nav';
+}
+
+/**
+ * Whether a URL looks like a search-results / archive / paged listing page.
+ *
+ * Used to distinguish an `archive` refinement search (submitted from a results
+ * page) from a `nav` search (submitted from a normal content page).
+ *
+ * @param string $url Candidate URL (typically the search event's source_url).
+ * @return bool True when the URL carries search/archive/pagination markers.
+ */
+function extrachill_analytics_url_is_search_surface( $url ) {
+	$url = (string) $url;
+	if ( '' === $url ) {
+		return false;
+	}
+
+	// Pretty + query-string search markers and core pagination. `/search/` is
+	// the network search permalink base; `s=` is the core search query var;
+	// `/page/N` and `paged=` are core pagination that only appears on listing
+	// (archive / search-results) views.
+	$needles = array(
+		'/search/',
+		'?s=',
+		'&s=',
+		'/page/',
+		'?paged=',
+		'&paged=',
+	);
+
+	foreach ( $needles as $needle ) {
+		if ( false !== stripos( $url, $needle ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}


### PR DESCRIPTION
## Summary

`search` analytics events did not record which search **surface** fired them. `source_url` is populated on only ~17% of search events and is empty on the high-signal community zero-result rows, and `event_data` carried `search_term` / `result_count` / `is_bot` but no surface field. This blocked acting on search-gaps: we could not tell whether a dead-end search happened in the nav/header search vs the bbPress in-forum search vs an archive/results-page search.

This PR adds a low-cardinality **`source`** field to every `search` event, stamped server-side at write time, plus a per-surface breakdown in `get-search-gaps`.

## Where search events are captured (the map)

All `search` analytics events flow through a **single** capture path:

- **`extrachill-search`** (`extrachill-search.php` → `track_search_analytics`, hooked on `extrachill_search_performed`) is the only thing that writes `event_type='search'`. The action fires from `extrachill_multisite_search()` in `inc/core/search-algorithm.php`. This covers the **main-site search results page** and any **nav/header search** that routes through multisite search. The existing `source_url` is captured from a JS-injected `source_page` field (`inject_search_source_tracking`), which is why `source_url` is sparsely populated — it only lands when that hidden field is present.
- **bbPress in-forum search** (`bbp_search` query var, see `extrachill-community/inc/core/filter-bar.php`) uses bbPress's native search and does **not** currently fire `extrachill_search_performed`, so it is **not captured as a `search` event at all today** — a separate capture gap (see follow-up).
- No other plugin/theme writes `event_type='search'`.

**The capture site (`extrachill-search`) is outside this worktree.** Per the issue's hard constraint, this PR only edits `extrachill-analytics`.

## The fix

Field name chosen: **`source`** (the issue's preferred name; mirrors how the newsletter `integration` context names its sources). Stable, low-cardinality identifiers:

- `nav` — search submitted from a normal (non-results) page: the homepage / header / nav search box (the dominant surface; e.g. `source_url` is a bare site root).
- `archive` — search submitted from a search-results / archive / paged listing page (`source_url` carries `?s=` / `&s=` / `/search/` / `/page/` / `paged=`).
- `bbpress_forum` — community in-forum bbPress search (request carries the `bbp_search` query var).
- `unknown` — no usable signal (field is always present on new rows, never NULL, so readers get one consistent shape).

**How it threads through:** rather than editing the out-of-worktree capture site, the surface is **derived server-side at write time inside `extrachill_track_analytics_event()`**, mirroring exactly how the canonical `is_bot` flag is already stamped on every event. A new `inc/core/search-source-classifier.php` owns the one classification function, fed by the request context the search write already has (the `source_url` on the payload + the live request URI / `bbp_search` query var). This guarantees **every new `search` event carries a `source`** regardless of which surface fired it, with **no cross-plugin change required**.

- Only stamped for `event_type='search'`.
- Only when the caller hasn't already supplied an explicit `event_data['source']` — a future upstream caller threading its own surface always wins (same "caller wins" rule as `is_bot`).
- Purely additive: old rows simply lack the key (NULL) and bucket as `unknown` in readers.

**Bonus:** `get-search-gaps` now returns a `by_source` array (`{source, count, zero_result_count}` per surface), reusing the same window/blog/is_bot WHERE so the split is consistent with the totals.

## How a new search from each surface now carries `source`

Verified the classifier against real `source_url` values from the live events table:

| source_url (observed) | classified |
|---|---|
| `https://community.extrachill.com` | `nav` |
| `https://extrachill.com/` | `nav` |
| `https://extrachill.com/page/2/` | `archive` |
| `https://extrachill.com/search/the/` | `archive` |
| `https://community.extrachill.com/?sort=recent&s=Palace+hotel` | `archive` |
| `https://extrachill.com/{post-slug}/` | `nav` |
| (empty) | `unknown` |
| request with `bbp_search` query var | `bbpress_forum` |

Also verified the write-path stamping mutates the payload (`{"search_term":...,"result_count":0,"source":"nav"}`) and that an explicit caller-supplied `source` is preserved. The new `by_source` SQL runs cleanly against the live table (all existing rows bucket `unknown`, as expected for an additive field).

## Instrumented vs follow-up

- **Now instrumented (this PR):** every `search` event written through `extrachill_track_analytics_event` — i.e. all current `search` capture (nav + archive surfaces), classified at write time.
- **Follow-up (outside this worktree):**
  1. **bbPress in-forum search is not captured as a `search` event today.** Capturing it (firing an analytics event from the `bbp_search` path in `extrachill-community`) is a separate capture change. Once captured, this PR's classifier already routes it to `bbpress_forum` via the `bbp_search` query var.
  2. **Optional cleanup:** thread an explicit `source` from the `extrachill-search` capture listener (and any future capture sites) so the value comes from the caller that knows its surface rather than being inferred. The "caller wins" guard here already accommodates that with zero churn.

## Verification

- `php -l` clean on all changed files.
- Classifier + write-path stamping + caller-wins verified via `wp eval` against live `source_url` data.
- `by_source` aggregation SQL validated read-only against the live events table.

## Files

- `inc/core/search-source-classifier.php` (new) — owns the surface classification.
- `inc/core/events.php` — stamp `source` on `search` events at write time (next to the `is_bot` stamp).
- `inc/core/abilities/get-search-gaps.php` — add `by_source` breakdown.
- `extrachill-analytics.php` — load the new classifier.

closes Extra-Chill/extrachill-analytics#86