### PR TITLE
feat: own the shared Chart.js asset (network-activated charting handle)

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -225,6 +225,63 @@ function extrachill_analytics_prime_visitor_cookie() {
 add_action( 'template_redirect', 'extrachill_analytics_prime_visitor_cookie' );
 
 /**
+ * Script handle for the shared, network-activated Chart.js v4 asset.
+ *
+ * extrachill-analytics is network-activated, so registering Chart.js once here
+ * makes a single guaranteed-present copy available to every consumer on the
+ * network — instead of each plugin re-bundling its own. Consumers (artist-
+ * platform link-page analytics, the Mediavine revenue ARC, the Studio Network
+ * tab) declare this handle as a script dependency and webpack-externalize their
+ * `chart.js` import to the exposed global. See extrachill-analytics#93.
+ */
+const EXTRACHILL_ANALYTICS_CHART_HANDLE = 'extrachill-analytics-chart';
+
+/**
+ * Register (do NOT enqueue) the shared Chart.js v4 script handle.
+ *
+ * Registering — rather than unconditionally enqueuing — means the asset loads
+ * only where a consumer actually declares it as a dependency, on both the front
+ * end and in the admin. The built bundle (`build/chart.js`, entry `src/chart.js`)
+ * exposes the full Chart.js v4 module namespace on `window.ExtraChillChart`; its
+ * `default` / `.Chart` members are the auto-registered Chart constructor.
+ *
+ * Downstream webpack consumers map their `chart.js` (and `chart.js/auto`) import
+ * to the `ExtraChillChart` external and add `extrachill-analytics-chart` to
+ * their script dependencies, e.g.:
+ *
+ *   externals: { 'chart.js': 'ExtraChillChart', 'chart.js/auto': 'ExtraChillChart' }
+ *
+ * @return bool True when the handle was registered, false when the build asset
+ *               is missing (e.g. plugin shipped without a build).
+ */
+function extrachill_analytics_register_chart_asset() {
+	if ( wp_script_is( EXTRACHILL_ANALYTICS_CHART_HANDLE, 'registered' ) ) {
+		return true;
+	}
+
+	$asset_file = EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'build/chart.asset.php';
+	if ( ! file_exists( $asset_file ) ) {
+		return false;
+	}
+
+	$asset = require $asset_file;
+
+	wp_register_script(
+		EXTRACHILL_ANALYTICS_CHART_HANDLE,
+		EXTRACHILL_ANALYTICS_PLUGIN_URL . 'build/chart.js',
+		isset( $asset['dependencies'] ) ? $asset['dependencies'] : array(),
+		isset( $asset['version'] ) ? $asset['version'] : EXTRACHILL_ANALYTICS_VERSION,
+		true
+	);
+
+	return true;
+}
+// Register early (priority 5) so the handle exists before consumers' default-
+// priority enqueues resolve their dependency tree.
+add_action( 'wp_enqueue_scripts', 'extrachill_analytics_register_chart_asset', 5 );
+add_action( 'admin_enqueue_scripts', 'extrachill_analytics_register_chart_asset', 5 );
+
+/**
  * Enqueue view tracking script on singular pages.
  */
 function extrachill_analytics_enqueue_view_tracking() {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@wordpress/components": "^28.0.0",
 		"@wordpress/element": "^6.0.0",
 		"@wordpress/i18n": "^5.0.0",
+		"chart.js": "^4.4.0",
 		"wp-native-client": "^0.0.1"
 	},
 	"private": true

--- a/src/chart.js
+++ b/src/chart.js
@@ -1,0 +1,45 @@
+/**
+ * Shared Chart.js asset — network-activated charting handle.
+ *
+ * extrachill-analytics is network-activated, so registering Chart.js here as a
+ * WordPress script handle (`extrachill-analytics-chart`) makes ONE guaranteed-
+ * present copy available to every consumer on the network instead of each
+ * plugin re-bundling its own. See extrachill-analytics#93.
+ *
+ * This entry imports `chart.js/auto` (Chart.js v4 with all controllers,
+ * elements, scales, and plugins auto-registered) and exposes the full module
+ * namespace on `window.ExtraChillChart`. Downstream webpack consumers
+ * (extrachill-artist-platform#89, extrachill-studio#104) map the `chart.js`
+ * import to this global as a webpack external — the same way `react` /
+ * `wp-element` are externalized to `window.React` / `window.wp.element`:
+ *
+ *   // webpack.config.js (consumer)
+ *   externals: {
+ *     'chart.js': 'ExtraChillChart',
+ *     'chart.js/auto': 'ExtraChillChart',
+ *   }
+ *
+ *   // consumer source — unchanged ergonomics
+ *   import { Chart } from 'chart.js';      // -> window.ExtraChillChart.Chart
+ *   import Chart from 'chart.js/auto';     // -> window.ExtraChillChart (default)
+ *
+ * Handle:   extrachill-analytics-chart
+ * Global:   window.ExtraChillChart  (namespace object; `.default` and `.Chart`
+ *           both resolve to the auto-registered Chart constructor)
+ */
+
+import Chart, * as ChartModule from 'chart.js/auto';
+
+// Expose the full namespace. `default` is the auto-registered Chart
+// constructor; named exports (registerables, scales, controllers, etc.) ride
+// along so a consumer mapping either `chart.js` or `chart.js/auto` gets a
+// faithful module shape.
+const ExtraChillChart = {
+	...ChartModule,
+	default: Chart,
+	Chart,
+};
+
+window.ExtraChillChart = ExtraChillChart;
+
+export default ExtraChillChart;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,10 @@ module.exports = {
 	...defaultConfig,
 	entry: {
 		analytics: './src/index.js',
+		// Shared Chart.js v4 asset — registered network-wide as the
+		// `extrachill-analytics-chart` handle and externalized by consumers.
+		// See extrachill-analytics#93 and src/chart.js.
+		chart: './src/chart.js',
 	},
 	output: {
 		...defaultConfig.output,


### PR DESCRIPTION
## Summary

ECA now owns Chart.js v4 as a **network-activated WordPress script handle**, so every consumer shares one guaranteed-present copy instead of re-bundling its own. This is the **ECA side only** of #93 — the artist-platform companion (drop `build/349.js`, externalize `chart.js` to the ECA handle) is tracked separately in extrachill-artist-platform#89, and the Studio Network tab consumer is extrachill-studio#104.

## What changed

- **`package.json`** — add `chart.js` ^4.4.0 as a build dependency.
- **`src/chart.js`** (new webpack entry) — imports `chart.js/auto` (Chart.js v4 with all controllers/elements/scales/plugins auto-registered) and exposes the full module namespace on `window.ExtraChillChart`. `.default` and `.Chart` both resolve to the auto-registered `Chart` constructor.
- **`webpack.config.js`** — add the `chart` entry alongside `analytics`, producing `build/chart.js` + `build/chart.asset.php`.
- **`inc/core/assets.php`** — `extrachill_analytics_register_chart_asset()` **registers** (does not enqueue) the handle on both `wp_enqueue_scripts` and `admin_enqueue_scripts` at priority 5. Registering means it loads only where a consumer declares it as a dependency, on both front end and admin; priority 5 guarantees the handle exists before consumers' default-priority enqueues resolve their dependency tree.

## For downstream consumers (#89, #104)

| | |
|---|---|
| **Script handle** | `extrachill-analytics-chart` |
| **Exposed global** | `window.ExtraChillChart` (module namespace; `.default` / `.Chart` = auto-registered `Chart`) |
| **Built asset** | `build/chart.js` (no WP script deps) |

Map `chart.js` to the ECA handle as a webpack external — same pattern as `react` / `wp-element`:

```js
// consumer webpack.config.js
externals: {
  'chart.js': 'ExtraChillChart',
  'chart.js/auto': 'ExtraChillChart',
}
```

```js
// consumer source — unchanged ergonomics
import { Chart } from 'chart.js';   // -> window.ExtraChillChart.Chart
import Chart from 'chart.js/auto';  // -> window.ExtraChillChart (default)
```

Then add `extrachill-analytics-chart` to the consumer block's `*.asset.php` deps and drop the locally-bundled copy.

## Verification

- `npm install && npm run build` — succeeds; emits `build/chart.js` (201 KiB) + `build/chart.asset.php` (zero dependencies).
- Confirmed the bundle exposes `window.ExtraChillChart` and contains the full Chart.js v4 controller set (Bar/Line/Doughnut/etc. auto-registered).
- `wp-scripts lint-js src/chart.js` — clean.
- `php -l inc/core/assets.php` — no syntax errors.

## Notes / decisions

- **Why `chart.js/auto`** (vs. tree-shaken registration): the existing production asset (`build/349.js` in artist-platform) is `chart.js/auto`, so this preserves identical rendering behavior for the migrating consumer with no per-component registration burden. A future optimization can slim this to explicit `register()` calls if bundle size matters.
- **Why a namespace global** (`window.ExtraChillChart` holding the full module): lets consumers externalize *either* `chart.js` (named imports) *or* `chart.js/auto` (default import) against one handle, matching how Chart.js is normally imported.
- No chart *logic* moves here — this is purely an asset-ownership/build-externals change, per the issue.
- `build/` and `package-lock.json` are gitignored in this repo (built at release), so only source files are committed.

Closes #93