### PR TITLE
feat: backfill legacy is_bot on pre-classifier search events

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -35,6 +35,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/referrer-host-classifie
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/content-format-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/outbound-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/mediavine-csv-import.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/isbot-backfill.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/link-page-analytics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';

--- a/inc/core/isbot-backfill.php
+++ b/inc/core/isbot-backfill.php
@@ -1,0 +1,402 @@
+<?php
+/**
+ * Legacy `is_bot` Backfill
+ *
+ * One-off maintenance path that stamps the canonical human/bot verdict onto
+ * analytics events written BEFORE the write-time classifier existed (issue #57
+ * shipped the go-forward stamp in extrachill_track_analytics_event()). Those
+ * legacy rows carry no `is_bot` key in their `event_data` JSON, so every
+ * downstream reader that filters on the flag must decide what to do with them.
+ *
+ * WHY THIS EXISTS. get-search-gaps.php deliberately keeps NULL/no-flag legacy
+ * rows as "human" (the ternary-aware `IS NOT TRUE` predicate) and surfaces an
+ * `unclassified` count rather than guessing — a correct, conservative default
+ * for the go-forward reader (issues #85/#86/#87). But on this install the
+ * legacy search corpus is ~253k rows dated 2026-01-25 → 2026-06-20 that are
+ * overwhelmingly programmatic (events-pipeline / community band-name lookups
+ * fired server-side, the #51 root cause). Because they are counted as human,
+ * the 28-day demand report stays polluted until they age out of the window.
+ * This backfill retires that pollution by stamping the flag directly, instead
+ * of waiting weeks for the window to roll past them.
+ *
+ * THE CLASSIFICATION RULE (derived, not hard-coded "all legacy = bot").
+ * A historical row cannot be re-inspected live — the UA, request origin, and
+ * auth state that the canonical classifier uses are gone. The ONE signal that
+ * survives on the row itself is the same one the write path treats as the
+ * positive human marker: a stitched first-party `visitor_id` (the ec_vid
+ * cookie). The canonical anonymous-traffic verdict in
+ * extrachill_analytics_classify_request() is "human ONLY when a real browser
+ * minted the cookie; a cookieless anonymous request is non-human." Applied to a
+ * stored row that is the derivable rule:
+ *
+ *   - visitor_id present  → stamp is_bot = false  (human-plausible; a browser ran)
+ *   - visitor_id absent   → stamp is_bot = true   (cookieless anonymous → bot)
+ *
+ * This reuses the canonical classifier by feeding it the one signal a stored
+ * row can supply (`has_visitor_cookie`) and forcing the anonymous-traffic path
+ * (is_authenticated = false, request_origin = 'web', UA unknown/empty) — it does
+ * NOT reinvent the verdict. When even that single signal is ambiguous the
+ * command errs toward NOT stamping (a row is only ever touched when it is
+ * missing the flag), never toward a confident wrong verdict.
+ *
+ * IDEMPOTENT + SAFE. The command only ever touches rows whose `event_data`
+ * still lacks the `is_bot` key (`JSON_EXTRACT(...,'$.is_bot') IS NULL`), merges
+ * the single key in with JSON_SET (preserving every other key), and runs in a
+ * bounded LIMIT loop. Re-running it is a no-op once a row is stamped. It
+ * defaults to a dry run; a live pass requires the explicit --live flag.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.24.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve the backfill verdict for a single legacy row from the one signal a
+ * stored row can supply: whether it carries a stitched visitor_id cookie.
+ *
+ * Delegates to the canonical classifier so the backfill and the write path
+ * agree on what "human" means. Of the four signals the classifier weighs, only
+ * the visitor cookie survives on a stored row — the live UA, request origin,
+ * and auth state are gone. We therefore pin the other three to the values that
+ * let the COOKIE be the sole deciding factor, isolating the one historically
+ * truthful signal:
+ *
+ *   - is_authenticated = false  — legacy anonymous front-end traffic; the
+ *     authenticated-user short-circuit (#103) must NOT fire, or every legacy
+ *     row would false-classify as human.
+ *   - request_origin   = 'web'  — pin to the ONE origin the anonymous-traffic
+ *     policy accepts, so origin is neutralized and doesn't force a bot verdict
+ *     on its own.
+ *   - user_agent       = a neutral browser UA — pin to the 'browser' UA class
+ *     (not '' which classifies 'empty' → bot) so the UA is neutralized too.
+ *
+ * With auth/origin/UA neutralized, the classifier's verdict reduces to exactly
+ * `is_bot = ! has_visitor_cookie`: cookie present → human, cookieless → bot.
+ * That is the derived rule, produced BY the canonical classifier rather than
+ * hard-coded around it, so if the shared human policy ever changes this backfill
+ * follows it. (An empty '' UA was intentionally NOT used: it classifies as
+ * 'empty' and would force a bot verdict regardless of the cookie, collapsing the
+ * cookie signal we are trying to preserve.)
+ *
+ * @param bool $has_visitor_cookie Whether the row stored a non-empty visitor_id.
+ * @return bool True to stamp is_bot = true (bot), false to stamp is_bot = false (human).
+ */
+function extrachill_analytics_backfill_is_bot_verdict( $has_visitor_cookie ) {
+	if ( function_exists( 'extrachill_analytics_classify_request' ) ) {
+		$verdict = extrachill_analytics_classify_request(
+			array(
+				'has_visitor_cookie' => (bool) $has_visitor_cookie,
+				'is_authenticated'   => false,
+				'request_origin'     => 'web',
+				// Neutral browser-class UA so the UA signal doesn't veto the
+				// cookie signal (an empty string classifies as 'empty' == bot).
+				'user_agent'         => 'Mozilla/5.0',
+			)
+		);
+
+		return (bool) $verdict['is_bot'];
+	}
+
+	// Defensive fallback if the classifier is somehow unavailable: the cookie is
+	// the sole positive human signal, so cookieless == bot.
+	return ! $has_visitor_cookie;
+}
+
+/**
+ * Backfill the canonical `is_bot` flag onto legacy events missing it.
+ *
+ * Idempotent, batched, dry-run-by-default. Only rows whose event_data JSON does
+ * not already contain an `is_bot` key are considered; each is stamped with the
+ * per-row verdict from extrachill_analytics_backfill_is_bot_verdict(), merging
+ * the key in via JSON_SET so no other event_data key is disturbed.
+ *
+ * @param array $args {
+ *     Optional. Backfill parameters.
+ *
+ *     @type string   $event_type Event type to scope to, or 'all' for every
+ *                                type. Default 'search'.
+ *     @type int      $blog_id    Restrict to a single blog id. 0 = all. Default 0.
+ *     @type int      $batch_size Rows processed per UPDATE loop. Default 2000.
+ *     @type bool     $live       When false (default) computes counts without
+ *                                writing. When true, performs the UPDATEs.
+ *     @type callable $progress   Optional callback( array $tick ) invoked after
+ *                                each batch with running totals for CLI output.
+ * }
+ * @return array{
+ *     scanned: int,
+ *     stamped_bot: int,
+ *     stamped_human: int,
+ *     left_null: int,
+ *     batches: int,
+ *     live: bool,
+ *     event_type: string,
+ *     blog_id: int
+ * }
+ */
+function extrachill_analytics_backfill_is_bot( $args = array() ) {
+	global $wpdb;
+
+	$defaults = array(
+		'event_type' => 'search',
+		'blog_id'    => 0,
+		'batch_size' => 2000,
+		'live'       => false,
+		'progress'   => null,
+	);
+
+	$args       = wp_parse_args( $args, $defaults );
+	$event_type = (string) $args['event_type'];
+	$blog_id    = (int) $args['blog_id'];
+	$batch_size = max( 1, (int) $args['batch_size'] );
+	$live       = (bool) $args['live'];
+	$progress   = is_callable( $args['progress'] ) ? $args['progress'] : null;
+
+	$table = extrachill_analytics_events_table();
+
+	// Build the shared WHERE for "legacy rows still missing the flag".
+	$where  = array( "JSON_EXTRACT(event_data, '$.is_bot') IS NULL" );
+	$values = array();
+
+	if ( 'all' !== strtolower( $event_type ) && '' !== $event_type ) {
+		$where[]  = 'event_type = %s';
+		$values[] = sanitize_key( $event_type );
+	}
+
+	if ( $blog_id > 0 ) {
+		$where[]  = 'blog_id = %d';
+		$values[] = $blog_id;
+	}
+
+	$where_clause = implode( ' AND ', $where );
+
+	$totals = array(
+		'scanned'       => 0,
+		'stamped_bot'   => 0,
+		'stamped_human' => 0,
+		'left_null'     => 0,
+		'batches'       => 0,
+		'live'          => $live,
+		'event_type'    => $event_type,
+		'blog_id'       => $blog_id,
+	);
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	// Cursor by id so a live run (which removes rows from the candidate set as it
+	// stamps them) and a dry run (which does not) both make forward progress
+	// without re-reading the same rows.
+	$last_id = 0;
+
+	do {
+		$batch_where    = $where;
+		$batch_where[]  = 'id > %d';
+		$batch_values   = $values;
+		$batch_values[] = $last_id;
+		$batch_values[] = $batch_size;
+
+		$select_sql = "SELECT id, visitor_id FROM {$table} WHERE "
+			. implode( ' AND ', $batch_where )
+			. ' ORDER BY id ASC LIMIT %d';
+
+		$rows = $wpdb->get_results( $wpdb->prepare( $select_sql, $batch_values ) );
+
+		if ( empty( $rows ) ) {
+			break;
+		}
+
+		$bot_ids   = array();
+		$human_ids = array();
+
+		foreach ( $rows as $row ) {
+			$last_id            = (int) $row->id;
+			$has_visitor_cookie = ( null !== $row->visitor_id && '' !== $row->visitor_id );
+			$is_bot             = extrachill_analytics_backfill_is_bot_verdict( $has_visitor_cookie );
+
+			if ( $is_bot ) {
+				$bot_ids[] = (int) $row->id;
+			} else {
+				$human_ids[] = (int) $row->id;
+			}
+		}
+
+		$totals['scanned']       += count( $rows );
+		$totals['stamped_bot']   += count( $bot_ids );
+		$totals['stamped_human'] += count( $human_ids );
+		++$totals['batches'];
+
+		if ( $live ) {
+			// Merge the single key in with JSON_SET so every other event_data key
+			// is preserved. Two grouped UPDATEs per batch (bot vs human) keep the
+			// verdict literal out of a per-row loop.
+			if ( ! empty( $bot_ids ) ) {
+				extrachill_analytics_backfill_apply( $table, $bot_ids, true );
+			}
+			if ( ! empty( $human_ids ) ) {
+				extrachill_analytics_backfill_apply( $table, $human_ids, false );
+			}
+		}
+
+		if ( $progress ) {
+			call_user_func( $progress, $totals );
+		}
+	} while ( count( $rows ) === $batch_size );
+
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	return $totals;
+}
+
+/**
+ * Apply the is_bot stamp to a set of ids using JSON_SET so the merge preserves
+ * all other event_data keys.
+ *
+ * @param string $table  Fully-qualified events table name.
+ * @param int[]  $ids     Row ids to stamp.
+ * @param bool   $is_bot  Verdict to write.
+ * @return int|false Rows affected, or false on error.
+ */
+function extrachill_analytics_backfill_apply( $table, $ids, $is_bot ) {
+	global $wpdb;
+
+	$ids = array_map( 'intval', (array) $ids );
+	if ( empty( $ids ) ) {
+		return 0;
+	}
+
+	// JSON_SET writes a real JSON boolean so the stamped value matches the
+	// write-path shape ($.is_bot is a JSON true/false, which the readers test
+	// with IS TRUE / IS NOT TRUE). The value is the bare SQL boolean keyword
+	// `true`/`false` — NOT `CAST('true' AS JSON)`, which errors on this MariaDB
+	// server (verified). JSON_SET(..., true) yields {"is_bot": true}, identical
+	// to what extrachill_track_analytics_event() persists. The literal is a
+	// fixed, code-defined keyword — never request input.
+	$bool_literal = $is_bot ? 'true' : 'false';
+	$placeholders = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$sql = "UPDATE {$table} "
+		. "SET event_data = JSON_SET(event_data, '$.is_bot', {$bool_literal}) "
+		. "WHERE id IN ({$placeholders}) AND JSON_EXTRACT(event_data, '$.is_bot') IS NULL";
+
+	$result = $wpdb->query( $wpdb->prepare( $sql, $ids ) );
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	return $result;
+}
+
+// -----------------------------------------------------------------------------
+// WP-CLI command
+// -----------------------------------------------------------------------------
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+
+	/**
+	 * Backfill the canonical is_bot flag onto legacy pre-classifier events.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--event-type=<type>]
+	 * : Event type to scope the backfill to, or 'all' for every type. The search
+	 *   corpus is the priority because it pollutes the get-search-gaps demand
+	 *   report; other types (404_error, etc.) feed different readers, so scope
+	 *   stays tight by default.
+	 * ---
+	 * default: search
+	 * ---
+	 *
+	 * [--blog=<id>]
+	 * : Restrict to a single blog id. 0 = network-wide (all blogs).
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--batch-size=<n>]
+	 * : Rows processed per batch loop.
+	 * ---
+	 * default: 2000
+	 * ---
+	 *
+	 * [--dry-run]
+	 * : Compute and report the projected split WITHOUT writing. This is the
+	 *   default; the flag is accepted for explicitness.
+	 *
+	 * [--live]
+	 * : Actually write the stamps. Without this flag the command is read-only.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Dry-run the network-wide search backfill (default, no writes).
+	 *     wp extrachill-analytics backfill-isbot
+	 *
+	 *     # Live backfill search events for blog 1 only.
+	 *     wp extrachill-analytics backfill-isbot --live --blog=1
+	 *
+	 *     # Live backfill every event type still missing the flag.
+	 *     wp extrachill-analytics backfill-isbot --event-type=all --live
+	 *
+	 * @param array $pos_args   Positional args (unused).
+	 * @param array $assoc_args Flags.
+	 * @return void
+	 */
+	function extrachill_analytics_cli_backfill_isbot( $pos_args, $assoc_args ) {
+		$live       = isset( $assoc_args['live'] );
+		$event_type = isset( $assoc_args['event-type'] ) ? (string) $assoc_args['event-type'] : 'search';
+		$blog_id    = isset( $assoc_args['blog'] ) ? (int) $assoc_args['blog'] : 0;
+		$batch_size = isset( $assoc_args['batch-size'] ) ? (int) $assoc_args['batch-size'] : 2000;
+
+		WP_CLI::log(
+			sprintf(
+				'is_bot backfill — event_type=%s, blog=%s, batch_size=%d, mode=%s',
+				$event_type,
+				$blog_id > 0 ? (string) $blog_id : 'all',
+				$batch_size,
+				$live ? 'LIVE (writing)' : 'DRY-RUN (no writes)'
+			)
+		);
+
+		$progress = static function ( $tick ) {
+			WP_CLI::log(
+				sprintf(
+					'  batch %d — scanned %d, bot %d, human %d',
+					$tick['batches'],
+					$tick['scanned'],
+					$tick['stamped_bot'],
+					$tick['stamped_human']
+				)
+			);
+		};
+
+		$result = extrachill_analytics_backfill_is_bot(
+			array(
+				'event_type' => $event_type,
+				'blog_id'    => $blog_id,
+				'batch_size' => $batch_size,
+				'live'       => $live,
+				'progress'   => $progress,
+			)
+		);
+
+		WP_CLI::log( '' );
+		WP_CLI::log(
+			sprintf(
+				'%s: %d rows %s — %d bot, %d human, %d left NULL, in %d batch(es).',
+				$live ? 'STAMPED' : 'WOULD STAMP',
+				$result['stamped_bot'] + $result['stamped_human'],
+				$live ? 'stamped' : 'projected',
+				$result['stamped_bot'],
+				$result['stamped_human'],
+				$result['left_null'],
+				$result['batches']
+			)
+		);
+
+		if ( ! $live ) {
+			WP_CLI::success( 'Dry-run complete. Re-run with --live to apply.' );
+		} else {
+			WP_CLI::success( 'Backfill complete.' );
+		}
+	}
+
+	WP_CLI::add_command( 'extrachill-analytics backfill-isbot', 'extrachill_analytics_cli_backfill_isbot' );
+}


### PR DESCRIPTION
Closes #107

## What & why

The write-time `is_bot` stamp (issue #57) fixed the go-forward case, but **253,183** `search` events written **2026-01-25 → 2026-06-20** predate the classifier and carry no `is_bot` key. `get-search-gaps.php` deliberately counts NULL/no-flag legacy rows as **human** (correct conservative default, issues #85/#86/#87) — so the 28-day demand report stays polluted by that legacy programmatic traffic (the #51 root cause) until the window ages past 2026-06-20.

This adds an idempotent, batched, dry-run-first backfill that stamps the flag directly instead of waiting weeks for the pollution to roll out of the window.

## The classification rule (derived, not hard-coded)

A stored row can't be re-inspected live — UA, request origin, auth state are gone. The **one** signal that survives is the same positive human marker the write path uses: a stitched `visitor_id` cookie. So:

- `visitor_id` present → `is_bot = false` (a browser ran / human-plausible)
- `visitor_id` absent  → `is_bot = true`  (cookieless anonymous → non-human)

Crucially this is produced **by** `extrachill_analytics_classify_request()`, not around it: the verdict function feeds the classifier `has_visitor_cookie` (the real per-row signal) and pins the three unrecoverable signals to values that neutralize them so the cookie is the sole deciding factor —
- `is_authenticated = false` (legacy anon traffic; the #103 authed short-circuit must not fire),
- `request_origin = 'web'` (the one origin the anon policy accepts → neutral),
- `user_agent = 'Mozilla/5.0'` (a **browser-class** UA; an empty string classifies as `empty` and would force bot regardless of cookie, collapsing the signal we want to preserve).

With those pinned, the classifier reduces to exactly `is_bot = !has_visitor_cookie`. If the shared human policy ever changes, this backfill follows it. When a signal is genuinely ambiguous the command prefers **not** stamping over a confident wrong verdict (a row is only ever touched when it's missing the flag).

## Dry-run numbers (read-only SQL against the live table)

`search` scope (network-wide):

| verdict | rows |
|---|---|
| stamp **bot** | 253,183 |
| stamp **human** | 0 |
| left **NULL** | 0 |

100% cookieless → 100% bot. Verified two ways:
1. `SELECT ... GROUP BY (visitor_id present?)` → 253,183 cookieless, 0 cookied.
2. Engine dry-run (`extrachill_analytics_backfill_is_bot(['event_type'=>'search','live'=>false])`) → scanned 253,183 / bot 253,183 / human 0 / left_null 0, in 6 batches — matches the SQL exactly.

`all` scope projection (for reference; not the default): 710,467 rows would stamp (429k of them `404_error`, which feeds a different reader — hence the default stays `search`).

## Idempotency & safety

- Only ever selects/updates rows where `JSON_EXTRACT(event_data,'$.is_bot') IS NULL` — re-runs are no-ops.
- `JSON_SET(event_data, '$.is_bot', true|false)` merges the single key; **all other event_data keys preserved**. Uses the bare boolean keyword, **not** `CAST('true' AS JSON)` — that errors on this MariaDB server (verified). Confirmed the stamped value passes the readers' `IS TRUE` / `IS NOT TRUE` predicates and matches the exact `{"...":...,"is_bot":true}` shape the write path stores.
- Cursor-by-id `LIMIT` loop with progress output; `--batch-size` tunable (default 2000).
- **Dry-run by default**; `--live` required to write. `--event-type` (default `search`, or `all`), `--blog` optional filter.

## Why this does NOT reverse #51 / #85 / #86 / #87 / #103

It **complements** them. #57 stamps new events at write time; this backfills the historical tail the write path never saw. The reader's `IS NOT TRUE` predicate and default-OFF `require_visitor_id` gate (#85/#87) are untouched — the backfill just moves legacy rows out of the "NULL kept as human" bucket into an explicit verdict, which is exactly what those readers were built to consume. The #103 authed-human override is explicitly held OFF for this anonymous legacy corpus so it can't false-flag legacy rows as human. No product-direction reversal — go-forward stamp + historical backfill.

## Tests / lint

- `homeboy lint`: **phpstan 0 findings** on the change (the repo's declared gate via `phpstan.neon`). Pre-existing phpcs/eslint debt is unrelated to this PR (no JS added; new PHP follows the same style + `phpcs:disable` direct-query pragmas as the sibling `get-search-gaps.php`).
- `php -l` clean on both changed files.
- No phpunit test infra exists in this repo (phpunit is a dev dep but there is no `tests/` dir or `phpunit.xml`), so rather than bolt on an unused harness the classification rule is proven end-to-end against live data: verdict function returns `is_bot=false` for cookied and `is_bot=true` for cookieless, and the engine dry-run matches the independent SQL projection exactly.

## Not done (left for the human)

- **`--live` was NOT run against production.** Only read-only dry-run analysis. The live backfill is left for a human to execute.

## Files

- `inc/core/isbot-backfill.php` — engine (`extrachill_analytics_backfill_is_bot`, `_verdict`, `_apply`) + WP-CLI command `wp extrachill-analytics backfill-isbot`.
- `extrachill-analytics.php` — require the new file.