### PR TITLE
refactor: run the fatal-rate alarm as a Data Machine system task

### DIFF
--- a/inc/core/class-fatal-rate-alarm-task.php
+++ b/inc/core/class-fatal-rate-alarm-task.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Fatal-Rate Alarm System Task.
+ *
+ * Wraps the near-real-time PHP fatal-rate evaluator
+ * (`extrachill_analytics_evaluate_fatal_alarm()`) as a Data Machine system task
+ * so it is scheduled, run, and observed through the standard DM orchestration
+ * surface instead of a hand-rolled `cron_schedules` + `wp_schedule_event`
+ * pair:
+ *
+ *   wp datamachine system run fatal_rate_alarm
+ *   wp datamachine jobs list --task=fatal_rate_alarm
+ *
+ * This is a pure, agent-less operational sensor: it reads the live debug.log
+ * tail, computes per-signature fatal rates, and beacons an alert when a new or
+ * spiking fatal appears. It performs no AI work and mutates no WordPress
+ * content, so it opts out of the SystemTask agent-context gate.
+ *
+ * The 5-minute cadence (near-real-time detection is the entire point of
+ * issue #48) is declared as a recurring schedule in `php-fatal-alarm.php` via
+ * the `datamachine_recurring_schedules` filter using DM's built-in
+ * `every_5_minutes` interval. This class only owns the execution contract; the
+ * schedule binding owns the cadence.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.24.0
+ * @see https://github.com/Extra-Chill/extrachill-analytics/issues/98
+ */
+
+namespace ExtraChill\Analytics;
+
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+
+defined( 'ABSPATH' ) || exit;
+
+class FatalRateAlarmTask extends SystemTask {
+
+	/**
+	 * Task type identifier (registered via the `datamachine_tasks` filter).
+	 */
+	public const TASK_TYPE = 'fatal_rate_alarm';
+
+	/**
+	 * PluginSettings key that gates both manual and scheduled runs.
+	 *
+	 * Default-enabled: this is a safety alarm, not a destructive maintenance
+	 * task, so it should run out of the box. Operators can disable it via
+	 * `wp datamachine settings set fatal_rate_alarm_enabled false`.
+	 */
+	public const SETTING_KEY = 'fatal_rate_alarm_enabled';
+
+	/**
+	 * Get the task type identifier.
+	 *
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return self::TASK_TYPE;
+	}
+
+	/**
+	 * Pure operational sensor — runs without agent ownership context.
+	 *
+	 * The task reads debug.log and may dispatch an alert via the
+	 * `agents/dispatch-message` / `datamachine/post-message-discord`
+	 * abilities, but it never acts AS an agent or invokes an agent-scoped
+	 * mutation. It is registered as an agent-less recurring schedule, so it
+	 * must opt out of the SystemTask agent-context gate or
+	 * TaskScheduler::schedule() rejects it before it runs.
+	 *
+	 * @return bool
+	 */
+	public function requiresAgentContext(): bool {
+		return false;
+	}
+
+	/**
+	 * Task metadata for the Data Machine system surface.
+	 *
+	 * `setting_key` wires the task into DM's settings plumbing: the React
+	 * admin UI renders an enable/disable toggle, the TaskRegistry resolves
+	 * live state from `PluginSettings::get()`, and the recurring schedule
+	 * registration reads the same key to schedule/unschedule its tick.
+	 *
+	 * The `trigger` / `trigger_type` fields are intentionally omitted — DM
+	 * core resolves them from the bound schedule in RecurringScheduleRegistry.
+	 *
+	 * @return array
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'PHP Fatal-Rate Alarm',
+			'description'     => 'Reads the live debug.log tail every 5 minutes and beacons an alert when a new or spiking PHP fatal signature appears. Near-real-time fatal detection (issue #48).',
+			'setting_key'     => self::SETTING_KEY,
+			'default_enabled' => true,
+			'supports_run'    => true,
+		);
+	}
+
+	/**
+	 * Execute one alarm evaluation.
+	 *
+	 * Delegates to the existing procedural evaluator, which reads the live
+	 * debug.log tail, aggregates fatal-class signatures, decides which (if
+	 * any) should alarm, and beacons them. The full evaluation result is
+	 * recorded into the Jobs table so each tick has a first-class audit
+	 * record — which is exactly what was missing when a worktree-origin
+	 * false-positive paged the bot with no run history (issue #98).
+	 *
+	 * Params (optional):
+	 *   - `dry_run` (bool) — compute candidates without beaconing or mutating
+	 *                        dedupe state. Default: false.
+	 *
+	 * @param int   $jobId  Job ID from DM Jobs table.
+	 * @param array $params Task parameters from engine_data.
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		// Gate on the same PluginSetting the React UI toggles and the
+		// recurring schedule reads. Scheduled runs already wouldn't fire when
+		// the setting is off, but manual runs via `wp datamachine system run
+		// fatal_rate_alarm` bypass the schedule layer, so self-police here too.
+		$enabled = true;
+		if ( class_exists( '\\DataMachine\\Core\\PluginSettings' ) ) {
+			$enabled = (bool) \DataMachine\Core\PluginSettings::get( self::SETTING_KEY, true );
+		}
+		if ( ! $enabled ) {
+			$this->completeJob(
+				$jobId,
+				array(
+					'skipped' => true,
+					'reason'  => sprintf( 'Fatal-rate alarm disabled (PluginSettings: %s=false).', self::SETTING_KEY ),
+				)
+			);
+			return;
+		}
+
+		if ( ! function_exists( 'extrachill_analytics_evaluate_fatal_alarm' ) ) {
+			$this->failJob( $jobId, 'Fatal-rate evaluator unavailable.' );
+			return;
+		}
+
+		$dry_run = ! empty( $params['dry_run'] );
+
+		// The evaluator always returns a fully-populated result array
+		// (window_seconds, threshold, candidates, alarms, beacon), so the
+		// fields below are read directly without defensive ?? / isset.
+		$result = extrachill_analytics_evaluate_fatal_alarm( $dry_run );
+
+		$this->completeJob(
+			$jobId,
+			array(
+				'dry_run'         => $dry_run,
+				'window_seconds'  => $result['window_seconds'],
+				'threshold'       => $result['threshold'],
+				'candidate_count' => count( $result['candidates'] ),
+				'alarm_count'     => count( $result['alarms'] ),
+				'alarms'          => $result['alarms'],
+				'beacon'          => $result['beacon'],
+			)
+		);
+	}
+}

--- a/inc/core/php-fatal-alarm.php
+++ b/inc/core/php-fatal-alarm.php
@@ -36,11 +36,6 @@ defined( 'ABSPATH' ) || exit;
 const EXTRACHILL_ANALYTICS_FATAL_ALARM_HOOK = 'extrachill_analytics_fatal_alarm_check';
 
 /**
- * Custom cron interval name used by the alarm (independent of any other plugin).
- */
-const EXTRACHILL_ANALYTICS_FATAL_ALARM_SCHEDULE = 'extrachill_analytics_five_minutes';
-
-/**
  * Site-option key holding per-signature alarm state (last-alerted bookkeeping).
  */
 const EXTRACHILL_ANALYTICS_FATAL_ALARM_STATE_OPTION = 'extrachill_analytics_fatal_alarm_state';
@@ -56,48 +51,73 @@ const EXTRACHILL_ANALYTICS_FATAL_ALARM_CHANNEL_OPTION = 'extrachill_analytics_fa
 const EXTRACHILL_ANALYTICS_FATAL_ALARM_MENTION_OPTION = 'extrachill_analytics_fatal_alarm_mention';
 
 /**
- * Register the ~5-minute cron interval used by the alarm.
+ * Register the alarm as a Data Machine system task.
  *
- * The network already fires `wp cron event run --due-now` per site every 5 min
- * via the system cron heartbeat, so a recurring WP-cron event on this interval
- * is reliably drained even on low-traffic sites.
+ * The alarm runs as the agent-less `fatal_rate_alarm` SystemTask
+ * (FatalRateAlarmTask), scheduled through DM's RecurringScheduleRegistry on
+ * the built-in `every_5_minutes` interval. DM owns scheduling, idempotent
+ * reschedule, unschedule-on-disable, and per-tick Jobs-table run history —
+ * so the alarm is visible to `wp datamachine system` / `wp datamachine jobs`
+ * and no longer hand-rolls `cron_schedules` + `wp_schedule_event` (issue #98).
  *
- * @param array $schedules Existing cron schedules.
- * @return array Schedules with the alarm interval added.
+ * Registration is deferred to `plugins_loaded` priority 25 (after DM bootstraps
+ * at priority 20) and guarded on DM's `SystemTask` base class. This plugin has
+ * no PSR-4 autoloader, so the task class — which `extends SystemTask` — can only
+ * be safely included once the parent exists. When Data Machine is absent the
+ * task is simply never declared or scheduled and the rest of the plugin boots
+ * cleanly.
  */
-function extrachill_analytics_fatal_alarm_cron_schedule( $schedules ) {
-	if ( ! isset( $schedules[ EXTRACHILL_ANALYTICS_FATAL_ALARM_SCHEDULE ] ) ) {
-		$schedules[ EXTRACHILL_ANALYTICS_FATAL_ALARM_SCHEDULE ] = array(
-			// A sub-15-min interval is intentional: near-real-time fatal
-			// detection is the entire point (issue #48). The network's 5-min
-			// system-cron heartbeat drains it reliably.
-			'interval' => 5 * MINUTE_IN_SECONDS, // phpcs:ignore WordPress.WP.CronInterval.CronSchedulesInterval
-			'display'  => __( 'Every 5 Minutes (Extra Chill fatal alarm)', 'extrachill-analytics' ),
-		);
+function extrachill_analytics_register_fatal_alarm_task() {
+	if ( ! class_exists( '\\DataMachine\\Engine\\AI\\System\\Tasks\\SystemTask' ) ) {
+		return;
 	}
 
-	return $schedules;
+	require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/class-fatal-rate-alarm-task.php';
+
+	add_filter(
+		'datamachine_tasks',
+		function ( array $tasks ): array {
+			$tasks[ \ExtraChill\Analytics\FatalRateAlarmTask::TASK_TYPE ] = \ExtraChill\Analytics\FatalRateAlarmTask::class;
+			return $tasks;
+		}
+	);
+
+	// Near-real-time fatal detection is the entire point (issue #48), so the
+	// cadence is DM's built-in `every_5_minutes` (300s) interval. The network's
+	// 5-minute system-cron heartbeat drains Action Scheduler reliably even on
+	// low-traffic sites.
+	add_filter(
+		'datamachine_recurring_schedules',
+		function ( array $schedules ): array {
+			$schedules['fatal_rate_alarm'] = array(
+				'task_type'       => \ExtraChill\Analytics\FatalRateAlarmTask::TASK_TYPE,
+				'interval'        => 'every_5_minutes',
+				'enabled_setting' => \ExtraChill\Analytics\FatalRateAlarmTask::SETTING_KEY,
+				'default_enabled' => true,
+				'label'           => 'Every 5 minutes — near-real-time PHP fatal-rate detection',
+				'task_params'     => array( 'source' => 'recurring_schedule' ),
+			);
+			return $schedules;
+		}
+	);
 }
-// Sub-15-min interval is intentional (near-real-time fatal detection, #48).
-add_filter( 'cron_schedules', 'extrachill_analytics_fatal_alarm_cron_schedule' ); // phpcs:ignore WordPress.WP.CronInterval.CronSchedulesInterval
+add_action( 'plugins_loaded', 'extrachill_analytics_register_fatal_alarm_task', 25 );
 
 /**
- * Ensure the alarm cron is scheduled.
+ * Retire the legacy hand-rolled WP-cron event from pre-0.24.0 installs.
+ *
+ * Before the SystemTask migration (issue #98) the alarm self-scheduled a
+ * recurring `extrachill_analytics_fatal_alarm_check` WP-cron event. That event
+ * is now owned by DM's RecurringScheduleRegistry under a different hook, so the
+ * stale WP-cron event must be cleared or the evaluator would fire twice each
+ * tick. Idempotent: a no-op once the legacy event is gone.
  */
-function extrachill_analytics_schedule_fatal_alarm() {
-	if ( ! wp_next_scheduled( EXTRACHILL_ANALYTICS_FATAL_ALARM_HOOK ) ) {
-		wp_schedule_event( time() + MINUTE_IN_SECONDS, EXTRACHILL_ANALYTICS_FATAL_ALARM_SCHEDULE, EXTRACHILL_ANALYTICS_FATAL_ALARM_HOOK );
+function extrachill_analytics_clear_legacy_fatal_alarm_cron() {
+	if ( wp_next_scheduled( EXTRACHILL_ANALYTICS_FATAL_ALARM_HOOK ) ) {
+		wp_clear_scheduled_hook( EXTRACHILL_ANALYTICS_FATAL_ALARM_HOOK );
 	}
 }
-add_action( 'init', 'extrachill_analytics_schedule_fatal_alarm' );
-
-/**
- * Cron callback: run a live alarm evaluation and beacon any new/spiking fatals.
- */
-function extrachill_analytics_fatal_alarm_cron() {
-	extrachill_analytics_evaluate_fatal_alarm( false );
-}
-add_action( EXTRACHILL_ANALYTICS_FATAL_ALARM_HOOK, 'extrachill_analytics_fatal_alarm_cron' );
+add_action( 'init', 'extrachill_analytics_clear_legacy_fatal_alarm_cron', 99 );
 
 /**
  * Marker source stamped on this plugin's dispatch so the scoped permission

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    scanFiles:
+        - stubs/phpstan/datamachine-system-task.php
+        - stubs/phpstan/datamachine-plugin-settings.php

--- a/stubs/phpstan/datamachine-plugin-settings.php
+++ b/stubs/phpstan/datamachine-plugin-settings.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * PHPStan stub for Data Machine plugin settings.
+ *
+ * `FatalRateAlarmTask::executeTask()` gates manual runs on a DM PluginSetting.
+ * The class lives in the Data Machine plugin (outside this component's analysis
+ * scope), so this stub gives PHPStan the minimal shape for `PluginSettings::get()`.
+ *
+ * @package ExtraChill\Analytics\Stubs
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Static-analysis shape for the external Data Machine PluginSettings class.
+ */
+class PluginSettings {
+
+	/**
+	 * @param mixed $fallback Fallback value returned when the setting is unset.
+	 * @return mixed
+	 */
+	public static function get( string $key, $fallback = null ) {
+	}
+}

--- a/stubs/phpstan/datamachine-system-task.php
+++ b/stubs/phpstan/datamachine-system-task.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * PHPStan stub for Data Machine system tasks.
+ *
+ * extrachill-analytics registers `FatalRateAlarmTask` as a Data Machine system
+ * task (issue #98). The `SystemTask` base lives in the Data Machine plugin,
+ * which is not in this component's analysis scope, so this stub gives PHPStan
+ * the minimal shape it needs to resolve the parent class and its protected job
+ * lifecycle helpers.
+ *
+ * @package ExtraChill\Analytics\Stubs
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Static-analysis shape for the external Data Machine SystemTask class.
+ */
+abstract class SystemTask {
+
+	/**
+	 * @param array<string,mixed> $data Job result payload.
+	 */
+	protected function completeJob( int $jobId, array $data = array() ): void {
+	}
+
+	protected function failJob( int $jobId, string $message ): void {
+	}
+}


### PR DESCRIPTION
## Summary

Migrates the near-real-time PHP fatal-rate alarm off its **hand-rolled recurring scheduling** and onto Data Machine's existing **SystemTask + RecurringScheduleRegistry** infrastructure. Closes #98.

The alarm previously registered its own `cron_schedules` interval, self-managed a `wp_schedule_event`, and kept all run state in a bespoke site option — reinventing infra DM already ships. Because it ran outside the DM job engine, it also had **no per-tick run record**, which is why the worktree-origin false-positive (PR #101) paged the bot with no audit trail to reconstruct from.

## What changed

- **New `FatalRateAlarmTask`** (`inc/core/class-fatal-rate-alarm-task.php`) — an agent-less `SystemTask` (`requiresAgentContext(): false`) whose `executeTask()` delegates to the existing `extrachill_analytics_evaluate_fatal_alarm()` evaluator and records the full evaluation result (window, threshold, candidate/alarm counts, beacon outcome) into the **Jobs table**.
- **Registered via the two DM filters** (`php-fatal-alarm.php`):
  - `datamachine_tasks` → maps `fatal_rate_alarm` to the task class.
  - `datamachine_recurring_schedules` → binds it to DM's built-in **`every_5_minutes`** (300s) interval, preserving the near-real-time cadence that is the entire point of #48.
- **Deferred + guarded registration** — runs on `plugins_loaded:25` (after DM bootstraps at 20) behind a `class_exists( SystemTask )` guard. This plugin has no PSR-4 autoloader, so the task class (which `extends SystemTask`) is only included once its parent exists. When Data Machine is absent the task is simply never declared/scheduled and the rest of the plugin boots cleanly.
- **Removed** the custom `cron_schedules` interval, the `wp_schedule_event` self-scheduling, and the cron callback.
- **Legacy teardown** — clears the stale `extrachill_analytics_fatal_alarm_check` WP-cron event on upgrade (`init:99`, idempotent) so the evaluator never double-fires during the transition.
- **PHPStan stubs** (`stubs/phpstan/`, `phpstan.neon`) for the external DM `SystemTask` / `PluginSettings` classes, matching the `data-machine-code` convention so the new task analyzes clean cross-plugin.

The agent/Discord dispatch path is **unchanged** — it already used the canonical `agents/dispatch-message` and `datamachine/post-message-discord` abilities.

## Why `every_5_minutes` (not a custom interval or cron expression)

DM ships `every_5_minutes` (300s) as a **built-in** scheduler interval (`SchedulerIntervals.php`), and `data-machine-code` already runs a sub-hourly non-AI sensor (`workspace_disk_emergency_cleanup`, `hourly`) on this exact substrate. So the alarm's cadence is a first-class DM interval — no custom interval registration or cron expression needed.

## Result

- Alarm is now visible to `wp datamachine system` and produces a **Jobs-table run record each tick** — the observability that was missing.
- `wp datamachine system run fatal_rate_alarm` / `--dry_run` for manual triage.
- Toggle via `wp datamachine settings set fatal_rate_alarm_enabled false`.
- Near-real-time detection (#48) preserved; dispatch behavior unchanged.

## Verification

- `php -l` clean on all new/changed PHP files.
- `homeboy lint`: **zero new findings** in the new/changed files. The new task analyzes clean thanks to the DM stubs; phpstan total stays at the pre-existing baseline (72) and phpcs at (187) — none of that pre-existing debt is in these files.
- No dangling references to the removed `cron_schedules` interval/const; the retained `FATAL_ALARM_HOOK` const is used only by the legacy teardown.

## Note

This plugin still carries pre-existing lint debt (187 phpcs + 72 phpstan, predating v0.22.0) that forces `--skip-checks` on release. This PR adds none of it; cleaning it up is separate scope.
