### PR TITLE
fix: land empty-name setcookie guard atop merged cookie-domain fix (Closes #99)

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -179,8 +179,11 @@ function extrachill_analytics_get_or_mint_visitor_id() {
 	// every subdomain on this multisite — without it each subdomain mints its
 	// own id and cross-site retention is unmeasurable.
 	// Guarded against headers_sent() as defense-in-depth; the early
-	// template_redirect hook below is what actually makes this succeed.
-	if ( ! headers_sent() ) {
+	// template_redirect hook below is what actually makes this succeed. The
+	// non-empty $cookie_name guard is belt-and-suspenders: an empty name throws
+	// an uncaught ValueError on PHP 8 (setcookie() rejects an empty $name), so
+	// we never call setcookie() unless we have a real cookie name to set.
+	if ( '' !== $cookie_name && ! headers_sent() ) {
 		setcookie(
 			$cookie_name,
 			$visitor_id,


### PR DESCRIPTION
## What this is

Lands the **empty-name `setcookie()` fatal guard** on top of the already-merged cross-subdomain cookie-domain fix, so issue #99's full acceptance — **both** the network-root domain scope **and** the empty-name guard — is satisfied by one merge.

**Closes #99.**

## Important correction to the #99 premise

Issue #99 says the cross-subdomain domain fix (branch `cookie-domain-network`, commit `3847b52`) "was never merged to `main`." **That is no longer true.** That fix already merged via **PR #84** (`138c6f9`, "fix: scope ec_vid visitor cookie to network root for cross-subdomain identity (#84)", merged Jun 26). I confirmed `git diff 138c6f9 3847b52 -- inc/core/assets.php` is **empty** — the merged commit is byte-identical to the branch fix. So:

- ✅ `ec_vid` cookie domain = leading-dot network root via the filterable `extrachill_analytics_visitor_cookie_domain()` helper — **already on `main`** (`'domain' => extrachill_analytics_visitor_cookie_domain()` at the single setcookie call site).
- ❌ #82's empty-name guard — **was still an open PR, not on `main`.**

Opening a fresh PR to "land the domain fix" would have produced an empty diff. The only thing actually missing from `main` was #82's guard, so **that** is what this PR adds — on top of the landed domain fix — to fully close #99.

## The change

```php
// before (current main — domain fix present, no name guard):
if ( ! headers_sent() ) {

// after:
if ( '' !== $cookie_name && ! headers_sent() ) {
```

An empty `$name` throws an uncaught `ValueError` on PHP 8 (`setcookie()` rejects an empty name), 500-ing the request and burying real errors. The `$_COOKIE[ $cookie_name ]` write is already inside this block, so it's covered too. This is byte-for-byte the same guard reviewed in #82, just rebased onto the now-landed domain fix.

## Reconciliation with #82 (read this before merging)

#82 (`setcookie-fatal`) adds the **same** empty-name guard but branches from before the domain fix context. This PR **fully contains #82's guard** and sits on top of the merged domain fix (#84), so the final setcookie call here has **both** protections present coherently:

- `'domain' => extrachill_analytics_visitor_cookie_domain()` (network root — from #84, on main)
- `'' !== $cookie_name &&` (empty-name fatal guard — from #82, this PR)

**Recommendation:** merge **this** PR and **close #82 as superseded** — this PR's guard is identical to #82's and #82's root-cause analysis (the fatal already stopped firing on 20-Jun after `b212102`/v0.14.1; the 11,891 log hits are a stale-`debug.log` burst) remains accurate and worth preserving in #82's thread for the record. If you'd rather merge #82 first, that's fine too: this PR's guard is the same line, so a post-#82 rebase of this branch is a clean no-op on the guard and just carries the #99 close + documentation. Either way **the empty-name fatal guard must not be dropped**, and either way `main` ends with both protections.

## Verification

- `php -l inc/core/assets.php` → no syntax errors.
- Confirmed the single setcookie call now passes the resolved network-root `domain` **and** is gated by the non-empty `$cookie_name` guard.
- `git diff 138c6f9 3847b52 -- inc/core/assets.php` empty → confirms the domain fix on `main` is identical to the original branch fix (nothing left to port).
- phpcs/phpunit not run here (vendor deps not installed in the production-adjacent worktree); the change is a single-line conditional matching the exact form already reviewed in #82 — no new WPCS issues in the changed file, and pre-existing debt (if any) is untouched.

## Behavior note

This is **forward-only**. The cross-subdomain identity now works for **new** pageviews (one `ec_vid` spans `extrachill.com` ↔ `events.extrachill.com` ↔ `community.extrachill.com`, etc.). It does **not** backfill historical rows, so the Studio Network tab's conversion-map, cross-site-return, and retention-by-referrer-host metrics populate **going forward** as visitors traverse subdomains under the network-root cookie.
