### PR TITLE
feat: capture normalized referrer_host on pageview events

### DIFF
--- a/assets/js/view-tracking.js
+++ b/assets/js/view-tracking.js
@@ -13,6 +13,16 @@
 		payload.visitor_id = config.visitorId;
 	}
 
+	// Capture the TRUE referrer client-side. This beacon fires after page load,
+	// so the request's own HTTP Referer header is this article page itself —
+	// document.referrer is the only place the page the reader navigated FROM is
+	// available. The server normalizes it to a host-only `referrer_host` (no
+	// query strings, no PII) and drops direct/same-host referrers. Empty for
+	// direct traffic.
+	if ( document.referrer ) {
+		payload.referrer = document.referrer;
+	}
+
 	var data = JSON.stringify( payload );
 
 	if ( navigator.sendBeacon ) {

--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -30,6 +30,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/events.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/security-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/visitor-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/search-source-classifier.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/referrer-host-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/content-format-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/outbound-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/mediavine-csv-import.php';

--- a/inc/core/abilities/get-retention-stats.php
+++ b/inc/core/abilities/get-retention-stats.php
@@ -37,7 +37,7 @@ function extrachill_analytics_register_retention_stats_ability() {
 		'extrachill/get-retention-stats',
 		array(
 			'label'               => __( 'Get Retention Stats', 'extrachill-analytics' ),
-			'description'         => __( 'Returns deterministic, bot-filtered visitor-retention metrics (return rate, cohort retention, cross-site return, session depth) from first-party pageview events.', 'extrachill-analytics' ),
+			'description'         => __( 'Returns deterministic, bot-filtered visitor-retention metrics (return rate, cohort retention, cross-site return, session depth) plus a cross-surface referrer-host breakdown from first-party pageview events.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -245,6 +245,47 @@ function extrachill_analytics_ability_get_retention_stats( $input ) {
 	$avg_depth = $depth_row && null !== $depth_row->avg_depth ? round( (float) $depth_row->avg_depth, 2 ) : 0.0;
 	$max_depth = $depth_row ? (int) $depth_row->max_depth : 0;
 
+	// ---------------------------------------------------------------------
+	// (e) Referrer-host breakdown: top cross-surface origins that SENT readers
+	// to a pageview in the window (AI-citation / social / search / cross-
+	// subdomain landing attribution). Stamped onto new pageview rows as the
+	// normalized, host-only `referrer_host` (issue #90). Unlike the per-visitor
+	// metrics above this counts ALL pageviews (including anonymous/opted-out)
+	// since referrer provenance is meaningful regardless of visitor_id, and only
+	// rows that actually carry a referrer_host participate (direct + same-host
+	// traffic omit the field). Old rows predating the field simply don't appear.
+	// ---------------------------------------------------------------------
+	$ref_where  = array( 'event_type = %s', 'created_at >= %s', "JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.referrer_host')) IS NOT NULL" );
+	$ref_values = array( $event_type, $since );
+	if ( $end_days_ago > 0 ) {
+		$ref_where[]  = 'created_at < %s';
+		$ref_values[] = $window_end;
+	}
+	if ( $blog_id > 0 ) {
+		$ref_where[]  = 'blog_id = %d';
+		$ref_values[] = $blog_id;
+	}
+	$ref_where_clause = implode( ' AND ', $ref_where );
+
+	$ref_sql = "SELECT
+			JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.referrer_host')) AS referrer_host,
+			COUNT(*) AS landings
+		FROM {$table}
+		WHERE {$ref_where_clause}
+		GROUP BY referrer_host
+		ORDER BY landings DESC
+		LIMIT 25";
+
+	$ref_rows = $wpdb->get_results( $wpdb->prepare( $ref_sql, $ref_values ) );
+
+	$by_referrer_host = array();
+	foreach ( (array) $ref_rows as $row ) {
+		$by_referrer_host[] = array(
+			'referrer_host' => (string) $row->referrer_host,
+			'landings'      => (int) $row->landings,
+		);
+	}
+
 	return array(
 		'return_rate'       => array(
 			'total_visitors'     => $total_visitors,
@@ -267,6 +308,10 @@ function extrachill_analytics_ability_get_retention_stats( $input ) {
 			'avg_pageviews_per_visitor_day' => $avg_depth,
 			'max_pageviews_per_visitor_day' => $max_depth,
 			'definition'                    => 'Average (and max) pageview events per visitor per active UTC day.',
+		),
+		'by_referrer_host'  => array(
+			'hosts'      => $by_referrer_host,
+			'definition' => 'Top cross-surface referrer hosts (host-only, no query strings/PII) that sent readers to a pageview in the window — AI-citation (chatgpt.com / perplexity.ai), social, search engines, and cross-subdomain landings. Counts ALL pageviews carrying a referrer_host (not just identified visitors); direct + same-host traffic omit the field, and rows predating issue #90 do not appear.',
 		),
 		'days'              => $days,
 		'end_days_ago'      => $end_days_ago,

--- a/inc/core/abilities/track-page-view.php
+++ b/inc/core/abilities/track-page-view.php
@@ -34,6 +34,11 @@ function extrachill_analytics_register_track_page_view_ability(): void {
 						'description' => __( 'Optional anonymous first-party visitor UUID v4. Stored on the pageview event only if well-formed; never PII. Empty when the visitor opted out (GPC/DNT).', 'extrachill-analytics' ),
 						'default'     => '',
 					),
+					'referrer'   => array(
+						'type'        => 'string',
+						'description' => __( 'Optional raw client-side referrer (document.referrer). Normalized server-side to a host-only `referrer_host` (no query strings, no PII) on the pageview event. Empty for direct traffic.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
 				),
 				'required'   => array( 'post_id' ),
 			),
@@ -61,7 +66,9 @@ function extrachill_analytics_register_track_page_view_ability(): void {
  * Mirrors the existing REST handler: quick post-meta increment,
  * plus link-page daily-table action when applicable. Additionally writes a
  * `pageview` event row to the network-wide events table (carrying the
- * anonymous visitor_id when present) so per-visitor retention history exists.
+ * anonymous visitor_id when present, plus a normalized `referrer_host` when the
+ * reader arrived from a different surface) so per-visitor retention history and
+ * cross-surface / AI-citation landing attribution exist.
  * The post-meta bump is retained for back-compat with the theme view counter.
  *
  * @param array $input Input parameters.
@@ -70,6 +77,7 @@ function extrachill_analytics_register_track_page_view_ability(): void {
 function extrachill_analytics_ability_track_page_view( array $input ) {
 	$post_id    = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
 	$visitor_id = isset( $input['visitor_id'] ) ? (string) $input['visitor_id'] : '';
+	$referrer   = isset( $input['referrer'] ) ? (string) $input['referrer'] : '';
 
 	if ( $post_id <= 0 ) {
 		return new \WP_Error(
@@ -111,10 +119,30 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 		&& 'browser' !== extrachill_analytics_classify_user_agent( $user_agent );
 
 	if ( ! $is_bot && function_exists( 'extrachill_track_analytics_event' ) ) {
-		$permalink = get_permalink( $post_id );
+		$permalink  = get_permalink( $post_id );
+		$event_data = array( 'post_id' => $post_id );
+
+		// Stamp a NORMALIZED, host-only referrer provenance on the pageview so
+		// AI-citation (chatgpt.com / perplexity.ai / gemini.google.com), social,
+		// search-engine, and cross-surface landing attribution is no longer
+		// blind. The raw referrer MUST come from the client (document.referrer):
+		// this beacon fires after page load, so the request's own HTTP Referer
+		// is the article page itself, not the page the reader came from. We
+		// reduce it to a host only — no query strings, no PII — and drop direct
+		// + same-host referrers so the field means "a different surface sent
+		// this reader here". Additive + backward-compatible: old rows simply
+		// lack the field. Mirrors the #86 search-source stamping shape (capture
+		// provenance at event time) and the 404 tracker's referer capture.
+		if ( function_exists( 'extrachill_analytics_normalize_referrer_host' ) ) {
+			$referrer_host = extrachill_analytics_normalize_referrer_host( $referrer );
+			if ( '' !== $referrer_host ) {
+				$event_data['referrer_host'] = $referrer_host;
+			}
+		}
+
 		extrachill_track_analytics_event(
 			defined( 'EC_ANALYTICS_EVENT_PAGEVIEW' ) ? EC_ANALYTICS_EVENT_PAGEVIEW : 'pageview',
-			array( 'post_id' => $post_id ),
+			$event_data,
 			is_string( $permalink ) ? $permalink : '',
 			$visitor_id
 		);

--- a/inc/core/referrer-host-classifier.php
+++ b/inc/core/referrer-host-classifier.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Referrer Host Classifier
+ *
+ * Owns the ONE place that normalizes a raw referrer URL into a stable,
+ * low-cardinality `referrer_host` — just the host (e.g. `chatgpt.com`,
+ * `facebook.com`, `community.extrachill.com`), never the full URL with query
+ * strings. The verdict is stamped into a `pageview` event's `event_data` under
+ * the `referrer_host` key at write time (see the track-page-view ability),
+ * mirroring how the search SURFACE `source` (issue #86) and the canonical
+ * human/bot `is_bot` flag are stamped on events.
+ *
+ * WHY HOST-ONLY (not the full referrer URL)
+ * -----------------------------------------
+ * The full referrer URL carries query strings that can leak PII (search terms,
+ * session tokens, email addresses in `?email=` links, etc.) and explodes
+ * cardinality so no reader can GROUP BY it cleanly. The host alone answers the
+ * question the field exists to answer — "what surface SENT this reader here?"
+ * (an AI engine like chatgpt.com / perplexity.ai, a social network, a search
+ * engine, another network subdomain) — with zero PII and tiny cardinality.
+ *
+ * WHY THE RAW REFERRER COMES FROM THE CLIENT
+ * ------------------------------------------
+ * The pageview fires via a deferred `sendBeacon` AFTER page load, so the
+ * beacon request's own HTTP `Referer` header is the article page itself, NOT
+ * the page the reader navigated FROM. `wp_get_referer()` would therefore
+ * mis-attribute every pageview to its own URL. The TRUE referrer is only
+ * available client-side as `document.referrer`, which the view-tracking beacon
+ * threads into the `referrer` input. This classifier reduces that raw URL to a
+ * host server-side at write time.
+ *
+ * Direct traffic (empty referrer) and same-host referrers (in-page reloads /
+ * intra-page nav that the browser still reports) collapse to '' so the field
+ * is only present when there is a meaningful cross-host provenance signal.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.22.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalize a raw referrer URL into a low-cardinality host.
+ *
+ * Pure given its inputs: pass the raw referrer (typically `document.referrer`
+ * from the beacon) and optionally the current request host so the function is
+ * testable without a live request. When `$current_host` is null it reads the
+ * live request host (read-only).
+ *
+ * @param string      $raw_referrer The raw referrer URL (e.g. document.referrer).
+ *                                  May be empty (direct traffic).
+ * @param string|null $current_host Optional current host override for testing.
+ *                                  Defaults to the live request host.
+ * @return string The normalized referrer host (e.g. `chatgpt.com`), or '' for
+ *                direct traffic, same-host referrers, or an unparseable URL.
+ */
+function extrachill_analytics_normalize_referrer_host( $raw_referrer, $current_host = null ) {
+	$raw_referrer = trim( (string) $raw_referrer );
+
+	// Direct traffic (no referrer) — nothing to attribute. Omit the field.
+	if ( '' === $raw_referrer ) {
+		return '';
+	}
+
+	// Extract the host component only. wp_parse_url() is the canonical, safe
+	// URL parser; a referrer without a host (e.g. a bare path the browser
+	// reported, or a malformed value) yields no usable provenance signal.
+	$host = wp_parse_url( $raw_referrer, PHP_URL_HOST );
+	if ( ! is_string( $host ) || '' === $host ) {
+		return '';
+	}
+
+	// Lowercase + strip a leading `www.` so `www.facebook.com` and
+	// `facebook.com` collapse to one bucket, keeping cardinality low.
+	$host = strtolower( $host );
+	if ( 0 === strpos( $host, 'www.' ) ) {
+		$host = substr( $host, 4 );
+	}
+
+	// Same-host referrers carry no cross-surface signal (an in-page reload or
+	// intra-page navigation the browser still reports as a referrer). Drop them
+	// so the field means "a DIFFERENT surface sent this reader here". The
+	// current request host is resolved the same way for an apples-to-apples
+	// comparison.
+	if ( null === $current_host ) {
+		$current_host = isset( $_SERVER['HTTP_HOST'] )
+			? (string) wp_unslash( $_SERVER['HTTP_HOST'] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+			: '';
+	}
+	$current_host = strtolower( trim( (string) $current_host ) );
+	if ( 0 === strpos( $current_host, 'www.' ) ) {
+		$current_host = substr( $current_host, 4 );
+	}
+
+	if ( '' !== $current_host && $host === $current_host ) {
+		return '';
+	}
+
+	return $host;
+}


### PR DESCRIPTION
## Summary

`pageview` events were blind to where a reader arrived FROM, so AI-citation / social / cross-surface landing attribution could not be measured. Ironically `404_error` events already capture the referer (`404-tracking.php:46`). This PR captures a **normalized, host-only `referrer_host`** on every new pageview going forward.

closes Extra-Chill/extrachill-analytics#90

## The capture path (and why the referrer must come from the client)

The pageview fires via a **deferred `sendBeacon` AFTER page load**, from the article page itself. That means:

- `wp_get_referer()` / the beacon request's own HTTP `Referer` header is the **article page itself**, NOT the page the reader navigated FROM. Using it would mis-attribute every pageview to its own URL.
- The TRUE referrer is only available **client-side** as `document.referrer` — the page the user came from.

So the flow is:

1. **`assets/js/view-tracking.js`** — threads `document.referrer` into the beacon JSON payload as `referrer` (omitted for direct traffic).
2. **`track-page-view` ability** (`inc/core/abilities/track-page-view.php`) — accepts a new optional `referrer` input (Abilities API maps the JSON body key → input schema property), then normalizes it and stamps `referrer_host` into the pageview `event_data` (only when non-empty).
3. **`inc/core/referrer-host-classifier.php`** (new) — `extrachill_analytics_normalize_referrer_host()` reduces the raw referrer to a host only.

## The normalized `referrer_host` field (host-only, no PII)

`extrachill_analytics_normalize_referrer_host()`:

- Extracts **only the host** via `wp_parse_url()` — drops path + query strings, so PII like `?q=secret+search+term`, `?email=...`, session tokens never land in analytics, and cardinality stays low for clean `GROUP BY`.
- Lowercases and strips a leading `www.` so `www.facebook.com` and `facebook.com` collapse to one bucket.
- Drops **direct** (empty referrer) and **same-host** referrers (in-page reloads the browser still reports) → returns `''`, and the ability omits the field entirely. So the field means *"a different surface sent this reader here."*

Simulated output (proves the path):

| `document.referrer` | `referrer_host` |
|---|---|
| `https://chatgpt.com/c/abc123?q=secret+query` | `chatgpt.com` |
| `https://www.facebook.com/` | `facebook.com` |
| `https://www.google.com/search?q=live+music+charleston` | `google.com` |
| `https://perplexity.ai/search/foo` | `perplexity.ai` |
| `https://community.extrachill.com/forums/x` | `community.extrachill.com` (cross-subdomain kept) |
| `https://extrachill.com/some-article/` (same host) | *(omitted)* |
| `` (direct) | *(omitted)* |
| `not a url` | *(omitted)* |

A new pageview from a ChatGPT citation therefore writes `event_data = { post_id, is_bot, referrer_host: "chatgpt.com" }`.

## Mirrors the #86 search-source pattern

This follows the same shape as the search SOURCE field shipped in #88 (issue #86): capture provenance at event time into a stable, low-cardinality `event_data` key, derived from a single dedicated classifier file, additive and backward-compatible. The one deliberate difference: the raw signal is captured client-side (`document.referrer`) rather than server-side, because — unlike the search `source_url` — the server has no access to the true referrer on a post-load beacon. It also mirrors `404-tracking.php`'s existing referer capture.

## Backward compatibility

Purely additive. Old pageview rows simply lack `referrer_host` (fine). No schema migration — `event_data` is JSON.

## Bonus read

`get-retention-stats` gains a `by_referrer_host` block: top cross-surface origins (AI engines, social, search, cross-subdomain) that sent readers to a pageview in the window. Counts ALL pageviews carrying the field (not just identified visitors, since referrer provenance is meaningful regardless of `visitor_id`); direct/same-host omit the field and pre-#90 rows don't appear.

## Verification

- `php -l` clean on all modified files.
- Normalizer logic simulated end-to-end (table above).