### PR TITLE
feat: own link-page analytics (flip extrachill_get_link_page_analytics provider to ECA)

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -23,6 +23,7 @@ define( 'EXTRACHILL_ANALYTICS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/events-db.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/php-error-log-db.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/mediavine-revenue-db.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/link-page-analytics-db.php';
 
 // Core functionality (network-wide).
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/event-types.php';
@@ -35,6 +36,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/content-format-classifi
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/outbound-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/mediavine-csv-import.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/link-page-analytics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/gtm.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities.php';

--- a/inc/core/abilities/get-link-page-analytics.php
+++ b/inc/core/abilities/get-link-page-analytics.php
@@ -58,8 +58,15 @@ function extrachill_analytics_register_get_link_page_analytics_ability(): void {
 /**
  * Execute callback for get-link-page-analytics ability.
  *
- * Validates the link page, checks ownership via ec_can_manage_artist(),
- * then delegates to the extrachill_get_link_page_analytics filter.
+ * Validates the link page, checks ownership via ec_can_manage_artist(), then
+ * resolves analytics through the extrachill_get_link_page_analytics filter.
+ *
+ * As of extrachill-analytics#94 that filter is PROVIDED BY ECA itself
+ * (extrachill_analytics_provide_link_page_analytics in
+ * inc/core/link-page-analytics.php) — it no longer delegates "up" to artist-
+ * platform. The filter is kept as the single read seam so this ability and the
+ * extrachill-api REST route share one provider rather than duplicating the
+ * query.
  *
  * @param array $input Input parameters.
  * @return array|WP_Error Analytics data or error.

--- a/inc/core/link-page-analytics.php
+++ b/inc/core/link-page-analytics.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Link Page Analytics — Provider, Write Path, and Prune
+ *
+ * ECA-owned analytics for artist link pages (extrachill-analytics#94). This is
+ * a lift-and-shift of the logic that previously lived in extrachill-artist-
+ * platform's `inc/link-pages/live/analytics.php`:
+ *
+ *   - WRITE PATH: listeners on `extrachill_link_page_view_recorded` (fired by
+ *     ECA's own track-page-view ability) and `extrachill_link_click_recorded`
+ *     (fired by the extrachill-api click route) that INSERT ... ON DUPLICATE
+ *     KEY UPDATE into the daily-aggregate tables.
+ *   - READ PROVIDER: `extrachill_analytics_provide_link_page_analytics()`
+ *     registered on the `extrachill_get_link_page_analytics` filter, returning the unchanged
+ *     frontend contract (summary / chart_data{labels,datasets} / top_links).
+ *   - PRUNE: a daily cron that drops rows older than 90 days.
+ *
+ * COEXISTENCE WITH ARTIST-PLATFORM (until extrachill-analytics#94's companion,
+ * extrachill-artist-platform#89, lands):
+ *
+ *   AP currently still attaches its own copies of these write listeners and its
+ *   own filter provider against the SAME tables and SAME hooks. If both ECA's
+ *   and AP's listeners stayed attached, every view/click would be DOUBLE-
+ *   counted and the filter would resolve twice. To guarantee a single writer
+ *   and a single provider regardless of load order, ECA detaches AP's known
+ *   callbacks (by their stable global function names) before attaching its own.
+ *   `remove_action`/`remove_filter` against a callback that isn't attached is a
+ *   harmless no-op, so this is safe whether AP is present, already removed by
+ *   #89, or loads after ECA. ECA also unschedules AP's prune cron event and
+ *   runs its own, so pruning happens exactly once.
+ *
+ *   When #89 lands and AP stops registering these, the detach calls simply
+ *   become no-ops and ECA is the sole owner with no behavioural change.
+ *
+ * AP still owns (ECA only CALLS INTO these, guarded with function_exists /
+ * apply_filters): the artist-analytics React block UI, the beacon JS, and the
+ * ownership/resolution helpers ec_get_link_page_for_artist / ec_can_manage_artist
+ * / ec_get_artist_id.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.23.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Detach artist-platform's legacy link-page analytics callbacks so ECA is the
+ * single writer/provider during the coexistence window.
+ *
+ * Runs late on `init` (priority 99) — after AP's own `init`-time registration
+ * (its create-table + prune scheduling hook on `init`, and its module-load-time
+ * add_action/add_filter calls which all execute during plugin load, before
+ * `init`). Detaching by the stable AP function names is idempotent: if AP is
+ * gone (post-#89) or never loaded, every call is a no-op.
+ */
+function extrachill_analytics_link_page_detach_legacy_providers() {
+	// Write listeners (AP: extrachill_handle_link_page_view_db_write @10,
+	// extrachill_handle_link_click_db_write @10).
+	remove_action( 'extrachill_link_page_view_recorded', 'extrachill_handle_link_page_view_db_write', 10 );
+	remove_action( 'extrachill_link_click_recorded', 'extrachill_handle_link_click_db_write', 10 );
+
+	// Read provider (AP: extrachill_provide_link_page_analytics @10).
+	remove_filter( 'extrachill_get_link_page_analytics', 'extrachill_provide_link_page_analytics', 10 );
+
+	// Prune (AP: extrachill_artist_prune_old_analytics_data on its own event).
+	// Detach AP's listener and unschedule AP's event so only ECA's prune runs.
+	remove_action( 'extrachill_artist_daily_analytics_prune_event', 'extrachill_artist_prune_old_analytics_data' );
+	if ( wp_next_scheduled( 'extrachill_artist_daily_analytics_prune_event' ) ) {
+		wp_clear_scheduled_hook( 'extrachill_artist_daily_analytics_prune_event' );
+	}
+}
+add_action( 'init', 'extrachill_analytics_link_page_detach_legacy_providers', 99 );
+
+/*
+ * ECA write-path listeners. Attached at load time on the SAME action hooks the
+ * write routes fire. AP's identically-named callbacks are detached on init@99
+ * above, so exactly one increment happens per beacon.
+ */
+add_action( 'extrachill_link_page_view_recorded', 'extrachill_analytics_handle_link_page_view_db_write', 10, 1 );
+add_action( 'extrachill_link_click_recorded', 'extrachill_analytics_handle_link_click_db_write', 10, 3 );
+
+/*
+ * ECA read provider. Registered at priority 20 so that — even in the unlikely
+ * window before init@99 detaches AP's @10 provider — ECA's value is the one the
+ * filter ultimately returns (later priority wins as the final filtered value).
+ */
+add_filter( 'extrachill_get_link_page_analytics', 'extrachill_analytics_provide_link_page_analytics', 20, 3 );
+
+/**
+ * Supplies link-page analytics data for the extrachill_get_link_page_analytics
+ * filter (consumed by the extrachill-api REST route, ECA's
+ * get-link-page-analytics ability, and AP's artist-get-analytics ability).
+ *
+ * Frontend contract is UNCHANGED from AP's prior provider:
+ *   summary{total_views,total_clicks}
+ *   chart_data{labels[],datasets[{label,data[]}]}
+ *   top_links[{text,identifier,clicks}]
+ *
+ * @param mixed $data         Prior filter value (unused).
+ * @param int   $link_page_id Link page post ID.
+ * @param int   $date_range   Number of days to include (1-90).
+ * @return array|WP_Error
+ */
+function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id, $date_range ) {
+	global $wpdb;
+
+	$link_page_id = absint( $link_page_id );
+	if ( ! $link_page_id ) {
+		return new WP_Error( 'invalid_link_page', 'Invalid or missing link page ID.', array( 'status' => 400 ) );
+	}
+
+	$range = absint( $date_range );
+	$range = $range ? $range : 30;
+	$range = max( 1, min( 90, $range ) );
+
+	$today       = current_time( 'Y-m-d' );
+	$start_stamp = strtotime( $today . ' -' . ( $range - 1 ) . ' days' );
+	$start_date  = gmdate( 'Y-m-d', $start_stamp );
+
+	$views_table  = extrachill_analytics_link_page_views_table();
+	$clicks_table = extrachill_analytics_link_page_clicks_table();
+
+	$views = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT stat_date, view_count FROM {$views_table} WHERE link_page_id = %d AND stat_date BETWEEN %s AND %s ORDER BY stat_date ASC",
+			$link_page_id,
+			$start_date,
+			$today
+		)
+	);
+
+	$clicks = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT stat_date, SUM(click_count) AS click_count FROM {$clicks_table} WHERE link_page_id = %d AND stat_date BETWEEN %s AND %s GROUP BY stat_date ORDER BY stat_date ASC",
+			$link_page_id,
+			$start_date,
+			$today
+		)
+	);
+
+	$top_links = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT link_url, link_text, SUM(click_count) AS total_clicks FROM {$clicks_table} WHERE link_page_id = %d AND stat_date BETWEEN %s AND %s GROUP BY link_url, link_text ORDER BY total_clicks DESC LIMIT 20",
+			$link_page_id,
+			$start_date,
+			$today
+		)
+	);
+
+	$view_map  = array();
+	$click_map = array();
+
+	foreach ( $views as $row ) {
+		$view_map[ $row->stat_date ] = (int) $row->view_count;
+	}
+
+	foreach ( $clicks as $row ) {
+		$click_map[ $row->stat_date ] = (int) $row->click_count;
+	}
+
+	$labels       = array();
+	$view_series  = array();
+	$click_series = array();
+
+	for ( $i = 0; $i < $range; $i++ ) {
+		$date           = gmdate( 'Y-m-d', strtotime( $start_date . ' +' . $i . ' days' ) );
+		$labels[]       = $date;
+		$view_series[]  = isset( $view_map[ $date ] ) ? $view_map[ $date ] : 0;
+		$click_series[] = isset( $click_map[ $date ] ) ? $click_map[ $date ] : 0;
+	}
+
+	$total_views  = array_sum( $view_series );
+	$total_clicks = array_sum( $click_series );
+
+	$formatted_top_links = array_map(
+		static function ( $row ) {
+			return array(
+				'text'       => $row->link_text,
+				'identifier' => $row->link_url,
+				'clicks'     => (int) $row->total_clicks,
+			);
+		},
+		$top_links
+	);
+
+	return array(
+		'summary'    => array(
+			'total_views'  => $total_views,
+			'total_clicks' => $total_clicks,
+		),
+		'chart_data' => array(
+			'labels'   => $labels,
+			'datasets' => array(
+				array(
+					'label' => 'Page Views',
+					'data'  => $view_series,
+				),
+				array(
+					'label' => 'Link Clicks',
+					'data'  => $click_series,
+				),
+			),
+		),
+		'top_links'  => $formatted_top_links,
+	);
+}
+
+/**
+ * Writes page-view data to the daily views table.
+ *
+ * @param int $link_page_id The link page post ID.
+ */
+function extrachill_analytics_handle_link_page_view_db_write( $link_page_id ) {
+	global $wpdb;
+
+	$today      = current_time( 'Y-m-d' );
+	$table_name = extrachill_analytics_link_page_views_table();
+
+	$wpdb->query(
+		$wpdb->prepare(
+			"INSERT INTO {$table_name}
+				(link_page_id, stat_date, view_count)
+			VALUES
+				(%d, %s, 1)
+			ON DUPLICATE KEY UPDATE
+				view_count = view_count + 1",
+			$link_page_id,
+			$today
+		)
+	);
+}
+
+/**
+ * Writes link-click data to the daily aggregation table.
+ *
+ * @param int    $link_page_id The link page post ID.
+ * @param string $link_url     The clicked URL (already normalized by the API).
+ * @param string $link_text    The link text at time of click.
+ */
+function extrachill_analytics_handle_link_click_db_write( $link_page_id, $link_url, $link_text = '' ) {
+	global $wpdb;
+
+	$today      = current_time( 'Y-m-d' );
+	$table_name = extrachill_analytics_link_page_clicks_table();
+
+	$wpdb->query(
+		$wpdb->prepare(
+			"INSERT INTO {$table_name}
+				(link_page_id, stat_date, link_url, link_text, click_count)
+			VALUES
+				(%d, %s, %s, %s, 1)
+			ON DUPLICATE KEY UPDATE
+				click_count = click_count + 1",
+			$link_page_id,
+			$today,
+			$link_url,
+			$link_text
+		)
+	);
+}
+
+/**
+ * Prunes link-page analytics data older than 90 days from both daily tables.
+ */
+function extrachill_analytics_prune_link_page_data() {
+	global $wpdb;
+
+	$ninety_days_ago = gmdate( 'Y-m-d', strtotime( '-90 days', current_time( 'timestamp' ) ) );
+
+	$table_views  = extrachill_analytics_link_page_views_table();
+	$result_views = $wpdb->query(
+		$wpdb->prepare(
+			"DELETE FROM {$table_views} WHERE stat_date < %s",
+			$ninety_days_ago
+		)
+	);
+
+	if ( false === $result_views ) {
+		error_log( '[ECA Link Page Analytics Pruning] Error pruning daily views: ' . $wpdb->last_error );
+	}
+
+	$table_clicks  = extrachill_analytics_link_page_clicks_table();
+	$result_clicks = $wpdb->query(
+		$wpdb->prepare(
+			"DELETE FROM {$table_clicks} WHERE stat_date < %s",
+			$ninety_days_ago
+		)
+	);
+
+	if ( false === $result_clicks ) {
+		error_log( '[ECA Link Page Analytics Pruning] Error pruning daily link clicks: ' . $wpdb->last_error );
+	}
+}
+add_action( 'extrachill_analytics_link_page_prune_event', 'extrachill_analytics_prune_link_page_data' );
+
+/**
+ * Schedules the ECA-owned daily prune cron if not already scheduled.
+ */
+function extrachill_analytics_schedule_link_page_prune_cron() {
+	if ( ! wp_next_scheduled( 'extrachill_analytics_link_page_prune_event' ) ) {
+		wp_schedule_event( time(), 'daily', 'extrachill_analytics_link_page_prune_event' );
+	}
+}
+add_action( 'init', 'extrachill_analytics_schedule_link_page_prune_cron' );

--- a/inc/database/link-page-analytics-db.php
+++ b/inc/database/link-page-analytics-db.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Link Page Analytics Database Management
+ *
+ * Owns the two daily-aggregate tables that back artist link-page analytics:
+ *   - {prefix}extrch_link_page_daily_views        (one row per link page per day)
+ *   - {prefix}extrch_link_page_daily_link_clicks  (one row per link page / day / link)
+ *
+ * These tables historically lived in extrachill-artist-platform (AP). Ownership
+ * is being flipped to extrachill-analytics (ECA) per extrachill-analytics#94 so
+ * the network analytics plugin owns the link-page analytics store, write path,
+ * prune, and read provider. AP retains only the artist-analytics block UI, the
+ * beacon JS, and its artist/ownership resolution helpers — it now CONSUMES the
+ * ECA-provided read primitive.
+ *
+ * IMPORTANT — table names and prefix are intentionally IDENTICAL to AP's prior
+ * schema (per-site `$wpdb->prefix`, same table names, same columns/keys) so the
+ * existing data is shared and continuous: no migration, no backfill. dbDelta on
+ * an already-correct table is a no-op, so ECA adopting the same schema is safe
+ * even while AP's create-table routine is still registered (#89 removes it).
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.23.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'EXTRACHILL_ANALYTICS_LINK_PAGE_DB_VERSION', '1.2' );
+define( 'EXTRACHILL_ANALYTICS_LINK_PAGE_DB_VERSION_OPTION', 'extrachill_analytics_link_page_db_version' );
+
+/**
+ * Get the daily-views table name.
+ *
+ * Per-site table (`$wpdb->prefix`) — link pages live on the artist site, so the
+ * data is scoped to that site exactly as it was under AP ownership.
+ *
+ * @return string Table name with the site prefix.
+ */
+function extrachill_analytics_link_page_views_table() {
+	global $wpdb;
+	return $wpdb->prefix . 'extrch_link_page_daily_views';
+}
+
+/**
+ * Get the daily-link-clicks table name.
+ *
+ * @return string Table name with the site prefix.
+ */
+function extrachill_analytics_link_page_clicks_table() {
+	global $wpdb;
+	return $wpdb->prefix . 'extrch_link_page_daily_link_clicks';
+}
+
+/**
+ * Create or update the link-page analytics tables when the DB version changes.
+ *
+ * Schema is a verbatim copy of AP's prior definition so dbDelta treats an
+ * already-existing AP table as up-to-date (no-op). We use a DISTINCT option key
+ * from AP (`extrachill_analytics_link_page_db_version`) so ECA's gate is
+ * independent of AP's `extrch_analytics_db_version` — both can run dbDelta
+ * harmlessly against the same idempotent schema during the coexistence window.
+ */
+function extrachill_analytics_link_page_create_table() {
+	$current_db_version = get_option( EXTRACHILL_ANALYTICS_LINK_PAGE_DB_VERSION_OPTION );
+
+	if ( $current_db_version === EXTRACHILL_ANALYTICS_LINK_PAGE_DB_VERSION ) {
+		return;
+	}
+
+	global $wpdb;
+	$charset_collate = $wpdb->get_charset_collate();
+
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+	$table_views = extrachill_analytics_link_page_views_table();
+	$sql_views   = "CREATE TABLE {$table_views} (
+		view_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		link_page_id bigint(20) unsigned NOT NULL,
+		stat_date date NOT NULL,
+		view_count bigint(20) unsigned NOT NULL DEFAULT 0,
+		PRIMARY KEY  (view_id),
+		UNIQUE KEY unique_daily_view (link_page_id, stat_date)
+	) {$charset_collate};";
+
+	$table_clicks = extrachill_analytics_link_page_clicks_table();
+	$sql_clicks   = "CREATE TABLE {$table_clicks} (
+		click_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		link_page_id bigint(20) unsigned NOT NULL,
+		stat_date date NOT NULL,
+		link_url varchar(2083) NOT NULL,
+		link_text varchar(255) NOT NULL DEFAULT '',
+		click_count bigint(20) unsigned NOT NULL DEFAULT 0,
+		PRIMARY KEY  (click_id),
+		UNIQUE KEY unique_daily_link_click (link_page_id, stat_date, link_url(191), link_text(100)),
+		KEY link_page_date (link_page_id, stat_date)
+	) {$charset_collate};";
+
+	dbDelta( $sql_views );
+	dbDelta( $sql_clicks );
+
+	update_option( EXTRACHILL_ANALYTICS_LINK_PAGE_DB_VERSION_OPTION, EXTRACHILL_ANALYTICS_LINK_PAGE_DB_VERSION );
+}
+
+add_action( 'admin_init', 'extrachill_analytics_link_page_create_table' );


### PR DESCRIPTION
## Summary

Flips ownership of artist **link-page analytics** from extrachill-artist-platform (AP) to extrachill-analytics (ECA), per #94. ECA now owns the store, write path, prune, and the read provider; the substrate no longer delegates *up* to a consumer.

This is the **ECA side only**. The companion AP-side PR — **Extra-Chill/extrachill-artist-platform#89** — removes AP's now-duplicate provider/listeners/tables. This PR is designed to **coexist safely with AP until #89 lands**, so it is `Refs #94`, not `Closes` (the issue fully closes when #89 also merges).

## What moved into ECA (lift-and-shift)

- **Tables** — `inc/database/link-page-analytics-db.php` defines `{prefix}extrch_link_page_daily_views` and `{prefix}extrch_link_page_daily_link_clicks` via `dbDelta`, gated on a NEW DB-version option (`extrachill_analytics_link_page_db_version`) independent of AP's. **Same table names + same per-site `$wpdb->prefix` + identical schema** as AP's prior definition, so existing data is **shared and continuous — no migration, no backfill.** dbDelta on an already-correct table is a no-op.
- **Write handlers** — listeners on `extrachill_link_page_view_recorded` (fired by ECA's own `track-page-view` ability) and `extrachill_link_click_recorded` (fired by the extrachill-api `/analytics/click` route) that `INSERT ... ON DUPLICATE KEY UPDATE`.
- **Prune** — an ECA-owned daily cron (`extrachill_analytics_link_page_prune_event`, >90 days).
- **Read provider** — `extrachill_analytics_provide_link_page_analytics()` registered on the `extrachill_get_link_page_analytics` filter.
- **Ability** — `extrachill/get-link-page-analytics` keeps resolving through the filter, which is now **ECA-provided** instead of delegating upward. The filter is kept as the single read seam so the ability and the extrachill-api REST route share one provider.

**Frontend data contract is UNCHANGED:** `summary{total_views,total_clicks}` / `chart_data{labels,datasets}` / `top_links[{text,identifier,clicks}]`.

## Coexistence behavior (⚠ #89 must land in the same release window)

AP still registers its own copies of these write listeners, filter provider, and prune cron against the **same tables and same hooks** until #89 removes them. If both stayed attached, every view/click would be **double-counted** and the filter would resolve twice.

To guarantee a **single writer and single provider regardless of load order**, ECA detaches AP's known callbacks (by their stable global function names) on `init` priority 99, before its own listeners do any work:

- `remove_action('extrachill_link_page_view_recorded', 'extrachill_handle_link_page_view_db_write', 10)`
- `remove_action('extrachill_link_click_recorded', 'extrachill_handle_link_click_db_write', 10)`
- `remove_filter('extrachill_get_link_page_analytics', 'extrachill_provide_link_page_analytics', 10)`
- `remove_action(...AP prune...)` + `wp_clear_scheduled_hook('extrachill_artist_daily_analytics_prune_event')`

`remove_*` against a callback that isn't attached is a harmless no-op, so this is correct whether AP is present, already stripped by #89, or loads after ECA. ECA's filter provider is also registered at priority 20 so it wins as the final filtered value even in the brief window before init@99 runs.

**When #89 lands**, AP stops registering these and every detach call simply becomes a no-op — ECA is the sole owner with zero behavioural change.

## Still AP-owned (ECA only calls into these, guarded)

The artist-analytics React block UI, the beacon JS, and the ownership/resolution helpers `ec_get_link_page_for_artist` / `ec_can_manage_artist` / `ec_get_artist_id`. AP now **consumes** the ECA read primitive instead of providing it.

## Verification

- `php -l` clean on all changed files.
- phpcs not run — `vendor/` is not installed in the worktree (pre-existing tooling gap), not introduced here.

## Notes

- Companion: Extra-Chill/extrachill-artist-platform#89 (removes AP provider/listeners/tables). **Both must land together** to retire the coexistence detach logic.
- Conventional commits; CHANGELOG/version untouched (homeboy owns those).

Refs #94