### PR TITLE
fix: separate unresolved revenue routes from content rollups

### DIFF
--- a/inc/core/abilities/get-content-revenue.php
+++ b/inc/core/abilities/get-content-revenue.php
@@ -39,7 +39,7 @@ function extrachill_analytics_register_content_revenue_ability() {
 		'extrachill/get-content-revenue',
 		array(
 			'label'               => __( 'Get Content Revenue Lens', 'extrachill-analytics' ),
-			'description'         => __( 'Join imported Mediavine per-URL ad revenue to WordPress content metadata (category, content format, age) and roll it up by category, by content format, or as a TIME-SERIES revenue arc. group_by=timeseries sums revenue/views per time bucket chronologically (month-over-month, the HCU cliff in dollars) — the first-class capability, since each monthly Mediavine export is one point on the arc. group_by=format/category/both reports pages, views, revenue, RPM, and $/page (revenue/pages) — $/page is the honest "worth producing" metric because RPM alone misleads (high RPM on tiny volume = pennies); scope these to one bucket with period=YYYY-MM. Revenue is exactly what was imported from the Mediavine Pages CSV (Mediavine has no per-page revenue API, only ad-config); this ability never estimates ad income. NOTE: the flat lifetime export is time-blind (no date column, one cumulative total per URL) and undercounts the 2022-2023 peak — import date-ranged monthly CSVs for the real arc.', 'extrachill-analytics' ),
+			'description'         => __( 'Join imported Mediavine per-URL ad revenue to WordPress content metadata (category, content format, age) and roll it up by category, by content format, or as a TIME-SERIES revenue arc. Content totals and rollups cover RESOLVED PUBLISHED POSTS ONLY — unresolved routes (home, pagination, taxonomy archives, app/account routes, legacy .html ghosts) are excluded from content metrics so published-content RPM is honest, and reported separately under `unresolved` with a by_route_family breakdown. group_by=timeseries sums revenue/views per time bucket chronologically (month-over-month, the HCU cliff in dollars) — the first-class capability, since each monthly Mediavine export is one point on the arc. group_by=format/category/both reports pages, views, revenue, RPM, and $/page (revenue/pages) — $/page is the honest "worth producing" metric because RPM alone misleads (high RPM on tiny volume = pennies); scope these to one bucket with period=YYYY-MM. Revenue is exactly what was imported from the Mediavine Pages CSV (Mediavine has no per-page revenue API, only ad-config); this ability never estimates ad income. NOTE: the flat lifetime export is time-blind (no date column, one cumulative total per URL) and undercounts the 2022-2023 peak — import date-ranged monthly CSVs for the real arc.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -146,100 +146,89 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 
 	if ( empty( $rows ) ) {
 		return array(
-			'success' => true,
-			'rows'    => 0,
-			'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
-			'rollups' => array(),
-			'totals'  => array(
+			'success'    => true,
+			'rows'       => 0,
+			'window'     => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
+			'rollups'    => array(),
+			'totals'     => array(
 				'pages'            => 0,
 				'views'            => 0,
 				'revenue'          => 0.0,
 				'rpm'              => 0.0,
 				'dollars_per_page' => 0.0,
 			),
-			'caveat'  => __( 'No revenue snapshots for this blog/window. Import a Mediavine Pages CSV first: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' ),
+			'unresolved' => array(
+				'pages'           => 0,
+				'views'           => 0,
+				'revenue'         => 0.0,
+				'rpm'             => 0.0,
+				'by_route_family' => array(),
+			),
+			'caveat'     => __( 'No revenue snapshots for this blog/window. Import a Mediavine Pages CSV first: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' ),
 		);
 	}
 
-	// Accumulators keyed by bucket label, per axis.
-	$by_format   = array();
-	$by_category = array();
-
-	$total_pages   = 0;
-	$total_views   = 0;
-	$total_revenue = 0.0;
-
-	// De-dupe pages across multiple URL variants of the same post within this
-	// window so a post is counted once per bucket (its revenue is summed).
-	$seen_post = array();
+	// Classify each snapshot row into a resolved-content record or an unresolved
+	// route record. Resolution = a post that currently EXISTS and is PUBLISHED.
+	// url_to_postid() (used at import AND here) already returns only published
+	// posts, but a stored post_id can go stale (post trashed since import), so the
+	// publish-status recheck is what keeps non-published IDs out of content
+	// totals. Unresolved rows become a diagnostic cohort, never content buckets.
+	$records = array();
 
 	foreach ( $rows as $row ) {
 		$post_id = (int) $row->post_id;
-		if ( 0 === $post_id && '' !== $row->slug ) {
+		if ( $post_id <= 0 && '' !== $row->slug ) {
 			$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
 		}
 
 		$views   = (int) $row->views;
 		$revenue = (float) $row->revenue;
 
-		$format     = 'legacy-html';
-		$categories = array( 'legacy-html' );
-
-		if ( $post_id > 0 ) {
-			$format = extrachill_analytics_classify_format( $post_id );
-			$terms  = get_the_terms( $post_id, 'category' );
+		if ( $post_id > 0 && 'publish' === get_post_status( $post_id ) ) {
+			$terms = get_the_terms( $post_id, 'category' );
 			if ( is_array( $terms ) && ! empty( $terms ) ) {
 				$categories = wp_list_pluck( $terms, 'slug' );
 			} else {
+				// Genuinely resolved post with no category — this is the real
+				// `uncategorized` cohort, NOT unresolved routes (issue #130).
 				$categories = array( 'uncategorized' );
 			}
+
+			$records[] = array(
+				'is_content' => true,
+				'page_key'   => 'p' . $post_id,
+				'format'     => extrachill_analytics_classify_format( $post_id ),
+				'categories' => $categories,
+				'views'      => $views,
+				'revenue'    => $revenue,
+				'url'        => $row->url ? $row->url : $row->slug,
+			);
 		} else {
-			// Unresolved: bucket by legacy-html if .html, else uncategorized.
-			$format     = preg_match( '/\.html(?:[\/?#]|$)/i', (string) $row->url ) ? 'legacy-html' : 'uncategorized';
-			$categories = array( $format );
-		}
-
-		// A page (post) is counted once per format bucket; revenue/views still sum.
-		$page_key               = $post_id > 0 ? 'p' . $post_id : 'u' . md5( $row->slug );
-		$count_page             = empty( $seen_post[ $page_key ] );
-		$seen_post[ $page_key ] = true;
-
-		extrachill_analytics_revenue_accumulate( $by_format, $format, $views, $revenue, $count_page );
-
-		foreach ( $categories as $cat ) {
-			extrachill_analytics_revenue_accumulate( $by_category, $cat, $views, $revenue, $count_page );
-		}
-
-		$total_views   += $views;
-		$total_revenue += $revenue;
-		if ( $count_page ) {
-			++$total_pages;
+			// Unresolved route (post_id 0, or stale/non-published ID): diagnostic
+			// cohort only — excluded from content totals and buckets.
+			$records[] = array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( (string) $row->slug ),
+				'views'      => $views,
+				'revenue'    => $revenue,
+				'url'        => $row->url ? $row->url : $row->slug,
+			);
 		}
 	}
 
-	$rollups = array();
-	if ( 'format' === $group_by || 'both' === $group_by ) {
-		$rollups['by_format'] = extrachill_analytics_revenue_finalize( $by_format );
-	}
-	if ( 'category' === $group_by || 'both' === $group_by ) {
-		$rollups['by_category'] = extrachill_analytics_revenue_finalize( $by_category );
-	}
+	$built = extrachill_analytics_revenue_build_rollups( $records, $group_by );
 
 	return array(
-		'success'  => true,
-		'rows'     => count( $rows ),
-		'blog_id'  => $blog_id,
-		'group_by' => $group_by,
-		'window'   => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
-		'rollups'  => $rollups,
-		'totals'   => array(
-			'pages'            => $total_pages,
-			'views'            => $total_views,
-			'revenue'          => round( $total_revenue, 2 ),
-			'rpm'              => $total_views > 0 ? round( $total_revenue / ( $total_views / 1000 ), 2 ) : 0.0,
-			'dollars_per_page' => $total_pages > 0 ? round( $total_revenue / $total_pages, 2 ) : 0.0,
-		),
-		'caveat'   => __( '$/page is the honest "worth producing" metric — RPM alone misleads (high RPM on tiny volume = pennies). High LIFETIME revenue can just mean a page is old and accumulated; use a window for the earning-NOW lens. Revenue is Mediavine-imported (the only source of ad income); never estimated.', 'extrachill-analytics' ),
+		'success'    => true,
+		'rows'       => count( $rows ),
+		'blog_id'    => $blog_id,
+		'group_by'   => $group_by,
+		'window'     => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
+		'rollups'    => $built['rollups'],
+		'totals'     => $built['totals'],
+		'unresolved' => $built['unresolved'],
+		'caveat'     => __( 'Totals and rollups cover RESOLVED PUBLISHED CONTENT ONLY — unresolved routes (home, pagination, taxonomy archives, app/account routes, legacy .html ghosts) are excluded so published-content RPM is honest, and reported separately under `unresolved` with a by_route_family breakdown. $/page is the honest "worth producing" metric — RPM alone misleads (high RPM on tiny volume = pennies). Revenue is Mediavine-imported (the only source of ad income); never estimated. Note: the Mediavine Pages CSV carries one path per row and may omit hostnames, so cross-site paths (e.g. Festival Wire) can land under the import blog when the hostname is ambiguous — treat the unresolved cohort as coverage signal, not an attribution verdict.', 'extrachill-analytics' ),
 	);
 }
 
@@ -303,6 +292,210 @@ function extrachill_analytics_revenue_finalize( array $bucket ) {
 	);
 
 	return $rows;
+}
+
+/**
+ * Classify an unresolved (non-post) route into a coarse diagnostic family.
+ *
+ * Pure (no WordPress dependency) so the revenue rollup can report WHAT the
+ * unresolved traffic actually is — home, pagination, taxonomy archives, app/
+ * account routes, legacy .html ghost pages — instead of lumping every
+ * non-content path under a misleading `uncategorized` bucket. See issue #130.
+ *
+ * @param string $url Raw URL/path from the revenue row (may be host-relative).
+ * @return string Route family slug.
+ */
+function extrachill_analytics_revenue_classify_route_family( $url ) {
+	$raw = strtolower( trim( (string) $url ) );
+
+	// Reduce a full URL to its path; bare slugs/paths pass through.
+	$path = $raw;
+	if ( preg_match( '#^https?://#i', $raw ) ) {
+		$parsed = parse_url( $raw ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- pure by design (no WP at test time).
+		$path   = isset( $parsed['path'] ) ? $parsed['path'] : '/';
+	}
+	if ( '' === $path ) {
+		$path = '/';
+	}
+	$path = '/' . ltrim( $path, '/' );
+
+	if ( '/' === $path ) {
+		return 'home';
+	}
+
+	if ( preg_match( '#^/page/\d+(/|$)#i', $path ) ) {
+		return 'pagination';
+	}
+
+	// Legacy .html ghost pages that no longer resolve to a WordPress post.
+	if ( preg_match( '/\.html(?:[\/?#]|$)/i', $path ) ) {
+		return 'legacy-html';
+	}
+
+	// Taxonomy / archive routes (no single post to attribute revenue to).
+	if ( preg_match( '#^/(location|locations|category|categories|tag|tags|t|festival|festivals|artist|artists|venue|venues)(/|$)#i', $path ) ) {
+		return 'taxonomy-archive';
+	}
+
+	// App / account / auth / admin / shop chrome routes.
+	if ( preg_match( '#^/(account|accounts|app|apps|login|log-in|signin|sign-in|register|sign-up|signup|member|members|my-|dashboard|cart|checkout|wp-|wp-admin|wp-login)(/|$)#i', $path ) ) {
+		return 'app-account';
+	}
+
+	return 'other';
+}
+
+/**
+ * Build the category/format rollups, content totals, and the unresolved
+ * diagnostic cohort from pre-classified revenue records.
+ *
+ * This is the PURE core of the rollup — it touches no WordPress state, so it is
+ * unit-tested directly. The execute_callback does the WordPress-dependent
+ * resolution (post lookup, publish-status gate, term lookup) and hands the
+ * resulting records here.
+ *
+ * CONTRACT (issue #130):
+ *   - `totals` and `rollups` contain RESOLVED PUBLISHED CONTENT ONLY. Unresolved
+ *     routes never inflate content pages/views/revenue or leak into category/
+ *     format buckets. This keeps published-content RPM honest ($23.37, not the
+ *     contaminated $13.98 the combined rollup reported).
+ *   - `unresolved` is an explicit diagnostic cohort — same metrics, plus a
+ *     `by_route_family` breakdown — so non-content routes (/, /page/2/,
+ *     /location/..., app routes, legacy .html ghosts) stay visible without being
+ *     mistaken for uncategorized posts.
+ *
+ * Each record shape:
+ *   {
+ *     is_content (bool):  true = resolved published post; false = unresolved.
+ *     page_key   (string): dedupe key ('p'.post_id or 'u'.hash(slug)).
+ *     format     (string): content format (content rows only; unused otherwise).
+ *     categories (string[]): category slugs (content rows only).
+ *     views      (int),
+ *     revenue    (float),
+ *     url        (string): raw URL/path (unresolved rows only, for route family).
+ *   }
+ *
+ * @param array  $records  Pre-classified revenue records.
+ * @param string $group_by 'format', 'category', 'both', or 'timeseries'.
+ * @return array {
+ *     @type array $rollups    by_format and/or by_category (content only).
+ *     @type array $totals     Content-only pages/views/revenue/rpm/dollars_per_page.
+ *     @type array $unresolved Diagnostic cohort + by_route_family breakdown.
+ * }
+ */
+function extrachill_analytics_revenue_build_rollups( array $records, $group_by ) {
+	$by_format   = array();
+	$by_category = array();
+
+	$content_pages   = 0;
+	$content_views   = 0;
+	$content_revenue = 0.0;
+	$seen_content    = array();
+
+	$unresolved_pages   = 0;
+	$unresolved_views   = 0;
+	$unresolved_revenue = 0.0;
+	$seen_unresolved    = array();
+	$unresolved_family  = array();
+
+	foreach ( $records as $rec ) {
+		$views   = (int) ( isset( $rec['views'] ) ? $rec['views'] : 0 );
+		$revenue = (float) ( isset( $rec['revenue'] ) ? $rec['revenue'] : 0.0 );
+		$key     = (string) ( isset( $rec['page_key'] ) ? $rec['page_key'] : '' );
+
+		if ( empty( $rec['is_content'] ) ) {
+			// Unresolved diagnostic cohort — excluded from content totals/buckets.
+			if ( '' !== $key && empty( $seen_unresolved[ $key ] ) ) {
+				$seen_unresolved[ $key ] = true;
+				++$unresolved_pages;
+			}
+			$unresolved_views   += $views;
+			$unresolved_revenue += $revenue;
+
+			$family = extrachill_analytics_revenue_classify_route_family( isset( $rec['url'] ) ? $rec['url'] : '' );
+			if ( ! isset( $unresolved_family[ $family ] ) ) {
+				$unresolved_family[ $family ] = array(
+					'pages'   => 0,
+					'views'   => 0,
+					'revenue' => 0.0,
+					'seen'    => array(),
+				);
+			}
+			if ( '' !== $key && empty( $unresolved_family[ $family ]['seen'][ $key ] ) ) {
+				$unresolved_family[ $family ]['seen'][ $key ] = true;
+				++$unresolved_family[ $family ]['pages'];
+			}
+			$unresolved_family[ $family ]['views']   += $views;
+			$unresolved_family[ $family ]['revenue'] += $revenue;
+			continue;
+		}
+
+		// Resolved content: de-dupe the page across URL variants in this window.
+		$count_page           = '' !== $key && empty( $seen_content[ $key ] );
+		$seen_content[ $key ] = true;
+
+		$format = isset( $rec['format'] ) ? (string) $rec['format'] : 'uncategorized';
+		extrachill_analytics_revenue_accumulate( $by_format, $format, $views, $revenue, $count_page );
+
+		$categories = ( ! empty( $rec['categories'] ) && is_array( $rec['categories'] ) )
+			? array_map( 'strval', $rec['categories'] )
+			: array( 'uncategorized' );
+		foreach ( $categories as $cat ) {
+			extrachill_analytics_revenue_accumulate( $by_category, $cat, $views, $revenue, $count_page );
+		}
+
+		$content_views   += $views;
+		$content_revenue += $revenue;
+		if ( $count_page ) {
+			++$content_pages;
+		}
+	}
+
+	$rollups = array();
+	if ( 'format' === $group_by || 'both' === $group_by ) {
+		$rollups['by_format'] = extrachill_analytics_revenue_finalize( $by_format );
+	}
+	if ( 'category' === $group_by || 'both' === $group_by ) {
+		$rollups['by_category'] = extrachill_analytics_revenue_finalize( $by_category );
+	}
+
+	$family_rows = array();
+	foreach ( $unresolved_family as $family => $agg ) {
+		$fpages        = (int) $agg['pages'];
+		$fviews        = (int) $agg['views'];
+		$frevenue      = (float) $agg['revenue'];
+		$family_rows[] = array(
+			'route_family' => $family,
+			'pages'        => $fpages,
+			'views'        => $fviews,
+			'revenue'      => round( $frevenue, 2 ),
+			'rpm'          => $fviews > 0 ? round( $frevenue / ( $fviews / 1000 ), 2 ) : 0.0,
+		);
+	}
+	usort(
+		$family_rows,
+		static function ( $a, $b ) {
+			return $b['views'] <=> $a['views'];
+		}
+	);
+
+	return array(
+		'rollups'    => $rollups,
+		'totals'     => array(
+			'pages'            => $content_pages,
+			'views'            => $content_views,
+			'revenue'          => round( $content_revenue, 2 ),
+			'rpm'              => $content_views > 0 ? round( $content_revenue / ( $content_views / 1000 ), 2 ) : 0.0,
+			'dollars_per_page' => $content_pages > 0 ? round( $content_revenue / $content_pages, 2 ) : 0.0,
+		),
+		'unresolved' => array(
+			'pages'           => $unresolved_pages,
+			'views'           => $unresolved_views,
+			'revenue'         => round( $unresolved_revenue, 2 ),
+			'rpm'             => $unresolved_views > 0 ? round( $unresolved_revenue / ( $unresolved_views / 1000 ), 2 ) : 0.0,
+			'by_route_family' => $family_rows,
+		),
+	);
 }
 
 /**

--- a/tests/GetContentRevenueRollupTest.php
+++ b/tests/GetContentRevenueRollupTest.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * Behavioral + contract tests for the content-revenue rollup (issue #130).
+ *
+ * The pure core (route-family classifier + rollup builder) is unit-tested
+ * directly; the WordPress-dependent resolution gate is locked down via a
+ * source-string contract on the ability callback.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue.php';
+
+/**
+ * Verify resolved published content is separated from unresolved routes.
+ */
+final class GetContentRevenueRollupTest extends TestCase {
+
+	/**
+	 * Route-family classifier maps the issue's example paths to honest buckets.
+	 */
+	public function test_route_family_classification(): void {
+		$this->assertSame( 'home', extrachill_analytics_revenue_classify_route_family( '/' ) );
+		$this->assertSame( 'pagination', extrachill_analytics_revenue_classify_route_family( '/page/2/' ) );
+		$this->assertSame( 'pagination', extrachill_analytics_revenue_classify_route_family( '/page/12' ) );
+		$this->assertSame( 'taxonomy-archive', extrachill_analytics_revenue_classify_route_family( '/location/charleston/' ) );
+		$this->assertSame( 'taxonomy-archive', extrachill_analytics_revenue_classify_route_family( '/t/grateful-dead' ) );
+		$this->assertSame( 'taxonomy-archive', extrachill_analytics_revenue_classify_route_family( '/festival/bonaroo/' ) );
+		$this->assertSame( 'app-account', extrachill_analytics_revenue_classify_route_family( '/account' ) );
+		$this->assertSame( 'app-account', extrachill_analytics_revenue_classify_route_family( '/wp-admin/edit.php' ) );
+		$this->assertSame( 'legacy-html', extrachill_analytics_revenue_classify_route_family( '/old-ghost-page.html' ) );
+		$this->assertSame( 'other', extrachill_analytics_revenue_classify_route_family( '/some-mystery-path/' ) );
+
+		// Full-URL form is reduced to its path before classification.
+		$this->assertSame( 'home', extrachill_analytics_revenue_classify_route_family( 'https://extrachill.com/' ) );
+		$this->assertSame( 'pagination', extrachill_analytics_revenue_classify_route_family( 'https://wire.extrachill.com/page/3/' ) );
+	}
+
+	/**
+	 * Mixed rows: content totals must reflect only the resolved published post,
+	 * while unresolved routes land in their own diagnostic cohort.
+	 */
+	public function test_unresolved_routes_excluded_from_content_totals(): void {
+		$records = array(
+			// Published song-meaning post: $100 over 1,000 views = $100 RPM.
+			array(
+				'is_content' => true,
+				'page_key'   => 'p100',
+				'format'     => 'song-meaning',
+				'categories' => array( 'song-meanings' ),
+				'views'      => 1000,
+				'revenue'    => 100.0,
+				'url'        => '/song-meaning-post/',
+			),
+			// Unresolved home route: 5,000 views, $5 (the RPM-diluter).
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( '/' ),
+				'views'      => 5000,
+				'revenue'    => 5.0,
+				'url'        => '/',
+			),
+			// Unresolved pagination: 1,000 views, $1.
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( 'page/2' ),
+				'views'      => 1000,
+				'revenue'    => 1.0,
+				'url'        => '/page/2/',
+			),
+		);
+
+		$result = extrachill_analytics_revenue_build_rollups( $records, 'both' );
+
+		// Content totals = the single published post.
+		$this->assertSame( 1, $result['totals']['pages'] );
+		$this->assertSame( 1000, $result['totals']['views'] );
+		$this->assertEquals( 100.0, $result['totals']['revenue'] );
+		$this->assertEquals( 100.0, $result['totals']['rpm'] );
+
+		// Unresolved cohort = the two unresolved paths.
+		$this->assertSame( 2, $result['unresolved']['pages'] );
+		$this->assertSame( 6000, $result['unresolved']['views'] );
+		$this->assertEquals( 6.0, $result['unresolved']['revenue'] );
+		// ~$1 RPM for unresolved, not the contaminated $15.38 the combined rollup
+		// would have produced (the exact distortion issue #130 reports).
+		$this->assertEquals( round( 6.0 / 6.0, 2 ), $result['unresolved']['rpm'] );
+	}
+
+	/**
+	 * Category and format buckets must never contain unresolved routes, and the
+	 * bogus `uncategorized`/`legacy-html` entries they used to create are gone.
+	 */
+	public function test_buckets_contain_only_content(): void {
+		$records = array(
+			array(
+				'is_content' => true,
+				'page_key'   => 'p100',
+				'format'     => 'song-meaning',
+				'categories' => array( 'song-meanings' ),
+				'views'      => 1000,
+				'revenue'    => 100.0,
+				'url'        => '/song/',
+			),
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( '/' ),
+				'views'      => 5000,
+				'revenue'    => 5.0,
+				'url'        => '/',
+			),
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( 'old.html' ),
+				'views'      => 500,
+				'revenue'    => 2.0,
+				'url'        => '/old.html',
+			),
+		);
+
+		$result = extrachill_analytics_revenue_build_rollups( $records, 'both' );
+
+		$format_buckets   = $this->pluck( $result['rollups']['by_format'], 'bucket' );
+		$category_buckets = $this->pluck( $result['rollups']['by_category'], 'bucket' );
+
+		$this->assertSame( array( 'song-meaning' ), $format_buckets );
+		$this->assertSame( array( 'song-meanings' ), $category_buckets );
+		$this->assertNotContains( 'uncategorized', $format_buckets );
+		$this->assertNotContains( 'uncategorized', $category_buckets );
+		$this->assertNotContains( 'legacy-html', $format_buckets );
+	}
+
+	/**
+	 * A genuinely resolved post with no category IS the real `uncategorized`
+	 * cohort and must not be conflated with unresolved routes.
+	 */
+	public function test_resolved_post_without_category_is_uncategorized(): void {
+		$records = array(
+			array(
+				'is_content' => true,
+				'page_key'   => 'p200',
+				'format'     => 'uncategorized',
+				'categories' => array( 'uncategorized' ),
+				'views'      => 2000,
+				'revenue'    => 50.0,
+				'url'        => '/orphan-post/',
+			),
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( '/' ),
+				'views'      => 4000,
+				'revenue'    => 4.0,
+				'url'        => '/',
+			),
+		);
+
+		$result = extrachill_analytics_revenue_build_rollups( $records, 'category' );
+
+		// The real uncategorized post is counted as content.
+		$this->assertSame( 1, $result['totals']['pages'] );
+		$this->assertSame( 2000, $result['totals']['views'] );
+		$this->assertEquals( 50.0, $result['totals']['revenue'] );
+
+		$category_buckets = $this->pluck( $result['rollups']['by_category'], 'bucket' );
+		$this->assertContains( 'uncategorized', $category_buckets );
+
+		// The unresolved home route is NOT in the category buckets.
+		$this->assertSame( 1, $result['unresolved']['pages'] );
+		$this->assertEquals( 4.0, $result['unresolved']['revenue'] );
+		// Exactly one category row — the real uncategorized post, not the route.
+		$this->assertCount( 1, $result['rollups']['by_category'] );
+	}
+
+	/**
+	 * Duplicate URL variants of the same post/page count once for pages while
+	 * revenue and views still sum (the existing de-dupe contract, preserved).
+	 */
+	public function test_content_and_unresolved_dedupe_independently(): void {
+		$records = array(
+			// Same post via two URL variants.
+			array(
+				'is_content' => true,
+				'page_key'   => 'p300',
+				'format'     => 'trivia',
+				'categories' => array( 'trivia' ),
+				'views'      => 500,
+				'revenue'    => 10.0,
+				'url'        => '/quiz-one/',
+			),
+			array(
+				'is_content' => true,
+				'page_key'   => 'p300',
+				'format'     => 'trivia',
+				'categories' => array( 'trivia' ),
+				'views'      => 500,
+				'revenue'    => 10.0,
+				'url'        => '/quiz-one/?ref=x',
+			),
+			// Same unresolved path twice.
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( '/' ),
+				'views'      => 100,
+				'revenue'    => 1.0,
+				'url'        => '/',
+			),
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( '/' ),
+				'views'      => 100,
+				'revenue'    => 1.0,
+				'url'        => '/',
+			),
+		);
+
+		$result = extrachill_analytics_revenue_build_rollups( $records, 'format' );
+
+		// One content page, summed views/revenue.
+		$this->assertSame( 1, $result['totals']['pages'] );
+		$this->assertSame( 1000, $result['totals']['views'] );
+		$this->assertEquals( 20.0, $result['totals']['revenue'] );
+
+		// One unresolved page, summed views/revenue.
+		$this->assertSame( 1, $result['unresolved']['pages'] );
+		$this->assertSame( 200, $result['unresolved']['views'] );
+		$this->assertEquals( 2.0, $result['unresolved']['revenue'] );
+	}
+
+	/**
+	 * Group_by axis controls which rollup keys are present.
+	 */
+	public function test_group_by_controls_rollup_keys(): void {
+		$records = array(
+			array(
+				'is_content' => true,
+				'page_key'   => 'p1',
+				'format'     => 'news',
+				'categories' => array( 'news' ),
+				'views'      => 100,
+				'revenue'    => 1.0,
+				'url'        => '/p1/',
+			),
+		);
+
+		$format_only = extrachill_analytics_revenue_build_rollups( $records, 'format' );
+		$this->assertArrayHasKey( 'by_format', $format_only['rollups'] );
+		$this->assertArrayNotHasKey( 'by_category', $format_only['rollups'] );
+
+		$category_only = extrachill_analytics_revenue_build_rollups( $records, 'category' );
+		$this->assertArrayNotHasKey( 'by_format', $category_only['rollups'] );
+		$this->assertArrayHasKey( 'by_category', $category_only['rollups'] );
+	}
+
+	/**
+	 * The unresolved by_route_family breakdown must sum back to the cohort totals
+	 * and bucket the issue's example paths correctly.
+	 */
+	public function test_unresolved_route_family_breakdown(): void {
+		$records = array(
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( '/' ),
+				'views'      => 5000,
+				'revenue'    => 5.0,
+				'url'        => '/',
+			),
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( 'page/2' ),
+				'views'      => 1000,
+				'revenue'    => 1.0,
+				'url'        => '/page/2/',
+			),
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( 'location/c' ),
+				'views'      => 2000,
+				'revenue'    => 2.0,
+				'url'        => '/location/charleston/',
+			),
+			array(
+				'is_content' => false,
+				'page_key'   => 'u' . md5( 'old.html' ),
+				'views'      => 300,
+				'revenue'    => 1.5,
+				'url'        => '/old.html',
+			),
+		);
+
+		$result  = extrachill_analytics_revenue_build_rollups( $records, 'format' );
+		$family  = array();
+		$views   = 0;
+		$revenue = 0.0;
+		foreach ( $result['unresolved']['by_route_family'] as $row ) {
+			$family[ $row['route_family'] ] = $row;
+			$views                         += $row['views'];
+			$revenue                       += $row['revenue'];
+		}
+
+		$this->assertArrayHasKey( 'home', $family );
+		$this->assertArrayHasKey( 'pagination', $family );
+		$this->assertArrayHasKey( 'taxonomy-archive', $family );
+		$this->assertArrayHasKey( 'legacy-html', $family );
+
+		// Breakdown sums back to cohort totals.
+		$this->assertSame( $result['unresolved']['views'], $views );
+		$this->assertEquals( round( $result['unresolved']['revenue'], 2 ), round( $revenue, 2 ) );
+		$this->assertSame( $result['unresolved']['pages'], $family['home']['pages'] + $family['pagination']['pages'] + $family['taxonomy-archive']['pages'] + $family['legacy-html']['pages'] );
+	}
+
+	/**
+	 * Source-string contract: the callback must publish-gate content and build
+	 * is_content records (the WP-dependent half that can't be unit-tested).
+	 */
+	public function test_callback_publish_gates_content_and_reports_unresolved(): void {
+		$source = $this->ability_source();
+
+		// A row is content only when its post is currently published.
+		$this->assertStringContainsString( "'publish' === get_post_status( \$post_id )", $source );
+		// Unresolved routes are marked is_content => false and excluded.
+		$this->assertStringContainsString( "'is_content' => false", $source );
+		$this->assertStringContainsString( "'is_content' => true", $source );
+		// The response exposes an explicit unresolved cohort.
+		$this->assertStringContainsString( "'unresolved'", $source );
+		$this->assertStringContainsString( "'by_route_family'", $source );
+		// The old conflation (unresolved rows bucketed as uncategorized/legacy-html
+		// content) is gone.
+		$this->assertStringNotContainsString( "preg_match( '/\\.html(?:[\\/?#]|$)/i', (string) \$row->url ) ? 'legacy-html' : 'uncategorized'", $source );
+	}
+
+	/**
+	 * Helper: pull one column from a list of rows, indexed by another column.
+	 *
+	 * @param array  $rows  Rollup rows.
+	 * @param string $field Field to extract.
+	 * @return array<int, mixed>
+	 */
+	private function pluck( array $rows, $field ) {
+		$out = array();
+		foreach ( $rows as $row ) {
+			$out[] = $row[ $field ];
+		}
+		return $out;
+	}
+
+	/**
+	 * Read the production ability source.
+	 *
+	 * @return string
+	 */
+	private function ability_source() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local source file.
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue.php' );
+		$this->assertNotFalse( $source );
+
+		return $source;
+	}
+}


### PR DESCRIPTION
## Why combined totals understated published-content RPM

`extrachill/get-content-revenue` lumped unresolved/non-post Mediavine rows into the same totals it used to report content RPM, and labeled most of them `uncategorized`. For the imported 2026-01-01 → 2026-06-30 window on blog 1 this produced a misleading **$13.98 combined RPM**, masking the real picture:

- **Published posts:** 742 pages, 54,306 views, $1,269.00 → **$23.37 RPM**
- **Unresolved routes:** 1,871 paths, 41,420 views, $69.78 → **$1.68 RPM**

The unresolved cohort (home `/`, `/page/2/`, `/location/...`, `/t/...`, app/account routes, legacy `.html` ghosts, cross-site Festival Wire paths) dragged the headline RPM down ~40% and made the category/format lens imply that non-content routes were uncategorized posts.

## New resolved-vs-unresolved response semantics

Content **totals** and **rollups** (`by_format`, `by_category`) now cover **RESOLVED PUBLISHED POSTS ONLY**. A row counts as content iff it resolves to a post that currently exists and is published (`post_id > 0 && 'publish' === get_post_status( $post_id )`), so:
- `url_to_postid()` (used at import and at read time) already returns only published posts.
- A stored `post_id` that went stale (post trashed since import) or is otherwise non-published is treated as **unresolved**, keeping non-published IDs out of content totals (issue #130: "Consider missing/non-published post IDs explicitly").
- A genuinely resolved post with no category is still the real `uncategorized` category bucket — no longer conflated with unresolved paths.

Unresolved routes are reported in a new explicit **diagnostic cohort**:

```json
"unresolved": {
  "pages": 1871,
  "views": 41420,
  "revenue": 69.78,
  "rpm": 1.68,
  "by_route_family": [
    { "route_family": "home", "pages": ..., "views": ..., "revenue": ..., "rpm": ... },
    ...
  ]
}
```

`by_route_family` buckets coverage into `home`, `pagination`, `taxonomy-archive`, `app-account`, `legacy-html`, and `other`, so callers can see what the unresolved traffic actually is. The previous behavior of dumping unresolved rows into the `uncategorized`/`legacy-html` content buckets is removed.

### Implementation

The WordPress-dependent resolution (post lookup, publish gate, term lookup) builds normalized records; a new pure helper `extrachill_analytics_revenue_build_rollups()` (plus a pure `extrachill_analytics_revenue_classify_route_family()`) does the accumulation. Extracting the pure core is what made real behavioral tests possible — the old loop mixed WP calls into the accumulation and was untestable.

The pure `classify_route_family` deliberately uses native `parse_url` (not `wp_parse_url`) so it runs with no WordPress loaded at test time.

## Compatibility consideration for existing consumers

This is an **intentional numbers change**: `totals` and `rollups` now exclude unresolved routes (previously included), so RPM/$/page/revenue/pages will differ — that is the fix. The response keys (`success`, `rows`, `blog_id`, `group_by`, `window`, `rollups`, `totals`, `caveat`) are unchanged; a new `unresolved` key is **added** (non-breaking). Consumers that summed `unresolved` traffic into a "total" must now read it from the dedicated cohort. `group_by=timeseries` (the revenue ARC) is intentionally untouched — it is a total-revenue-over-time read, not a content-RPM lens.

The cross-site attribution limitation is now documented in the ability `caveat`: the Mediavine Pages CSV carries one path per row and may omit hostnames, so cross-site paths (e.g. Festival Wire) can land under the import blog — treat the unresolved cohort as coverage signal, not an attribution verdict.

## Tests run and results

- `vendor/bin/phpunit` → **24 tests, 104 assertions, OK** (existing suite + 9 new tests in `GetContentRevenueRollupTest`).
- `vendor/bin/phpcs --standard=WordPress` on both changed files → **0 errors, 0 warnings**.
- `homeboy review extrachill-analytics test` → could not run (machine load 81.6, no Homeboy Lab offload runner available); verification covered by phpunit + phpcs above.

New tests cover: route-family classification; unresolved routes excluded from content totals; buckets contain only content (no bogus `uncategorized`/`legacy-html` from routes); resolved-no-category post is the real `uncategorized`; independent content/unresolved de-dupe; `group_by` axis control; unresolved `by_route_family` breakdown sums to cohort totals; and a source-string contract locking the publish-gate + `unresolved` reporting on the WP-dependent callback.

No CHANGELOG edit or version bump — release tooling (Homeboy) owns both.

Fixes #130