### PR TITLE
fix: classify authenticated logged-in users as human (#103)

### DIFF
--- a/inc/core/visitor-classifier.php
+++ b/inc/core/visitor-classifier.php
@@ -30,6 +30,19 @@
  *      NON-human (suspect) by the default verdict, because a human who reached
  *      a search box or deep page has loaded a page and minted the cookie.
  *
+ * AUTHENTICATED-USER OVERRIDE (issue #103): the three signals above were
+ * designed for ANONYMOUS front-end traffic, where rest/cli/cron == "no browser
+ * ran" == not-a-human is correct. They are WRONG for an authenticated logged-in
+ * user whose action is captured server-side: a Roadie team member's real tool
+ * call fires inside a REST request (request_origin === 'rest') with no `ec_vid`
+ * cookie in that server-side context, so the anonymous-traffic policy
+ * false-flagged 100% of real logged-in team activity as bot. A logged-in WP
+ * user (`is_user_logged_in()`) is therefore a positive human signal that
+ * short-circuits the anonymous-traffic verdict: an authenticated request is
+ * human regardless of origin/cookie. The anonymous-traffic policy is left fully
+ * intact for the unauthenticated instruments (404s, pageviews, search-gaps)
+ * it was built for.
+ *
  * @package ExtraChill\Analytics
  * @since 0.12.0
  */
@@ -41,15 +54,19 @@ defined( 'ABSPATH' ) || exit;
  * return the evidence signals the verdict was derived from.
  *
  * Verdict policy (the single canonical answer every instrument consumes):
- *   is_human = TRUE only when ALL of these hold —
- *     - request_origin === 'web'            (not cli/cron/rest-internal)
- *     - ua_class === 'browser'              (not 'bot' and not 'empty')
- *     - has_visitor_cookie === true         (a real browser minted ec_vid)
+ *   is_human = TRUE when EITHER —
+ *     - is_authenticated === true           (a logged-in WP user; see #103), OR
+ *     - ALL of these hold (the anonymous-traffic policy):
+ *         - request_origin === 'web'        (not cli/cron/rest-internal)
+ *         - ua_class === 'browser'          (not 'bot' and not 'empty')
+ *         - has_visitor_cookie === true     (a real browser minted ec_vid)
  *   Otherwise is_human = FALSE (is_bot = TRUE).
  *
- * In other words: programmatic context OR a crawler/empty UA OR a cookieless
- * request all classify as non-human. Present cookie + browser UA + web origin
- * is the strongest human signal and the only combination treated as human.
+ * In other words: an authenticated user is always human. For ANONYMOUS traffic,
+ * programmatic context OR a crawler/empty UA OR a cookieless request all
+ * classify as non-human; present cookie + browser UA + web origin is the
+ * strongest anonymous human signal and the only anonymous combination treated
+ * as human.
  *
  * @param array $context {
  *     Optional. Override the request-derived signals (useful for tests and for
@@ -62,6 +79,9 @@ defined( 'ABSPATH' ) || exit;
  *                                          cookie via the read-only resolver.
  *     @type string    $request_origin      One of 'web'|'rest'|'cron'|'cli'.
  *                                          Defaults to auto-detection.
+ *     @type bool|null $is_authenticated    Whether the request is from a
+ *                                          logged-in WP user. Defaults to
+ *                                          reading is_user_logged_in().
  * }
  * @return array{
  *     is_human: bool,
@@ -69,7 +89,8 @@ defined( 'ABSPATH' ) || exit;
  *     signals: array{
  *         has_visitor_cookie: bool,
  *         ua_class: string,
- *         request_origin: string
+ *         request_origin: string,
+ *         is_authenticated: bool
  *     }
  * }
  */
@@ -91,16 +112,28 @@ function extrachill_analytics_classify_request( $context = array() ) {
 		? (string) $context['request_origin']
 		: extrachill_analytics_detect_request_origin();
 
+	if ( array_key_exists( 'is_authenticated', $context ) && null !== $context['is_authenticated'] ) {
+		$is_authenticated = (bool) $context['is_authenticated'];
+	} else {
+		$is_authenticated = function_exists( 'is_user_logged_in' ) && is_user_logged_in();
+	}
+
 	$ua_class = extrachill_analytics_classify_user_agent( $user_agent );
 
 	$signals = array(
 		'has_visitor_cookie' => $has_visitor_cookie,
 		'ua_class'           => $ua_class,
 		'request_origin'     => $request_origin,
+		'is_authenticated'   => $is_authenticated,
 	);
 
 	// --- Apply the single canonical verdict policy. ---
-	$is_human = (
+	// An authenticated logged-in user is human regardless of origin/UA/cookie
+	// (issue #103): their server-side-captured actions (e.g. a Roadie tool call
+	// inside a REST request, cookieless) must not inherit the anonymous-traffic
+	// bot verdict. For everyone else, the anonymous-traffic policy applies: web
+	// origin + browser UA + minted ec_vid cookie is the only human combination.
+	$is_human = $is_authenticated || (
 		'web' === $request_origin
 		&& 'browser' === $ua_class
 		&& $has_visitor_cookie


### PR DESCRIPTION
## Root cause

The canonical visitor classifier `extrachill_analytics_classify_request()` (`inc/core/visitor-classifier.php`) is the single source of truth for "human or bot?" across every analytics instrument. Its verdict policy required **all** of:

- `request_origin === 'web'`
- `ua_class === 'browser'`
- `has_visitor_cookie === true` (a real browser minted `ec_vid`)

That policy was designed for **anonymous front-end traffic** (404s, pageviews, search-gaps), where rest/cli/cron == "no browser ran" == not-a-human is correct. It has **no notion of `is_user_logged_in()` as a positive human signal**.

A Roadie `present_question`/tool-call fires **server-side inside a REST request** — the agent runtime executing the tool via the `extrachill/track-analytics-event` ability. In that context `request_origin === 'rest'` (fails clause 1) and there is no `ec_vid` cookie (fails clause 3), so `is_bot` becomes `true` **every time, for a real logged-in human**. The `is_bot` flag is stamped in `inc/core/events.php` (`extrachill_track_analytics_event()`), which calls the classifier at write time.

## Evidence

- `qrisg` (user_id 38, `extra_chill_team`): **100%** of real Roadie tool-calls stamped `is_bot:true` (39 tool-call rows). These are genuine logged-in human actions.
- The `is_bot` field was absent on pre-instrumentation rows (e.g. the 19-Jun rows predate the stamp), so this is purely the post-instrumentation verdict misfiring on authenticated activity.

## What changed (and why it lives here)

Fixed in **extrachill-analytics** — the canonical home of the classifier (layer purity / canonical-home rule). Roadie correctly emits via the `extrachill/track-analytics-event` ability with the real `user_id` and passes **no** `is_bot` of its own; the substrate was discarding the logged-in signal. The fix belongs in the classifier, **not** Roadie or any higher layer.

- Added an `is_authenticated` positive human signal to `extrachill_analytics_classify_request()`. An authenticated WP user (`is_user_logged_in()`) is now classified **human regardless of origin/UA/cookie**, short-circuiting the anonymous-traffic policy.
- The signal follows the **existing override pattern** (mirrors `has_visitor_cookie` / `request_origin`): callers/tests can pass `context['is_authenticated']`; default reads `is_user_logged_in()` when not overridden.
- `is_authenticated` is added to the returned **evidence `signals` array**, preserving the file's evidence-alongside-verdict design.
- The **anonymous-traffic policy is fully intact** for unauthenticated requests — `rest`/`cli`/`cron`/cookieless/crawler-UA still classify as bot for the 404 / pageview / search-gap instruments it was built for. Only authenticated users are exempted.

Docblocks (module header + function header), the verdict-policy summary, and the `@return`/`@param` shapes were updated to document the new signal. `php -l` clean.

## Downstream consumer audit (the broader risk)

Any report filtering on the stamped `is_bot` was silently dropping logged-in team activity. Audited the consumers; this fix corrects all of them in one place:

- **`get-search-gaps.php`** — filters `JSON_EXTRACT(event_data,'$.is_bot') IS NOT TRUE`. Authenticated team searches were being dropped; now correctly retained as human.
- **`get-outbound-clicks.php`** — drops rows where `is_bot` is truthy unless `include_bots`. Same benefit.
- **`404-tracking.php`** — calls `extrachill_analytics_request_is_bot()` (UA-only override) live; a logged-in user hitting a 404 is no longer counted as a bot 404. Consistent and correct.
- Other `is_bot` references are docblocks/the UA-only backward-compat shim (`extrachill_analytics_is_bot()`), unaffected.

Note: previously-written rows already stamped `is_bot:true` for authenticated users are **not** backfilled by this change — only new writes get the corrected verdict.

## Tests

No PHPUnit harness exists in this plugin (no `tests/` dir, no `phpunit.xml`, no bootstrap), though `phpunit` is a dev-dependency and a `test` composer script is declared. Per the task's "do not invent a harness" guidance, no test was added. When a harness is stood up, the cases to assert are: a logged-in user with `request_origin:'rest'` and no cookie classifies **human**, and an anonymous rest/cookieless request still classifies **bot**. The new `context['is_authenticated']` override makes both trivially unit-testable without WP globals.

Closes #103