### PR TITLE
feat: relax reporting-ability gates to team-readable tier

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -38,6 +38,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/gtm.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/reports-permission.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-analytics-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-analytics-meta.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-404-summary.php';

--- a/inc/core/abilities/get-analytics-meta.php
+++ b/inc/core/abilities/get-analytics-meta.php
@@ -30,9 +30,7 @@ function extrachill_analytics_register_meta_ability() {
 				'description' => __( 'Object with event_types (string array) and blogs (array of {id, name}).', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_meta',
-			'permission_callback' => function () {
-				return current_user_can( 'manage_network_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
-			},
+			'permission_callback' => 'extrachill_analytics_can_read_reports',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(

--- a/inc/core/abilities/get-analytics-summary.php
+++ b/inc/core/abilities/get-analytics-summary.php
@@ -46,9 +46,7 @@ function extrachill_analytics_register_summary_ability() {
 				'description' => __( 'Summary with event_types array and total count.', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_summary',
-			'permission_callback' => function () {
-				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
-			},
+			'permission_callback' => 'extrachill_analytics_can_read_reports',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(

--- a/inc/core/abilities/get-conversion-map.php
+++ b/inc/core/abilities/get-conversion-map.php
@@ -104,9 +104,7 @@ function extrachill_analytics_register_conversion_map_ability() {
 				'description' => __( 'Object with overall conversion, per-article ranking, per-category ranking, and the exact UTC window.', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_conversion_map',
-			'permission_callback' => function () {
-				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
-			},
+			'permission_callback' => 'extrachill_analytics_can_read_reports',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(

--- a/inc/core/abilities/get-retention-stats.php
+++ b/inc/core/abilities/get-retention-stats.php
@@ -69,9 +69,7 @@ function extrachill_analytics_register_retention_stats_ability() {
 				'description' => __( 'Object with return_rate, cohort_retention, cross_site_return, session_depth, and the exact UTC window.', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_retention_stats',
-			'permission_callback' => function () {
-				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
-			},
+			'permission_callback' => 'extrachill_analytics_can_read_reports',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(

--- a/inc/core/abilities/get-surface-growth.php
+++ b/inc/core/abilities/get-surface-growth.php
@@ -80,9 +80,7 @@ function extrachill_analytics_register_surface_growth_ability() {
 				'description' => __( 'Object with per-surface supply + demand growth, a normalized comparable figure per surface, and a ranked fastest-growing surface, plus the exact UTC window.', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_surface_growth',
-			'permission_callback' => function () {
-				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
-			},
+			'permission_callback' => 'extrachill_analytics_can_read_reports',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(

--- a/inc/core/abilities/reports-permission.php
+++ b/inc/core/abilities/reports-permission.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Reporting-ability permission policy
+ *
+ * Single home for the read-permission policy shared by the team-readable
+ * reporting abilities (traffic, growth, retention, top content, conversion).
+ * Centralizing the cap check here means the tiered policy lives in ONE place
+ * instead of being copy-pasted into each ability's inline permission_callback.
+ *
+ * TIERED POLICY (settled product decision, see issue #92):
+ *   - Team-readable: traffic, growth, retention, top content, conversion. These
+ *     abilities use this helper and are readable by the broader extra_chill_team
+ *     role (the `access_studio` cap) in addition to network/site admins and
+ *     WP-CLI, so the Studio "Network" tab can render for the whole team.
+ *   - Admin-only (unchanged): revenue (Mediavine), attack/scanner summaries,
+ *     PHP error summaries, destructive purges. Those abilities keep their own
+ *     manage_options gate and must NOT call this helper.
+ *
+ * Uses the `access_studio` cap directly — the underlying cap behind
+ * ec_is_team_member() — to avoid a cross-plugin function dependency.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.23.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Whether the current actor may read team-readable analytics reports.
+ *
+ * True for network/site admins (manage_options), team members (access_studio,
+ * granted by the extra_chill_team role), and WP-CLI. The cap policy for the
+ * team-readable reporting tier lives here so it is defined once.
+ *
+ * @return bool
+ */
+function extrachill_analytics_can_read_reports() {
+	return current_user_can( 'manage_options' )
+		|| current_user_can( 'access_studio' )
+		|| ( defined( 'WP_CLI' ) && WP_CLI );
+}


### PR DESCRIPTION
## Summary

The **ability-layer** half of analytics #92. Relaxes the five in-scope reporting abilities from their admin-only gate to the **team-readable tier** so the Studio "Network" tab can render for the whole `extra_chill_team`, not just network admins.

- New `extrachill_analytics_can_read_reports()` helper (`inc/core/abilities/reports-permission.php`) is the single home for the team-readable permission policy — `manage_options` **or** `access_studio` (the cap behind `ec_is_team_member()`, granted by the `extra_chill_team` role) **or** WP-CLI. Checked directly to avoid a cross-plugin function dependency.
- Points the `permission_callback` of these abilities at the helper:
  - `extrachill/get-analytics-summary`
  - `extrachill/get-retention-stats`
  - `extrachill/get-surface-growth`
  - `extrachill/get-analytics-meta` (was `manage_network_options`)
  - `extrachill/get-conversion-map`
- Helper is `require`d before the abilities that use it in the plugin loader.

## Tiered policy (settled)

- **Team-readable** (relaxed here): traffic, growth, retention, top content, conversion.
- **Admin-only** (intentionally untouched): revenue (Mediavine), attack/scanner summaries, PHP-error summaries, destructive purges — these keep their own `manage_options` gate and do **not** use the helper.

## Paired PR

The **REST-layer** half lives in extrachill-api (the routes don't live in this repo): Extra-Chill/extrachill-api#PLACEHOLDER_API_PR — both gates must allow `access_studio` or team users are blocked before the ability runs.

## Verify

- `php -l` clean on all changed files.
- phpcs vendor not installed in this checkout (pre-existing); changed files follow existing WordPress-standard style. No new lint introduced.

Refs #92