### PR TITLE
fix: count only recent PHP errors as active

### DIFF
--- a/inc/core/abilities/get-php-error-summary.php
+++ b/inc/core/abilities/get-php-error-summary.php
@@ -86,10 +86,10 @@ function extrachill_analytics_register_php_error_summary_ability() {
  *   [
  *     'rows'                => [ [ signature, severity, file, count, per_day, sample, first_seen, last_seen ], ... ],
  *     'total'               => int,
- *     'active_total'        => int,    // Hits from signatures still firing within the active window.
- *     'active_per_day'      => float,  // active_total / days_covered — the CURRENT error rate.
- *     'active_window_hours' => int,    // The activity threshold used to decide still-firing vs resolved.
- *     'active_signatures'   => int,    // Distinct signatures whose last_seen is within the active window.
+ *     'active_total'        => int,    // Occurrences whose timestamps fall inside the active window.
+ *     'active_per_day'      => float,  // active_total normalized to the active-window length (per day).
+ *     'active_window_hours' => int,    // The activity threshold defining "currently firing".
+ *     'active_signatures'   => int,    // Distinct signatures with at least one active-window occurrence.
  *     'distinct_signatures' => int,
  *     'window_days'         => int,
  *     'days_covered'        => int,
@@ -99,12 +99,18 @@ function extrachill_analytics_register_php_error_summary_ability() {
  *     'log_path'            => string,
  *   ]
  *
- * The `active_*` keys are the "currently firing" lens: a signature whose
- * last_seen is older than the active window is treated as RESOLVED and excluded
- * from `active_total` / `active_per_day`, so a spike that was fixed hours ago
- * stops inflating the current error rate. The full-window `total` is preserved
+ * The `active_*` keys are the "currently firing" lens: `active_total` counts
+ * ONLY occurrences whose own timestamps fall inside the active window — not the
+ * full-window count of a signature that merely has a recent tail (issue #128).
+ * A resolved multi-day spike that left a single fresh occurrence contributes
+ * just that one recent occurrence, so a fixed spike stops inflating the current
+ * error rate. The full-window `total` and per-signature `per_day` are preserved
  * unchanged for trend continuity. The activity window defaults to 24 hours and
  * is filterable via `extrachill_analytics_error_active_window_hours`.
+ *
+ * Persisted/live merge: the persisted daily table covers bytes [0, watermark)
+ * already snapshotted; the live tail is read from that watermark so the two
+ * sources are byte-disjoint and never count the same occurrence twice.
  */
 function extrachill_analytics_ability_get_php_error_summary( $input ) {
 	global $wpdb;
@@ -126,6 +132,13 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 
 	$since_ts  = $days > 0 ? strtotime( "-{$days} days", time() ) : null;
 	$since_day = null !== $since_ts ? gmdate( 'Y-m-d', $since_ts ) : null;
+
+	// Active-window threshold (computed early so both persisted and live sources
+	// share one cutoff). active_total counts only occurrences inside this window,
+	// not the full-window count of a signature that merely has a recent tail (#128).
+	$active_window_hours = (int) apply_filters( 'extrachill_analytics_error_active_window_hours', 24 );
+	$active_window_hours = max( 1, $active_window_hours );
+	$active_cutoff       = time() - ( $active_window_hours * HOUR_IN_SECONDS );
 
 	// 1. Persisted daily counts from the durable table.
 	$table  = extrachill_analytics_php_error_table();
@@ -161,6 +174,35 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 		: $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
+	// Active-window persisted counts: sum the per-day rows whose latest
+	// occurrence (last_seen) falls inside the active cutoff. The durable table
+	// stores daily aggregates, so active resolution is day-granularity: a daily
+	// row counts toward active_total when its newest occurrence that day is
+	// recent. This correctly EXCLUDES resolved multi-day-old spikes even when the
+	// same signature has one fresh occurrence, fixing the #128 regression. Sub-day
+	// splitting is the documented limit of the daily schema.
+	$active_where        = $where;
+	$active_values       = $values;
+	$active_where[]      = 'last_seen >= %s';
+	$active_values[]     = gmdate( 'Y-m-d H:i:s', $active_cutoff );
+	$active_where_clause = implode( ' AND ', $active_where );
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$active_sql = "SELECT signature, SUM(count) AS active_count
+				FROM {$table}
+				WHERE {$active_where_clause}
+				GROUP BY signature";
+
+	$persisted_active = $wpdb->get_results( $wpdb->prepare( $active_sql, $active_values ) );
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	$persisted_active_map = array();
+	if ( is_array( $persisted_active ) ) {
+		foreach ( $persisted_active as $active_row ) {
+			$persisted_active_map[ (string) $active_row->signature ] = (int) $active_row->active_count;
+		}
+	}
+
 	$agg          = array();
 	$covered_days = array();
 
@@ -168,13 +210,14 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 		foreach ( $persisted as $row ) {
 			$sig         = (string) $row->signature;
 			$agg[ $sig ] = array(
-				'signature'  => $sig,
-				'severity'   => (string) $row->severity,
-				'file'       => (string) $row->file_line,
-				'count'      => (int) $row->total_count,
-				'sample'     => (string) $row->sample_message,
-				'first_seen' => (string) $row->first_seen,
-				'last_seen'  => (string) $row->last_seen,
+				'signature'    => $sig,
+				'severity'     => (string) $row->severity,
+				'file'         => (string) $row->file_line,
+				'count'        => (int) $row->total_count,
+				'active_count' => isset( $persisted_active_map[ $sig ] ) ? $persisted_active_map[ $sig ] : 0,
+				'sample'       => (string) $row->sample_message,
+				'first_seen'   => (string) $row->first_seen,
+				'last_seen'    => (string) $row->last_seen,
 			);
 			if ( $row->first_seen ) {
 				$covered_days[ gmdate( 'Y-m-d', strtotime( $row->first_seen ) ) ] = true;
@@ -187,9 +230,12 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 
 	// 2. Live tail of the current debug.log for not-yet-snapshotted entries.
 	$log_path = extrachill_analytics_php_error_log_path();
-	// Cap the live read so an enormous unrotated log can't blow up memory; the
-	// durable table is the source of truth for older history anyway.
-	$live = extrachill_analytics_parse_php_error_log( $log_path, $since_ts, 32 * MB_IN_BYTES );
+	// Read the live tail starting at the snapshot byte watermark so live entries
+	// are the not-yet-snapshotted bytes only — disjoint from the persisted set
+	// (which already covers bytes [0, watermark)). This prevents the same
+	// occurrence being counted in both sources. The memory cap still applies.
+	$watermark = extrachill_analytics_php_error_log_snapshot_offset( $log_path );
+	$live      = extrachill_analytics_parse_php_error_log( $log_path, $since_ts, 32 * MB_IN_BYTES, $watermark );
 
 	foreach ( $live['entries'] as $entry ) {
 		if ( 'all' !== $severity && $entry['severity'] !== $severity ) {
@@ -200,17 +246,23 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 
 		if ( ! isset( $agg[ $sig ] ) ) {
 			$agg[ $sig ] = array(
-				'signature'  => $sig,
-				'severity'   => $entry['severity'],
-				'file'       => $entry['file'],
-				'count'      => 0,
-				'sample'     => $entry['sample'],
-				'first_seen' => null,
-				'last_seen'  => null,
+				'signature'    => $sig,
+				'severity'     => $entry['severity'],
+				'file'         => $entry['file'],
+				'count'        => 0,
+				'active_count' => 0,
+				'sample'       => $entry['sample'],
+				'first_seen'   => null,
+				'last_seen'    => null,
 			);
 		}
 
 		++$agg[ $sig ]['count'];
+
+		// Live occurrences inside the active window count toward active volume.
+		if ( null !== $entry['ts'] && $entry['ts'] >= $active_cutoff ) {
+			++$agg[ $sig ]['active_count'];
+		}
 
 		if ( null !== $entry['ts'] ) {
 			$ts_str = gmdate( 'Y-m-d H:i:s', $entry['ts'] );
@@ -244,33 +296,21 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 		}
 	);
 
-	// Active-window threshold: a signature whose last_seen is older than this many
-	// hours is considered RESOLVED and excluded from the "currently firing" lens.
-	// The live tail is the arbiter — if a signature has stopped appearing, it no
-	// longer counts toward the current error rate even if it still sits in the
-	// persisted window total.
-	$active_window_hours = (int) apply_filters( 'extrachill_analytics_error_active_window_hours', 24 );
-	$active_window_hours = max( 1, $active_window_hours );
-	$active_cutoff       = time() - ( $active_window_hours * HOUR_IN_SECONDS );
+	// Finalize per-row rates and the active-window totals. The active lens is
+	// driven by each row's active_count (occurrences inside the active window),
+	// NOT its full-window count — the #128 fix. Isolated in a pure helper so the
+	// counting contract is unit-testable without a database.
+	$computed = extrachill_analytics_compute_php_error_active_totals(
+		$rows,
+		$denominator,
+		$active_window_hours
+	);
 
-	$grand_total       = 0;
-	$active_total      = 0;
-	$active_signatures = 0;
-	foreach ( $rows as &$row ) {
-		$grand_total   += $row['count'];
-		$row['per_day'] = round( $row['count'] / $denominator, 1 );
-
-		// Mark each row active/resolved and accumulate the active-only totals.
-		$last_seen_ts  = ! empty( $row['last_seen'] ) ? strtotime( (string) $row['last_seen'] . ' UTC' ) : false;
-		$row['active'] = ( false !== $last_seen_ts && $last_seen_ts >= $active_cutoff );
-		if ( $row['active'] ) {
-			$active_total += $row['count'];
-			++$active_signatures;
-		}
-	}
-	unset( $row );
-
-	$active_per_day = round( $active_total / $denominator, 1 );
+	$rows              = $computed['rows'];
+	$grand_total       = $computed['total'];
+	$active_total      = $computed['active_total'];
+	$active_per_day    = $computed['active_per_day'];
+	$active_signatures = $computed['active_signatures'];
 
 	$distinct  = count( $rows );
 	$truncated = false;
@@ -302,5 +342,70 @@ function extrachill_analytics_ability_get_php_error_summary( $input ) {
 		'source'              => $source,
 		'truncated'           => $truncated,
 		'log_path'            => $log_path,
+	);
+}
+
+/**
+ * Finalize per-row rates and compute the active-window (currently-firing) totals.
+ *
+ * Pure — no WP / DB dependencies — so the counting contract at the heart of
+ * issue #128 is unit-testable in isolation. Each row contributes to the active
+ * volume via its `active_count` (occurrences inside the active window), NOT its
+ * full-window `count`. A signature is "active" when it has at least one recent
+ * occurrence; a resolved multi-day spike that left a single fresh occurrence
+ * contributes just that one occurrence, not its entire historical count.
+ *
+ * `active_per_day` normalizes active volume to the active-window length (e.g.
+ * last-24h count expressed per day), matching the platform-health consumer's
+ * own active-window normalization.
+ *
+ * @param array $rows Aggregated rows; each carries 'count' (full window) and
+ *                    optionally 'active_count' (active window, defaulted to 0).
+ *                    Mutated in place: 'per_day', 'active_count', and 'active'
+ *                    are stamped on each row.
+ * @param int   $denominator Full-window per-day denominator (for per_day trend).
+ * @param int   $active_window_hours Active window length in hours.
+ * @return array{
+ *     rows: array<int, array>,
+ *     total: int,
+ *     active_total: int,
+ *     active_per_day: float,
+ *     active_signatures: int,
+ * }
+ */
+function extrachill_analytics_compute_php_error_active_totals( array $rows, $denominator, $active_window_hours ) {
+	$denominator        = max( 1, (int) $denominator );
+	$active_window_days = max( 1.0, (float) $active_window_hours / 24.0 );
+
+	$grand_total       = 0;
+	$active_total      = 0;
+	$active_signatures = 0;
+
+	foreach ( $rows as &$row ) {
+		$grand_total += (int) $row['count'];
+
+		// Full-window per-day trend rate (unchanged): total count over the
+		// requested window denominator.
+		$row['per_day'] = round( (int) $row['count'] / $denominator, 1 );
+
+		// Active lens: count only occurrences inside the active window.
+		if ( ! isset( $row['active_count'] ) ) {
+			$row['active_count'] = 0;
+		}
+		$row['active_count'] = (int) $row['active_count'];
+		$row['active']       = $row['active_count'] > 0;
+		if ( $row['active'] ) {
+			$active_total += $row['active_count'];
+			++$active_signatures;
+		}
+	}
+	unset( $row );
+
+	return array(
+		'rows'              => $rows,
+		'total'             => $grand_total,
+		'active_total'      => $active_total,
+		'active_per_day'    => round( $active_total / $active_window_days, 1 ),
+		'active_signatures' => $active_signatures,
 	);
 }

--- a/inc/core/php-error-log.php
+++ b/inc/core/php-error-log.php
@@ -16,6 +16,16 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Site-option key storing the byte high-water mark of the last snapshot pass.
+ *
+ * The snapshot writer persists bytes [0, offset) into the durable daily table
+ * and records {inode, offset} here. Read-side consumers (the summary ability)
+ * read the live tail starting at this offset so live entries are the
+ * not-yet-snapshotted bytes only — disjoint from the persisted set.
+ */
+define( 'EXTRACHILL_ANALYTICS_PHP_ERROR_LOG_OFFSET_OPTION', 'extrachill_analytics_php_error_log_offset' );
+
+/**
  * Resolve the path to the active PHP error log file.
  *
  * Honors the `error_log` ini directive when it points at a real file, then
@@ -90,13 +100,19 @@ function extrachill_analytics_php_error_log_siblings( $log_path ) {
  * @param string   $log_path Path to a log file.
  * @param int|null $since_ts Unix timestamp lower bound (inclusive). Null = no bound.
  * @param int      $max_bytes Maximum bytes to read from the tail of the file. 0 = whole file.
+ * @param int      $start_offset Byte offset to begin reading at. Used to read only
+ *                              the not-yet-snapshotted tail: persisted bytes live in
+ *                              [0, start_offset), so the live read starts here to
+ *                              stay disjoint and avoid double counting. The effective
+ *                              start is max( start_offset, size - max_bytes ) so the
+ *                              memory cap is still honored.
  * @return array{
  *     entries: array<int, array{ts:int|null, severity:string, message:string, file:string, line:int, signature:string, sample:string, origin_path:string, from_production:bool}>,
  *     min_ts: int|null,
  *     max_ts: int|null
  * }
  */
-function extrachill_analytics_parse_php_error_log( $log_path, $since_ts = null, $max_bytes = 0 ) {
+function extrachill_analytics_parse_php_error_log( $log_path, $since_ts = null, $max_bytes = 0, $start_offset = 0 ) {
 	$result = array(
 		'entries' => array(),
 		'min_ts'  => null,
@@ -114,10 +130,25 @@ function extrachill_analytics_parse_php_error_log( $log_path, $since_ts = null, 
 
 	if ( $max_bytes > 0 ) {
 		$size = filesize( $log_path );
-		if ( $size > $max_bytes ) {
-			fseek( $handle, $size - $max_bytes );
-			// Discard the partial first line after seeking into the middle.
-			fgets( $handle );
+		if ( is_int( $size ) && $size > $max_bytes ) {
+			$tail_start = $size - $max_bytes;
+			// Honor the memory cap: never read earlier than the tail window.
+			if ( $tail_start > $start_offset ) {
+				$start_offset = $tail_start;
+			}
+		}
+	}
+
+	if ( $start_offset > 0 ) {
+		// Only discard the first line when the seek landed mid-line (a partial
+		// fragment). The snapshot byte watermark always lands on a line boundary
+		// (ftell after a complete fgets loop), so its first full entry must be
+		// preserved — discarding it would silently lose the newest snapshot gap.
+		// A tail-memory-cap seek lands mid-line and drops the fragment instead.
+		fseek( $handle, $start_offset - 1 );
+		$prev = fgetc( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fgetc — advances pointer to start_offset.
+		if ( "\n" !== $prev ) {
+			fgets( $handle ); // Discard the remainder of the partial first line.
 		}
 	}
 
@@ -384,6 +415,61 @@ function extrachill_analytics_canonical_severity( $raw_severity ) {
 }
 
 /**
+ * Resolve the byte offset marking the boundary between already-snapshotted
+ * (persisted) bytes and not-yet-snapshotted bytes of the current error log.
+ *
+ * The snapshot writer (extrachill_analytics_snapshot_php_errors) persists bytes
+ * [0, offset) into the durable daily table and stores {inode, offset}. Reading
+ * the live tail from this offset guarantees live entries are disjoint from the
+ * persisted set, preventing double counting when the summary ability merges the
+ * two sources.
+ *
+ * Rotation / truncation is detected the same way the snapshot writer does: a
+ * changed inode (when one was previously recorded) or a file shorter than the
+ * stored offset resets to 0 — the persisted data from the prior inode is
+ * already in the table, and a truncated/rotated file starts fresh. This helper
+ * is read-only: it never mutates the stored offset (the snapshot owns the write).
+ *
+ * @param string $log_path Absolute path to the error log file.
+ * @return int Byte offset to start reading live (unsnapshotted) bytes from.
+ */
+function extrachill_analytics_php_error_log_snapshot_offset( $log_path ) {
+	if ( ! is_file( $log_path ) || ! is_readable( $log_path ) ) {
+		return 0;
+	}
+
+	clearstatcache( true, $log_path );
+	$size  = (int) filesize( $log_path );
+	$inode = (int) @fileinode( $log_path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+	$stored = get_site_option(
+		EXTRACHILL_ANALYTICS_PHP_ERROR_LOG_OFFSET_OPTION,
+		array(
+			'inode'  => 0,
+			'offset' => 0,
+		)
+	);
+	if ( ! is_array( $stored ) ) {
+		$stored = array(
+			'inode'  => 0,
+			'offset' => 0,
+		);
+	}
+
+	$stored_inode  = isset( $stored['inode'] ) ? (int) $stored['inode'] : 0;
+	$stored_offset = isset( $stored['offset'] ) ? (int) $stored['offset'] : 0;
+
+	// Rotation / truncation: new inode (when one was recorded), or the file
+	// shrank below the stored offset. Either means the stored boundary no
+	// longer describes the current file — start live reads from the top.
+	if ( ( 0 !== $stored_inode && $stored_inode !== $inode ) || $size < $stored_offset ) {
+		return 0;
+	}
+
+	return $stored_offset;
+}
+
+/**
  * Snapshot today's (and recent) signature counts from the live log into the
  * durable daily table, so per-day rates survive log rotation.
  *
@@ -399,7 +485,7 @@ function extrachill_analytics_snapshot_php_errors() {
 	global $wpdb;
 
 	$log_path      = extrachill_analytics_php_error_log_path();
-	$offset_option = 'extrachill_analytics_php_error_log_offset';
+	$offset_option = EXTRACHILL_ANALYTICS_PHP_ERROR_LOG_OFFSET_OPTION;
 	$stored        = get_site_option(
 		$offset_option,
 		array(

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit colors="true" bootstrap="tests/bootstrap.php">
 	<testsuites>
 		<testsuite name="Extra Chill Analytics">
 			<directory>tests</directory>

--- a/tests/PhpErrorActiveTotalsTest.php
+++ b/tests/PhpErrorActiveTotalsTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Tests for the PHP error active-count contract (issue #128).
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verify active_total counts only recent occurrences, not a signature's
+ * full-window count, and that full-window totals/rates are preserved.
+ */
+final class PhpErrorActiveTotalsTest extends TestCase {
+
+	/**
+	 * The #128 regression: a large historical spike that is resolved, plus one
+	 * recent occurrence, must yield an active_total of 1 — NOT the spike's
+	 * full-window count.
+	 */
+	public function test_resolved_spike_plus_one_recent_occurrence_does_not_inflate_active_total(): void {
+		$rows = array(
+			array(
+				'signature'    => 'oldspike',
+				'count'        => 1000, // Large historical spike.
+				'active_count' => 0,    // Resolved — nothing inside the active window.
+				'last_seen'    => gmdate( 'Y-m-d H:i:s', time() - ( 20 * DAY_IN_SECONDS ) ),
+			),
+			array(
+				'signature'    => 'fresh',
+				'count'        => 1,    // One recent occurrence.
+				'active_count' => 1,    // That single occurrence is inside the window.
+				'last_seen'    => gmdate( 'Y-m-d H:i:s', time() - ( 1 * HOUR_IN_SECONDS ) ),
+			),
+		);
+
+		$result = extrachill_analytics_compute_php_error_active_totals( $rows, 28, 24 );
+
+		// Full-window total is preserved unchanged.
+		$this->assertSame( 1001, $result['total'] );
+
+		// Active volume is the single recent occurrence, not 1001.
+		$this->assertSame( 1, $result['active_total'] );
+		$this->assertSame( 1, $result['active_signatures'] );
+
+		// Last-24h active volume expressed per day = 1 / (24/24) = 1.0.
+		$this->assertSame( 1.0, $result['active_per_day'] );
+
+		// The resolved spike row is marked inactive; the fresh row is active.
+		$by_sig = array_column( $result['rows'], null, 'signature' );
+		$this->assertFalse( $by_sig['oldspike']['active'] );
+		$this->assertTrue( $by_sig['fresh']['active'] );
+	}
+
+	/**
+	 * Before #128, a signature whose last_seen was recent contributed its entire
+	 * count. With active_count semantics, only the in-window portion counts even
+	 * when the row stays "active".
+	 */
+	public function test_active_total_uses_active_count_not_full_count(): void {
+		$rows = array(
+			array(
+				'signature'    => 'partial',
+				'count'        => 50,   // 50 across the full window.
+				'active_count' => 3,    // Only 3 inside the active window.
+			),
+		);
+
+		$result = extrachill_analytics_compute_php_error_active_totals( $rows, 28, 24 );
+
+		$this->assertSame( 50, $result['total'] );
+		$this->assertSame( 3, $result['active_total'] );
+		$this->assertSame( 3.0, $result['active_per_day'] );
+		// Full-window per-day trend is preserved.
+		$this->assertSame( round( 50 / 28, 1 ), $result['rows'][0]['per_day'] );
+	}
+
+	/**
+	 * When every signature is resolved, active volume is zero but the full-window
+	 * total remains intact for trend continuity.
+	 */
+	public function test_all_resolved_yields_zero_active_but_preserves_total(): void {
+		$rows = array(
+			array(
+				'signature'    => 'a',
+				'count'        => 500,
+				'active_count' => 0,
+			),
+			array(
+				'signature'    => 'b',
+				'count'        => 40,
+				'active_count' => 0,
+			),
+		);
+
+		$result = extrachill_analytics_compute_php_error_active_totals( $rows, 28, 24 );
+
+		$this->assertSame( 540, $result['total'] );
+		$this->assertSame( 0, $result['active_total'] );
+		$this->assertSame( 0, $result['active_signatures'] );
+		$this->assertSame( 0.0, $result['active_per_day'] );
+	}
+
+	/**
+	 * The active_per_day rate normalizes to the active-window length, not the
+	 * full window. A 48-hour window with 6 active occurrences => 3.0/day.
+	 */
+	public function test_active_per_day_normalizes_to_active_window_length(): void {
+		$rows = array(
+			array(
+				'signature'    => 's',
+				'count'        => 6,
+				'active_count' => 6,
+			),
+		);
+
+		$result = extrachill_analytics_compute_php_error_active_totals( $rows, 28, 48 );
+
+		$this->assertSame( 6, $result['active_total'] );
+		$this->assertSame( 3.0, $result['active_per_day'] ); // 6 / (48/24).
+	}
+
+	/**
+	 * Missing active_count defaults to 0 (defensive — a row must never count as
+	 * active without explicit in-window occurrences).
+	 */
+	public function test_missing_active_count_defaults_to_zero(): void {
+		$rows = array(
+			array(
+				'signature' => 's',
+				'count'     => 9,
+			),
+		);
+
+		$result = extrachill_analytics_compute_php_error_active_totals( $rows, 7, 24 );
+
+		$this->assertSame( 9, $result['total'] );
+		$this->assertSame( 0, $result['active_total'] );
+		$this->assertFalse( $result['rows'][0]['active'] );
+	}
+}

--- a/tests/PhpErrorLogParserTest.php
+++ b/tests/PhpErrorLogParserTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests for the PHP error-log parser byte-watermark semantics (issue #128).
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+// The whole class exercises direct filesystem calls against temp fixtures, so
+// the WP_Filesystem alternative-function sniff is disabled for it.
+// phpcs:disable WordPress.WP.AlternativeFunctions
+
+/**
+ * The live tail must start at the snapshot byte watermark so persisted bytes are
+ * not re-read and double counted. start_offset is the mechanism; this proves it
+ * skips already-snapshotted bytes while preserving the first entry at a line
+ * boundary.
+ */
+final class PhpErrorLogParserTest extends TestCase {
+
+	/**
+	 * Build a small debug.log fixture with three timestamped fatal entries.
+	 *
+	 * @return array{path:string, entries:array<int,string>} Log path and the raw entry strings.
+	 */
+	private function make_log() {
+		$entries = array(
+			'[10-Jul-2026 01:00:00 UTC] PHP Fatal error:  Old spike number one in /var/www/wp-content/plugins/foo/a.php on line 1',
+			'[10-Jul-2026 02:00:00 UTC] PHP Fatal error:  Old spike number two in /var/www/wp-content/plugins/foo/a.php on line 1',
+			'[13-Jul-2026 12:00:00 UTC] PHP Fatal error:  Recent occurrence in /var/www/wp-content/plugins/foo/b.php on line 2',
+		);
+
+		$path = tempnam( sys_get_temp_dir(), 'ec_err_' );
+		file_put_contents( $path, implode( "\n", $entries ) . "\n" );
+
+		return array(
+			'path'    => $path,
+			'entries' => $entries,
+		);
+	}
+
+	/**
+	 * Without a watermark the whole file parses.
+	 */
+	public function test_full_read_returns_all_entries(): void {
+		$log = $this->make_log();
+
+		try {
+			$parsed = extrachill_analytics_parse_php_error_log( $log['path'], null, 0, 0 );
+			$this->assertCount( 3, $parsed['entries'] );
+		} finally {
+			@unlink( $log['path'] ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		}
+	}
+
+	/**
+	 * The byte watermark (start_offset) lands on a line boundary after a snapshot
+	 * pass. Reading from it must return ONLY the not-yet-snapshotted entries —
+	 * the persisted half is excluded so it is never double counted. The entry at
+	 * the boundary must NOT be dropped.
+	 */
+	public function test_start_offset_at_line_boundary_skips_snapshotted_bytes(): void {
+		$log     = $this->make_log();
+		$entries = $log['entries'];
+		$path    = $log['path'];
+
+		// The watermark is the byte offset where the third entry begins — exactly
+		// where ftell lands after a snapshot consumed the first two full lines.
+		$marker = 'PHP Fatal error:  Recent occurrence';
+		$offset = strpos( (string) file_get_contents( $path ), $marker );
+		// Back up to the '[' that opens the third entry (the line boundary).
+		$boundary = strrpos( substr( (string) file_get_contents( $path ), 0, $offset ), '[' );
+
+		try {
+			$parsed = extrachill_analytics_parse_php_error_log( $path, null, 0, $boundary );
+			$this->assertCount( 1, $parsed['entries'], 'Only the unsnapshotted (live) entry must be returned.' );
+			$this->assertStringContainsString( 'Recent occurrence', $parsed['entries'][0]['sample'] );
+		} finally {
+			@unlink( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		}
+	}
+
+	/**
+	 * A start_offset landing mid-line discards the partial fragment (the
+	 * tail-memory-cap path) and never splits a single entry in two.
+	 */
+	public function test_start_offset_mid_line_discards_partial_fragment(): void {
+		$log     = $this->make_log();
+		$path    = $log['path'];
+		$content = (string) file_get_contents( $path );
+
+		// Seek a few bytes into the third entry's headline (mid-line).
+		$marker = 'Recent occurrence';
+		$mid    = strpos( $content, $marker ) + 2;
+
+		try {
+			$parsed = extrachill_analytics_parse_php_error_log( $path, null, 0, $mid );
+			// The partial third entry is dropped; nothing usable remains.
+			$this->assertCount( 0, $parsed['entries'] );
+		} finally {
+			@unlink( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		}
+	}
+
+	/**
+	 * The since_ts lower bound filters out occurrences older than the window even
+	 * when they are physically present in the read range.
+	 */
+	public function test_since_ts_filters_old_entries(): void {
+		$log = $this->make_log();
+
+		try {
+			// A timestamp inside the "recent" entry's day but before it excludes
+			// the two old entries and keeps only the recent one.
+			$cutoff = strtotime( '13-Jul-2026 11:00:00 UTC' );
+			$parsed = extrachill_analytics_parse_php_error_log( $log['path'], $cutoff, 0, 0 );
+			$this->assertCount( 1, $parsed['entries'] );
+			$this->assertStringContainsString( 'Recent occurrence', $parsed['entries'][0]['sample'] );
+		} finally {
+			@unlink( $log['path'] ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		}
+	}
+}
+// phpcs:enable WordPress.WP.AlternativeFunctions

--- a/tests/PhpErrorSummaryContractTest.php
+++ b/tests/PhpErrorSummaryContractTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Source-string contract tests for the PHP error summary (issue #128).
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Lock down the counting semantics so the #128 regression cannot silently
+ * return: active volume must come from in-window occurrences (active_count),
+ * the persisted/live merge must apply the snapshot byte watermark, and the old
+ * "add the full-window count when last_seen is recent" line must stay gone.
+ */
+final class PhpErrorSummaryContractTest extends TestCase {
+
+	/**
+	 * Read the production ability source.
+	 *
+	 * @return string
+	 */
+	private function get_ability_source() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local source file.
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/abilities/get-php-error-summary.php' );
+		$this->assertNotFalse( $source );
+
+		return $source;
+	}
+
+	/**
+	 * The exact buggy line from #128 must be gone: accumulating a row's full
+	 * 'count' into active_total just because it is flagged active.
+	 */
+	public function test_buggy_full_count_active_accumulation_is_removed(): void {
+		$source = $this->get_ability_source();
+
+		$this->assertStringNotContainsString( "\$active_total += \$row['count'];", $source );
+	}
+
+	/**
+	 * Active volume must be sourced from active_count, accumulated by the pure
+	 * helper — not from each row's full-window count.
+	 */
+	public function test_active_total_uses_active_count_via_helper(): void {
+		$source = $this->get_ability_source();
+
+		$this->assertStringContainsString( 'function extrachill_analytics_compute_php_error_active_totals', $source );
+		$this->assertStringContainsString( "\$active_total += \$row['active_count'];", $source );
+	}
+
+	/**
+	 * The persisted active count must be resolved at day-granularity from rows
+	 * whose last_seen falls inside the active cutoff — not from the collapsed
+	 * full-window sum.
+	 */
+	public function test_active_persisted_query_uses_last_seen_cutoff(): void {
+		$source = $this->get_ability_source();
+
+		$this->assertStringContainsString( 'last_seen >= %s', $source );
+		$this->assertStringContainsString( 'SUM(count) AS active_count', $source );
+	}
+
+	/**
+	 * The persisted/live merge must apply the snapshot byte watermark so live
+	 * entries are byte-disjoint from persisted entries (no double counting).
+	 */
+	public function test_live_read_applies_snapshot_byte_watermark(): void {
+		$source = $this->get_ability_source();
+
+		$this->assertStringContainsString( 'extrachill_analytics_php_error_log_snapshot_offset', $source );
+		$this->assertStringContainsString( '$watermark', $source );
+	}
+
+	/**
+	 * The active_per_day rate must normalize to the active-window length, not the
+	 * full-window denominator, matching the platform-health consumer.
+	 */
+	public function test_active_per_day_normalizes_to_active_window(): void {
+		$source = $this->get_ability_source();
+
+		// The old, incorrect normalization divided by the full-window denominator.
+		$this->assertStringNotContainsString( '$active_per_day = round( $active_total / $denominator, 1 );', $source );
+		// The new normalization uses the active-window length in days, guarded
+		// against a sub-1-day divisor.
+		$this->assertStringContainsString( '$active_window_days = max( 1.0, (float) $active_window_hours / 24.0 );', $source );
+		$this->assertStringContainsString( '$active_total / $active_window_days', $source );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * PHPUnit bootstrap for Extra Chill Analytics.
+ *
+ * The PHP error-log parser and the summary active-count helper are pure (no
+ * WP / DB dependencies) and are unit-tested directly. WordPress functions
+ * referenced at file scope or by the parser are stubbed so the real source
+ * files can be included and exercised without a WordPress test scaffold.
+ *
+ * The existing source-string contract tests (e.g. GetCrosslinkTargetsTest)
+ * need none of this and are unaffected by these definitions.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	// Satisfy the plugin's `defined( 'ABSPATH' ) || exit;` include guards.
+	define( 'ABSPATH', true );
+}
+
+// Time constants used across the plugin.
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 3600 );
+}
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
+if ( ! defined( 'MB_IN_BYTES' ) ) {
+	define( 'MB_IN_BYTES', 1048576 );
+}
+
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	define( 'WP_CONTENT_DIR', sys_get_temp_dir() . '/ec-analytics-wp-content' );
+}
+
+// Minimal WordPress function stubs (only when a real WP is not present). These
+// are intentional polyfill stubs for the unit-test harness, written to satisfy
+// the WordPress coding standard rather than wrap WP_Filesystem.
+if ( ! function_exists( 'add_action' ) ) {
+	/**
+	 * Stub for the WordPress add_action() function.
+	 *
+	 * @param mixed ...$args Hook name, callback, and optional priority/args.
+	 */
+	function add_action( ...$args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return true;
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	/**
+	 * Stub for the WordPress apply_filters() function.
+	 *
+	 * @param string $tag    The filter hook name.
+	 * @param mixed  $value  The value to return (filters are no-ops here).
+	 * @return mixed The untouched value.
+	 */
+	function apply_filters( $tag, $value ) {
+		return $value;
+	}
+}
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	/**
+	 * Stub for wp_strip_all_tags().
+	 *
+	 * @param string $text Markup that may contain HTML tags.
+	 * @return string Tag-free text.
+	 */
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( (string) $text ); // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
+	}
+}
+if ( ! function_exists( 'get_site_option' ) ) {
+	/**
+	 * Stub for get_site_option().
+	 *
+	 * @param string $option  Option name (unused in the stub).
+	 * @param mixed  $fallback Default to return when the option is absent.
+	 * @return mixed The fallback default.
+	 */
+	function get_site_option( $option, $fallback = false ) {
+		return $fallback;
+	}
+}
+if ( ! function_exists( 'update_site_option' ) ) {
+	/**
+	 * Stub for update_site_option().
+	 *
+	 * @param string $option Option name (unused in the stub).
+	 * @param mixed  $val    Option value (unused in the stub).
+	 * @return bool Always true in the stub.
+	 */
+	function update_site_option( $option, $val ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return true;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/core/php-error-log.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-php-error-summary.php';


### PR DESCRIPTION
## Summary

Fixes issue #128: `extrachill/get-php-error-summary` reported a signature's entire look-back count as current (`active_total`) whenever its `last_seen` fell inside the 24-hour activity window. One fresh occurrence caused all persisted occurrences from the requested window to be presented as current errors, so `platform health` reported ~1,244.6 errors/day even though the dominant signatures had stopped firing.

## Old counting behavior (the bug)

```php
$row['active'] = ( $last_seen_ts >= $active_cutoff );
if ( $row['active'] ) {
    $active_total += $row['count'];   // full-window SUM(count), not recent occurrences
}
```

A resolved multi-day spike with a single fresh occurrence contributed its **entire** historical count to `active_total`. The persisted/live merge also re-read the whole log from the window start, with no watermark applied, so already-snapshotted bytes could be counted again.

## New active-count semantics

`active_total` now counts **only occurrences whose own timestamps fall inside the active cutoff**:

- **Persisted** (durable daily table): a second day-granularity query sums per-day rows whose `last_seen >= active_cutoff` (`GROUP BY signature`). A daily row counts toward active volume only when its newest occurrence that day is recent, so resolved multi-day-old spikes are excluded even when the same signature has one fresh occurrence.
- **Live** (current `debug.log`): occurrences with `ts >= active_cutoff` contribute to the active count.
- The full-window `total` and per-signature `per_day` trend are preserved unchanged for continuity.

The active-counting loop is extracted into a pure, DB-free helper (`extrachill_analytics_compute_php_error_active_totals`) so the contract at the heart of #128 is unit-testable without a database.

## Persisted/live deduplication

The live tail now starts at the **snapshot byte watermark** (`extrachill_analytics_php_error_log_snapshot_offset`), making the persisted and live sources byte-disjoint:

- Persisted covers bytes `[0, watermark)`.
- Live covers bytes `[watermark, end)` (still honoring the 32 MB memory cap).

The same rotation/truncation detection the snapshot writer uses (changed inode, or file shorter than the stored offset) resets the watermark to 0, so a rotated log never reads stale offsets. This is read-only — the snapshot owns the offset write. The parser gains a `start_offset` parameter with **boundary-aware** partial-line handling: a watermark that lands on a line boundary (the normal case after a snapshot pass) preserves its first full entry; a mid-line seek (the memory-cap tail path) still discards the fragment.

## Backward compatibility of full-window totals

- `total`, per-row `count`, and `per_day` are unchanged (full look-back window, same denominator).
- `active_per_day` now normalizes to the **active-window length** (`active_total / (active_window_hours/24)`) instead of the full-window denominator. This matches the platform-health consumer's own fallback normalization (`HealthCommand::compose_errors`: `active_total / (active_window_hours/24)`), so the two now agree exactly instead of the ability dividing by the full window while the CLI fallback divided by the active window.
- New additive fields (`active_count` per row) are exposed for transparency; no existing field was removed.

## Documented limitation

The durable table stores **daily aggregates**, so active resolution from persisted data is day-granularity: a daily row's count is included when its `last_seen` is inside the cutoff. Sub-day splitting within a single day is the limit of the existing schema and is left as-is (no parallel logger, per the issue's "smallest schema-safe fix" guidance). The live tail provides exact per-occurrence timestamps for the most recent (most important) window.

## Verification performed

- `vendor/bin/phpunit` — **16 tests, 48 assertions, all passing** (existing `GetCrosslinkTargetsTest` + new behavioral + contract tests).
- `vendor/bin/phpcs --standard=WordPress` on all changed files — **clean** (exit 0).
- New regression coverage:
  - **Large historical spike + one recent occurrence**: a resolved spike (count 1000, active_count 0) plus a single fresh occurrence (count 1, active_count 1) yields `active_total = 1` (not 1001), `total = 1001` preserved.
  - **Partial-active**: `count 50` / `active_count 3` → `active_total = 3`, full-window `per_day` preserved.
  - **All-resolved**: `active_total = 0` while `total` stays intact.
  - **Window normalization**: 48-hour window / 6 active → 3.0/day.
  - **Source overlap / dedup**: parser `start_offset` at a line boundary returns only the unsnapshotted tail entry (proving the byte watermark excludes already-persisted bytes); a mid-line seek discards the partial fragment; `since_ts` filters old entries.

## Constraints

- ❌ No release performed. ❌ No deployment performed. ❌ Not merged.
- No `CHANGELOG.md` edits; no version strings hand-bumped (Homeboy owns both).
- No edits to production `wp-content/plugins/` or themes — work done in the `extrachill-analytics@fix-issue-128-active-error-rate` worktree only.

Closes #128