### PR TITLE
fix: register network pages under extrachill-network parent slug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ $views = ec_get_post_views($post_id);
 **Pattern**: WordPress multisite submenu page pattern with asset loading restrictions.
 
 **Menu Structure**:
-- Parent: `extrachill-multisite` (defined by extrachill-multisite plugin)
+- Parent: `EXTRACHILL_NETWORK_MENU_SLUG` (`extrachill-network`, defined by extrachill-network plugin, with literal fallback)
 - Page: `extrachill-analytics`
 - Capability: `manage_network_options`
 
@@ -90,7 +90,7 @@ $views = ec_get_post_views($post_id);
 
 **Asset Loading**: Only loads on specific submenu page via hook parameter check:
 ```php
-if ('extrachill-multisite_page_extrachill-analytics' !== $hook) {
+if ('extra-chill-network_page_extrachill-analytics' !== $hook) {
     return;
 }
 ```

--- a/inc/admin/network-menu.php
+++ b/inc/admin/network-menu.php
@@ -2,7 +2,7 @@
 /**
  * Network Admin Menu Integration
  *
- * Registers the analytics submenu under Extra Chill Multisite.
+ * Registers the analytics submenu under Extra Chill Network.
  *
  * @package ExtraChill\Analytics
  */
@@ -10,11 +10,11 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Add submenu page to Extra Chill Multisite menu.
+ * Add submenu page to Extra Chill Network menu.
  */
 function extrachill_analytics_add_network_menu() {
 	add_submenu_page(
-		'extrachill-multisite',
+		defined( 'EXTRACHILL_NETWORK_MENU_SLUG' ) ? EXTRACHILL_NETWORK_MENU_SLUG : 'extrachill-network',
 		'Analytics',
 		'Analytics',
 		'manage_network_options',
@@ -42,7 +42,7 @@ function extrachill_analytics_render_admin_page() {
  * Enqueue admin assets for the analytics page.
  */
 function extrachill_analytics_enqueue_admin_assets( $hook ) {
-	if ( 'extra-chill-multisite_page_extrachill-analytics' !== $hook ) {
+	if ( 'extra-chill-network_page_extrachill-analytics' !== $hook ) {
 		return;
 	}
 

--- a/inc/admin/network-tracking-settings.php
+++ b/inc/admin/network-tracking-settings.php
@@ -12,13 +12,13 @@ defined( 'ABSPATH' ) || exit;
 add_action( 'network_admin_menu', 'extrachill_analytics_add_tracking_network_menu', 30 );
 
 /**
- * Add Tracking submenu under Extra Chill Multisite.
+ * Add Tracking submenu under Extra Chill Network.
  *
  * @return void
  */
 function extrachill_analytics_add_tracking_network_menu() {
 	add_submenu_page(
-		'extrachill-multisite',
+		defined( 'EXTRACHILL_NETWORK_MENU_SLUG' ) ? EXTRACHILL_NETWORK_MENU_SLUG : 'extrachill-network',
 		'Tracking',
 		'Tracking',
 		'manage_network_options',


### PR DESCRIPTION
## Summary
- Analytics and Tracking network-admin submenu pages registered under the parent slug `extrachill-multisite`, which no plugin creates anymore (the old extrachill-multisite plugin was replaced by extrachill-network, whose top-level menu slug is `extrachill-network` / `EXTRACHILL_NETWORK_MENU_SLUG`).
- WordPress silently drops submenus whose parent doesn't exist, so both pages were invisible in the network admin sidebar.

## Fix
- `inc/admin/network-menu.php` — `add_submenu_page()` parent changed to `defined( 'EXTRACHILL_NETWORK_MENU_SLUG' ) ? EXTRACHILL_NETWORK_MENU_SLUG : 'extrachill-network'`; corresponding asset-loading hook-suffix check updated from `extra-chill-multisite_page_extrachill-analytics` to `extra-chill-network_page_extrachill-analytics`.
- `inc/admin/network-tracking-settings.php` — same parent-slug fix for the Tracking submenu.
- `AGENTS.md` — updated documentation to match the corrected parent slug and hook suffix.
- Grepped the whole repo for other `extrachill-multisite` occurrences (redirect URLs, form actions) — none found outside the two menu registrations and unrelated docblock references to the old `extrachill-multisite` GitHub repo name, which are out of scope.

Fixes #118

## Verification
- `php -l` on both changed PHP files — no syntax errors.
- No `vendor/bin/phpcs` available in this checkout to run the full lint suite; changes are minimal (string/constant swaps) and follow the reference pattern used in extrachill-seo's `inc/admin/network-settings.php`.