### PR TITLE
feat: add page and diagnostic revenue abilities

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -65,6 +65,8 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-crosslink
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-stickiness.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-activation-funnel.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-content-revenue.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-content-revenue-pages.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-content-revenue-diagnostics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-bot-filter-impact.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-php-error-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/check-fatal-alarm.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -33,6 +33,8 @@ add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_crosslink_ta
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_surface_stickiness_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_activation_funnel_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_content_revenue_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_content_revenue_pages_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_content_revenue_diagnostics_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_bot_filter_impact_ability' );
 
 /**

--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -5,10 +5,11 @@
  * Structured data-integrity lens for the Mediavine revenue store. Where
  * extrachill/get-content-revenue rolls up revenue and extrachill/get-content-
  * revenue-pages ranks individual pages, THIS ability reports the HEALTH of the
- * store itself: is the latest import fresh, are monthly periods contiguous,
- * are any periods double-imported, does the read model reconcile, how much
- * traffic is unresolved, are there zero-view-revenue or negative-value rows,
- * and does stored RPM agree with derived RPM?
+ * store itself: is the latest period fresh, are monthly periods contiguous,
+ * are any periods double-imported, does the read model reconcile against an
+ * INDEPENDENT SQL aggregate, how much traffic is unresolved, are there zero-
+ * view-revenue or impossible-value rows, and does stored RPM agree with derived
+ * RPM?
  *
  * Why a sibling and not a diagnostic flag on the rollup: the rollup output
  * contract is rollups/totals/unresolved — it has no place for an array of
@@ -19,17 +20,25 @@
  * Status contract: each check returns one of 'pass', 'warning', or 'fail'.
  *   - 'fail' is reserved for genuine data-integrity violations that make the
  *     numbers untrustworthy (negative/impossible values, a read model that does
- *     not reconcile). Source quirks (zero-view revenue, duplicate batches, RPM
- *     variance) are NEVER 'fail' without evidence — they are 'warning' so the
- *     analyst sees them without the system crying wolf. The issue is explicit:
- *     do not claim source anomalies are corruption without evidence.
+ *     not reconcile against the independent SQL aggregate). Source quirks
+ *     (zero-view revenue, duplicate batches, RPM variance) are NEVER 'fail'
+ *     without evidence — they are 'warning' so the analyst sees them without the
+ *     system crying wolf. The issue is explicit: do not claim source anomalies
+ *     are corruption without evidence.
  *   - The overall status is fail if any check fails, else warning if any warns,
  *     else pass.
  *
- * Reconciliation note: totals_reconciliation compares the in-scope row-sum
- * against the in-scope timeseries aggregation. Both come from the same table, so
- * a pass confirms the read path is self-consistent; a fail means the read model
- * itself is broken (a regression signal, not a Mediavine data issue).
+ * Reconciliation note (non-tautological): totals_reconciliation compares the
+ * PHP row-sum of get_rows() against an INDEPENDENT SQL SUM() aggregate
+ * (get_scope_totals) over the same scope — two genuinely different read paths
+ * (PHP hydration vs MySQL's aggregator). A divergence is a read-path regression
+ * signal. content_unresolved_reconciliation separately verifies the resolved/
+ * unresolved partition and dedupe are lossless and that rows with a stored
+ * post_id that is no longer published are correctly routed to unresolved.
+ *
+ * Network/blog authorization: a current-site manage_options holder may read
+ * their own blog; a CROSS-blog read requires manage_network_options. WP_CLI is
+ * allowed. All resolution runs switch_to_blog($blog_id).
  *
  * @package ExtraChill\Analytics
  * @since 0.28.0
@@ -45,34 +54,34 @@ function extrachill_analytics_register_content_revenue_diagnostics_ability() {
 		'extrachill/get-content-revenue-diagnostics',
 		array(
 			'label'               => __( 'Get Content Revenue Diagnostics Lens', 'extrachill-analytics' ),
-			'description'         => __( 'Structured data-integrity checks for the Mediavine revenue store. Returns an array of independent checks — latest-period freshness, missing periods, duplicate period/batch imports, totals reconciliation, resolution and content-format coverage, revenue with zero pageviews, views with zero revenue, negative/impossible values, stored-vs-derived RPM variance, and source/import provenance coverage — each with a stable pass|warning|fail status, evidence, and totals. Source quirks (zero-view revenue, duplicate batches, RPM variance) are warnings, never corruption claims without evidence; fail is reserved for genuine integrity violations (negative values, a read model that does not reconcile). Reuses the same store, resolver, and classifiers as the rollup/pages abilities — no new tables. CLI consumers map args and format output only.', 'extrachill-analytics' ),
+			'description'         => __( 'Structured data-integrity checks for the Mediavine revenue store. Returns independent checks — latest-period freshness (by period boundary), missing periods, duplicate period/batch imports, totals reconciliation (against an independent SQL aggregate), content/unresolved reconciliation, resolution and content-format coverage (on deduped pages), revenue with zero pageviews, views with zero revenue, negative/impossible values (range-checked), stored-vs-derived RPM variance, and provenance coverage — each with a stable pass|warning|fail status, evidence, and totals. Source quirks are warnings, never corruption claims without evidence; fail is reserved for genuine integrity violations (negative/impossible values, a read model that does not reconcile). An empty scoped query never passes. Cross-blog reads require network admin. Reuses the same store, resolver, and classifiers — no new tables. CLI consumers map args and format output only.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
 					'period'       => array(
 						'type'        => 'string',
-						'description' => __( 'Scope diagnostics to one time bucket, e.g. "2026-05" or "all-time". Empty = every bucket combined (the whole-store integrity view).', 'extrachill-analytics' ),
+						'description' => __( 'Scope row-level checks to one time bucket, e.g. "2026-05" or "all-time". Empty = whole store (the integrity view). Freshness/missing/duplicate checks always consider the whole per-blog history.', 'extrachill-analytics' ),
 						'default'     => '',
 					),
 					'period_start' => array(
 						'type'        => 'string',
-						'description' => __( 'Inclusive window start (Y-m-d). With period_end, scopes to snapshots imported for that window.', 'extrachill-analytics' ),
+						'description' => __( 'Inclusive window start (Y-m-d).', 'extrachill-analytics' ),
 						'default'     => '',
 					),
 					'period_end'   => array(
 						'type'        => 'string',
-						'description' => __( 'Inclusive window end (Y-m-d). See period_start.', 'extrachill-analytics' ),
+						'description' => __( 'Inclusive window end (Y-m-d).', 'extrachill-analytics' ),
 						'default'     => '',
 					),
 					'import_batch' => array(
 						'type'        => 'string',
-						'description' => __( 'Restrict to one import batch. Empty = all batches.', 'extrachill-analytics' ),
+						'description' => __( 'Restrict row-level checks to one import batch. Empty = all batches.', 'extrachill-analytics' ),
 						'default'     => '',
 					),
 					'blog_id'      => array(
 						'type'        => 'integer',
-						'description' => __( 'Blog ID whose revenue to diagnose. 0 = current blog.', 'extrachill-analytics' ),
+						'description' => __( 'Blog ID whose revenue to diagnose. 0 = current blog. Cross-blog reads require manage_network_options.', 'extrachill-analytics' ),
 						'default'     => 0,
 					),
 					'hostname'     => array(
@@ -83,12 +92,111 @@ function extrachill_analytics_register_content_revenue_diagnostics_ability() {
 				),
 			),
 			'output_schema'       => array(
-				'type'        => 'object',
-				'description' => __( 'checks array (each: check, status pass|warning|fail, evidence, totals), overall_status, summary { pass, warning, fail, total }, scope metadata, and caveats.', 'extrachill-analytics' ),
+				'type'       => 'object',
+				'properties' => array(
+					'success'        => array(
+						'type'        => 'boolean',
+						'description' => 'Whether the read succeeded.',
+					),
+					'blog_id'        => array(
+						'type'        => 'integer',
+						'description' => 'Blog ID diagnosed.',
+					),
+					'window'         => array(
+						'type'        => 'string',
+						'description' => 'Human-readable window label.',
+					),
+					'overall_status' => array(
+						'type'        => 'string',
+						'enum'        => array( 'pass', 'warning', 'fail' ),
+						'description' => 'fail if any check failed, else warning if any warned, else pass.',
+					),
+					'summary'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'pass'    => array(
+								'type'        => 'integer',
+								'description' => 'Count of checks at pass.',
+							),
+							'warning' => array(
+								'type'        => 'integer',
+								'description' => 'Count of checks at warning.',
+							),
+							'fail'    => array(
+								'type'        => 'integer',
+								'description' => 'Count of checks at fail.',
+							),
+							'total'   => array(
+								'type'        => 'integer',
+								'description' => 'Total checks.',
+							),
+						),
+						'required'   => array( 'pass', 'warning', 'fail', 'total' ),
+					),
+					'checks'         => array(
+						'type'        => 'array',
+						'description' => 'Integrity checks.',
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'check'    => array(
+									'type'        => 'string',
+									'description' => 'Stable check identifier.',
+								),
+								'status'   => array(
+									'type'        => 'string',
+									'enum'        => array( 'pass', 'warning', 'fail' ),
+									'description' => 'Check outcome.',
+								),
+								'evidence' => array(
+									'type'        => 'array',
+									'items'       => array( 'type' => 'string' ),
+									'description' => 'Human+machine readable facts.',
+								),
+								'totals'   => array(
+									'type'        => 'object',
+									'description' => 'Numeric totals / structured evidence.',
+									'properties'  => extrachill_analytics_revenue_diagnostic_totals_schema(),
+								),
+							),
+							'required'   => array( 'check', 'status', 'evidence', 'totals' ),
+						),
+					),
+					'scope'          => array(
+						'type'       => 'object',
+						'properties' => array(
+							'blog_id'          => array( 'type' => 'integer' ),
+							'period'           => array( 'type' => 'string' ),
+							'period_start'     => array( 'type' => 'string' ),
+							'period_end'       => array( 'type' => 'string' ),
+							'import_batch'     => array( 'type' => 'string' ),
+							'selected_periods' => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Distinct period_labels in scope.',
+							),
+							'selected_batches' => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Distinct import_batches in scope.',
+							),
+						),
+						'required'   => array( 'blog_id', 'period', 'period_start', 'period_end', 'import_batch', 'selected_periods', 'selected_batches' ),
+					),
+					'caveat'         => array(
+						'type'        => 'string',
+						'description' => 'Stable analyst caveat.',
+					),
+					'error'          => array(
+						'type'        => 'string',
+						'description' => 'Error message when success is false.',
+					),
+				),
+				'required'   => array( 'success', 'blog_id', 'window', 'overall_status', 'summary', 'checks', 'scope', 'caveat' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_content_revenue_diagnostics',
 			'permission_callback' => function () {
-				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+				return current_user_can( 'manage_options' ) || current_user_can( 'manage_network_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
 			},
 			'meta'                => array(
 				'show_in_rest' => false,
@@ -103,15 +211,101 @@ function extrachill_analytics_register_content_revenue_diagnostics_ability() {
 }
 
 /**
+ * Return the union schema used by diagnostic check totals.
+ *
+ * Checks expose different totals, but every emitted property is declared here
+ * so ability consumers do not receive an untyped object contract.
+ *
+ * @return array<string,array> Diagnostic totals properties.
+ */
+function extrachill_analytics_revenue_diagnostic_totals_schema() {
+	$aggregate = array(
+		'type'       => 'object',
+		'properties' => array(
+			'rows'    => array( 'type' => 'integer' ),
+			'views'   => array( 'type' => 'integer' ),
+			'revenue' => array( 'type' => 'number' ),
+		),
+		'required'   => array( 'rows', 'views', 'revenue' ),
+	);
+
+	$sample = array(
+		'type'       => 'object',
+		'properties' => array(
+			'slug'        => array( 'type' => 'string' ),
+			'revenue'     => array( 'type' => 'number' ),
+			'views'       => array( 'type' => 'integer' ),
+			'issues'      => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
+			'source_rpm'  => array( 'type' => 'number' ),
+			'derived_rpm' => array( 'type' => 'number' ),
+			'relative'    => array( 'type' => 'number' ),
+		),
+	);
+
+	return array(
+		'periods'             => array( 'type' => 'integer' ),
+		'rows'                => array( 'type' => 'integer' ),
+		'has_dated'           => array( 'type' => 'boolean' ),
+		'latest_period'       => array( 'type' => 'string' ),
+		'latest_period_end'   => array( 'type' => 'string' ),
+		'data_age_days'       => array( 'type' => array( 'integer', 'null' ) ),
+		'dated_periods'       => array( 'type' => 'integer' ),
+		'missing_periods'     => array( 'type' => 'integer' ),
+		'missing'             => array(
+			'type'  => 'array',
+			'items' => array( 'type' => 'string' ),
+		),
+		'period_labels'       => array( 'type' => 'integer' ),
+		'duplicate_labels'    => array( 'type' => 'integer' ),
+		'duplicates'          => array( 'type' => 'object' ),
+		'row_sum'             => $aggregate,
+		'independent'         => $aggregate,
+		'reconciled'          => array( 'type' => 'boolean' ),
+		'raw_rows'            => array( 'type' => 'integer' ),
+		'distinct_pages'      => array( 'type' => 'integer' ),
+		'resolved_pages'      => array( 'type' => 'integer' ),
+		'unresolved_pages'    => array( 'type' => 'integer' ),
+		'stale_post_id_rows'  => array( 'type' => 'integer' ),
+		'partition_complete'  => array( 'type' => 'boolean' ),
+		'content_rows'        => array( 'type' => 'integer' ),
+		'unresolved_rows'     => array( 'type' => 'integer' ),
+		'partition_views'     => array( 'type' => 'integer' ),
+		'partition_revenue'   => array( 'type' => 'number' ),
+		'total_pages'         => array( 'type' => 'integer' ),
+		'resolved_views'      => array( 'type' => 'integer' ),
+		'unresolved_views'    => array( 'type' => 'integer' ),
+		'unresolved_ratio'    => array( 'type' => 'number' ),
+		'by_route_family'     => array( 'type' => 'object' ),
+		'uncategorized_pages' => array( 'type' => 'integer' ),
+		'uncategorized_ratio' => array( 'type' => 'number' ),
+		'by_format'           => array( 'type' => 'object' ),
+		'revenue'             => array( 'type' => 'number' ),
+		'samples'             => array(
+			'type'  => 'array',
+			'items' => $sample,
+		),
+		'views'               => array( 'type' => 'integer' ),
+		'ratio'               => array( 'type' => 'number' ),
+		'checked'             => array( 'type' => 'integer' ),
+		'high_variance'       => array( 'type' => 'integer' ),
+		'missing_batch'       => array( 'type' => 'integer' ),
+		'missing_period'      => array( 'type' => 'integer' ),
+	);
+}
+
+/**
  * Execute callback for get-content-revenue-diagnostics ability.
  *
- * Owns the WordPress-dependent half: SQL (via the shared store helpers), slug->
- * post resolution, and the publish-status classification gate. Builds a
- * normalized snapshot — period batches, normalized rows with classification and
- * derived metrics, and timeseries totals — and hands it to the pure builder.
+ * Owns the WordPress-dependent half: network/blog authorization, SQL (the
+ * shared store helpers — including the independent scope aggregate for
+ * reconciliation), switch_to_blog-scoped resolution + classification. Builds a
+ * normalized snapshot and hands it to the pure builder.
  *
  * @param array $input Input parameters.
- * @return array Diagnostics response.
+ * @return array Diagnostics response (consistent shape whether empty or not).
  */
 function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) {
 	$period       = isset( $input['period'] ) ? (string) $input['period'] : '';
@@ -121,56 +315,117 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 	$blog_id      = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : get_current_blog_id();
 	$hostname     = ! empty( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com';
 
-	$rows = extrachill_analytics_revenue_get_rows(
-		array(
-			'blog_id'      => $blog_id,
-			'import_batch' => $import_batch,
-			'period_label' => $period,
-			'period_start' => $period_start,
-			'period_end'   => $period_end,
-		)
+	$scope_args = array(
+		'blog_id'      => $blog_id,
+		'import_batch' => $import_batch,
+		'period_label' => $period,
+		'period_start' => $period_start,
+		'period_end'   => $period_end,
 	);
 
-	// Normalize rows + classify resolved/unresolved (the same publish-status
-	// gate as the rollup/pages abilities). Derived RPM is precomputed per row so
-	// the pure builder can compare it to source RPM without re-deriving.
-	$normalized = array();
-	foreach ( $rows as $row ) {
-		$post_id = (int) $row->post_id;
-		if ( $post_id <= 0 && '' !== $row->slug ) {
-			$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
-		}
-		$is_content = $post_id > 0 && 'publish' === get_post_status( $post_id );
+	$scope_block_base = array(
+		'blog_id'          => $blog_id,
+		'period'           => $period,
+		'period_start'     => $period_start,
+		'period_end'       => $period_end,
+		'import_batch'     => $import_batch,
+		'selected_periods' => array(),
+		'selected_batches' => array(),
+	);
 
-		$views   = (int) $row->views;
-		$revenue = (float) $row->revenue;
+	$empty_summary = array(
+		'pass'    => 0,
+		'warning' => 0,
+		'fail'    => 0,
+		'total'   => 0,
+	);
 
-		$normalized[] = array(
-			'period_label'             => (string) $row->period_label,
-			'import_batch'             => (string) $row->import_batch,
-			'period_start'             => $row->period_start ? (string) $row->period_start : null,
-			'period_end'               => $row->period_end ? (string) $row->period_end : null,
-			'imported_at'              => (string) $row->imported_at,
-			'slug'                     => (string) $row->slug,
-			'post_id'                  => $is_content ? $post_id : 0,
-			'is_content'               => $is_content,
-			'route_family'             => $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $row->url ? $row->url : $row->slug ),
-			'format'                   => $is_content ? extrachill_analytics_classify_format( $post_id ) : '',
-			'views'                    => $views,
-			'revenue'                  => $revenue,
-			'source_rpm'               => (float) $row->rpm,
-			'cpm'                      => (float) $row->cpm,
-			'viewability'              => (float) $row->viewability,
-			'fill_rate'                => (float) $row->fill_rate,
-			'impressions_per_pageview' => (float) $row->impressions_per_pageview,
-			'derived_rpm'              => $views > 0 ? round( $revenue / ( $views / 1000 ), 4 ) : 0.0,
+	$fail_shape = function ( $error_message ) use ( $blog_id, $scope_block_base, $empty_summary ) {
+		return array(
+			'success'        => false,
+			'error'          => $error_message,
+			'blog_id'        => $blog_id,
+			'window'         => '',
+			'overall_status' => 'fail',
+			'summary'        => $empty_summary,
+			'checks'         => array(),
+			'scope'          => $scope_block_base,
+			'caveat'         => $error_message,
 		);
+	};
+
+	// Network/blog authorization.
+	$auth = extrachill_analytics_revenue_authorize_blog_read( $blog_id );
+	if ( true !== $auth ) {
+		return $fail_shape( is_string( $auth ) ? $auth : __( 'Permission denied.', 'extrachill-analytics' ) );
 	}
 
-	// Period-batch aggregates for the scope (from the SAME store, unscoped by
-	// period/window so freshness/missing-period/duplicate-batch checks see the
-	// whole per-blog history; period/window/batch scoping is applied to the
-	// row-level checks only).
+	// Independent SQL aggregate over the scope — the reconciliation check
+	// compares this against the PHP row-sum. Genuinely different read paths.
+	$scope_totals = extrachill_analytics_revenue_get_scope_totals( $scope_args );
+	$independent  = array(
+		'rows'    => $scope_totals && isset( $scope_totals->rows_count ) ? (int) $scope_totals->rows_count : 0,
+		'views'   => $scope_totals && isset( $scope_totals->views ) ? (int) $scope_totals->views : 0,
+		'revenue' => $scope_totals && isset( $scope_totals->revenue ) ? round( (float) $scope_totals->revenue, 4 ) : 0.0,
+	);
+
+	$rows = extrachill_analytics_revenue_get_rows( $scope_args );
+
+	// switch_to_blog so resolution + publish-status + term/format classification
+	// all run against the TARGET blog.
+	$normalized = extrachill_analytics_revenue_run_in_blog(
+		$blog_id,
+		static function () use ( $rows, $hostname ) {
+			$normalized = array();
+			foreach ( $rows as $row ) {
+				$post_id = (int) $row->post_id;
+				if ( $post_id <= 0 && '' !== $row->slug ) {
+					$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
+				}
+				$is_content = $post_id > 0 && 'publish' === get_post_status( $post_id );
+
+				$views   = (int) $row->views;
+				$revenue = (float) $row->revenue;
+
+				$normalized[] = array(
+					'period_label'             => (string) $row->period_label,
+					'import_batch'             => (string) $row->import_batch,
+					'period_start'             => $row->period_start ? (string) $row->period_start : null,
+					'period_end'               => $row->period_end ? (string) $row->period_end : null,
+					'imported_at'              => (string) $row->imported_at,
+					'slug'                     => (string) $row->slug,
+					'stored_post_id'           => (int) $row->post_id,
+					'post_id'                  => $is_content ? $post_id : 0,
+					'is_content'               => $is_content,
+					'route_family'             => $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $row->url ? $row->url : $row->slug ),
+					'format'                   => $is_content ? extrachill_analytics_classify_format( $post_id ) : '',
+					'views'                    => $views,
+					'revenue'                  => $revenue,
+					'source_rpm'               => (float) $row->rpm,
+					'cpm'                      => (float) $row->cpm,
+					'viewability'              => (float) $row->viewability,
+					'fill_rate'                => (float) $row->fill_rate,
+					'impressions_per_pageview' => (float) $row->impressions_per_pageview,
+					'derived_rpm'              => $views > 0 ? round( $revenue / ( $views / 1000 ), 4 ) : 0.0,
+				);
+			}
+
+			return $normalized;
+		}
+	);
+
+	// Selected periods/batches in scope.
+	$selected_periods = array();
+	$selected_batches = array();
+	foreach ( $normalized as $r ) {
+		$selected_periods[ $r['period_label'] ] = true;
+		$selected_batches[ $r['import_batch'] ] = true;
+	}
+	$scope_block_base['selected_periods'] = array_keys( $selected_periods );
+	$scope_block_base['selected_batches'] = array_keys( $selected_batches );
+
+	// Period-batch aggregates UNscoped by period/window/batch so freshness,
+	// missing-period, and duplicate-batch checks see the whole per-blog history.
 	$period_aggs = extrachill_analytics_revenue_list_batches( $blog_id );
 
 	$periods = array();
@@ -187,31 +442,18 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 		);
 	}
 
-	// Timeseries totals for the scope — the reconciliation check compares the
-	// in-scope row-sum against this. Computed from the in-scope rows directly so
-	// reconciliation is a self-consistency check on the normalized snapshot.
-	$ts_views   = 0;
-	$ts_revenue = 0.0;
-	foreach ( $normalized as $r ) {
-		$ts_views   += $r['views'];
-		$ts_revenue += $r['revenue'];
-	}
-
 	$built = extrachill_analytics_revenue_build_diagnostics(
 		array(
-			'scope'             => array(
+			'scope'              => array(
 				'blog_id'      => $blog_id,
 				'period'       => $period,
 				'period_start' => $period_start,
 				'period_end'   => $period_end,
 				'import_batch' => $import_batch,
 			),
-			'periods'           => $periods,
-			'rows'              => $normalized,
-			'timeseries_totals' => array(
-				'views'   => $ts_views,
-				'revenue' => round( $ts_revenue, 4 ),
-			),
+			'periods'            => $periods,
+			'rows'               => $normalized,
+			'independent_totals' => $independent,
 		)
 	);
 
@@ -219,11 +461,11 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 		'success'        => true,
 		'blog_id'        => $blog_id,
 		'window'         => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
-		'checks'         => $built['checks'],
 		'overall_status' => $built['overall_status'],
 		'summary'        => $built['summary'],
-		'scope'          => $built['scope'],
-		'caveat'         => __( 'Source quirks (zero-view revenue, duplicate period batches, stored-vs-derived RPM variance, unresolved routes) are warnings — disclosure, not corruption claims. fail is reserved for genuine integrity violations: negative/impossible values or a read model that does not reconcile. Freshness/missing-period/duplicate-batch checks consider the whole per-blog history (unscoped); row-level checks honor the requested period/window/batch scope. Resolution coverage uses the same publish-status gate as the rollup/pages abilities.', 'extrachill-analytics' ),
+		'checks'         => $built['checks'],
+		'scope'          => $scope_block_base,
+		'caveat'         => __( 'Source quirks (zero-view revenue, duplicate period batches, stored-vs-derived RPM variance, unresolved routes) are warnings — disclosure, not corruption claims. fail is reserved for genuine integrity violations: negative/impossible values or a read model that does not reconcile against the independent SQL aggregate. Freshness uses the period boundary (period_end), not the import timestamp. Resolution/format coverage dedupe by page_key before counting. Freshness/missing-period/duplicate-batch checks consider the whole per-blog history (unscoped); row-level checks honor the requested period/window/batch scope. An empty scoped query never passes. Resolution coverage uses the same publish-status gate as the rollup/pages abilities.', 'extrachill-analytics' ),
 	);
 }
 
@@ -231,15 +473,15 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
  * Build the diagnostics checks from a normalized store snapshot.
  *
  * PURE — no WordPress / DB dependency — so every check's status/evidence/totals
- * contract is unit-testable in isolation. The execute_callback owns querying and
- * resolution; this function owns the integrity logic.
+ * contract is unit-testable in isolation. The execute_callback owns querying,
+ * authorization, and resolution; this function owns the integrity logic.
  *
  * Snapshot shape:
  *   {
  *     scope: { blog_id, period, period_start, period_end, import_batch },
  *     periods: [ { period_label, import_batch, period_start, period_end, rows, revenue, views, imported_at }, ... ],
- *     rows: [ { period_label, import_batch, ..., is_content, route_family, format, views, revenue, source_rpm, derived_rpm, ... }, ... ],
- *     timeseries_totals: { views, revenue },
+ *     rows: [ { period_label, import_batch, stored_post_id, post_id, is_content, route_family, format, views, revenue, source_rpm, derived_rpm, cpm, viewability, fill_rate, impressions_per_pageview }, ... ],
+ *     independent_totals: { rows, views, revenue },  // from the independent SQL SUM() aggregate
  *   }
  *
  * @param array $snapshot Normalized snapshot.
@@ -248,7 +490,8 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 function extrachill_analytics_revenue_build_diagnostics( array $snapshot ) {
 	$periods = isset( $snapshot['periods'] ) && is_array( $snapshot['periods'] ) ? $snapshot['periods'] : array();
 	$rows    = isset( $snapshot['rows'] ) && is_array( $snapshot['rows'] ) ? $snapshot['rows'] : array();
-	$ts      = isset( $snapshot['timeseries_totals'] ) && is_array( $snapshot['timeseries_totals'] ) ? $snapshot['timeseries_totals'] : array(
+	$indep   = isset( $snapshot['independent_totals'] ) && is_array( $snapshot['independent_totals'] ) ? $snapshot['independent_totals'] : array(
+		'rows'    => 0,
 		'views'   => 0,
 		'revenue' => 0.0,
 	);
@@ -258,7 +501,8 @@ function extrachill_analytics_revenue_build_diagnostics( array $snapshot ) {
 	$checks[] = extrachill_analytics_revenue_diag_latest_period_freshness( $periods, $rows );
 	$checks[] = extrachill_analytics_revenue_diag_missing_periods( $periods );
 	$checks[] = extrachill_analytics_revenue_diag_duplicate_period_batches( $periods );
-	$checks[] = extrachill_analytics_revenue_diag_totals_reconciliation( $rows, $ts );
+	$checks[] = extrachill_analytics_revenue_diag_totals_reconciliation( $rows, $indep );
+	$checks[] = extrachill_analytics_revenue_diag_content_unresolved_reconciliation( $rows );
 	$checks[] = extrachill_analytics_revenue_diag_resolution_coverage( $rows );
 	$checks[] = extrachill_analytics_revenue_diag_format_coverage( $rows );
 	$checks[] = extrachill_analytics_revenue_diag_zero_view_revenue( $rows );
@@ -297,7 +541,11 @@ function extrachill_analytics_revenue_build_diagnostics( array $snapshot ) {
 }
 
 /**
- * Latest-period freshness: is there a dated period, and how recent is it?
+ * Latest-period freshness: is there a dated period, and how old is its DATA?
+ *
+ * Freshness uses the period BOUNDARY (period_end) — the age of the data itself —
+ * not the import timestamp (which only records when the operator happened to run
+ * the import). Warn when the newest dated period's data is older than 45 days.
  *
  * @param array $periods Period-batch aggregates.
  * @param array $rows    Normalized rows (used for the empty-store case).
@@ -316,59 +564,60 @@ function extrachill_analytics_revenue_diag_latest_period_freshness( array $perio
 		);
 	}
 
-	// Find the most recent DATED period (period_start not null). The flat
-	// "all-time" bucket has no date and does not count as fresh.
+	// Find the most recent DATED period by period_end (the data's boundary).
 	$latest_label = '';
-	$latest_at    = '';
+	$latest_end   = '';
 	$has_dated    = false;
 	foreach ( $periods as $p ) {
-		if ( ! empty( $p['period_start'] ) ) {
+		if ( ! empty( $p['period_end'] ) ) {
 			$has_dated = true;
-			if ( '' === $latest_at || ( isset( $p['imported_at'] ) && $p['imported_at'] > $latest_at ) ) {
-				$latest_at    = isset( $p['imported_at'] ) ? (string) $p['imported_at'] : '';
+			$end       = (string) $p['period_end'];
+			if ( '' === $latest_end || $end > $latest_end ) {
+				$latest_end   = $end;
 				$latest_label = isset( $p['period_label'] ) ? (string) $p['period_label'] : '';
 			}
 		}
 	}
 
 	$totals = array(
-		'periods'            => count( $periods ),
-		'has_dated'          => $has_dated,
-		'latest_period'      => $latest_label,
-		'latest_imported_at' => $latest_at,
+		'periods'           => count( $periods ),
+		'has_dated'         => $has_dated,
+		'latest_period'     => $latest_label,
+		'latest_period_end' => $latest_end,
+		'data_age_days'     => null,
 	);
 
 	if ( ! $has_dated ) {
 		return array(
 			'check'    => 'latest_period_freshness',
 			'status'   => 'warning',
-			'evidence' => array( 'Only the flat "all-time" bucket is present — no dated (monthly) periods imported. Import date-ranged CSVs with --period=YYYY-MM to build the arc and enable freshness tracking.' ),
+			'evidence' => array( 'Only the flat "all-time" bucket is present — no dated (monthly) periods imported. Import date-ranged CSVs with --period=YYYY-MM to enable freshness tracking.' ),
 			'totals'   => $totals,
 		);
 	}
 
-	// Warn if the newest dated import is older than 45 days (a quarter-ish).
+	// Data age = now - latest period_end.
 	$stale    = false;
 	$age_days = null;
-	if ( '' !== $latest_at ) {
-		$ts = strtotime( $latest_at );
-		if ( false !== $ts ) {
-			$age_days = (int) floor( ( time() - $ts ) / DAY_IN_SECONDS );
+	if ( '' !== $latest_end ) {
+		$end_ts = strtotime( $latest_end );
+		if ( false !== $end_ts ) {
+			$age_days = (int) floor( ( time() - $end_ts ) / DAY_IN_SECONDS );
 			$stale    = $age_days > 45;
 		}
 	}
+	$totals['data_age_days'] = $age_days;
 
 	$evidence   = array();
 	$status     = 'pass';
-	$evidence[] = "Newest dated period: {$latest_label} (imported {$latest_at}).";
+	$evidence[] = "Newest dated period: {$latest_label} (data through {$latest_end}).";
 	if ( null !== $age_days ) {
-		$evidence[] = "Imported {$age_days} day(s) ago.";
+		$evidence[] = "Data is {$age_days} day(s) old (by period boundary, not import time).";
 	}
 	if ( $stale ) {
 		$status     = 'warning';
-		$evidence[] = 'Newest dated import is older than 45 days — the revenue arc may be stale.';
+		$evidence[] = 'Newest dated data is older than 45 days — the revenue arc may be stale.';
 	}
-	$totals['age_days'] = $age_days;
 
 	return array(
 		'check'    => 'latest_period_freshness',
@@ -491,17 +740,24 @@ function extrachill_analytics_revenue_diag_duplicate_period_batches( array $peri
 }
 
 /**
- * Totals reconciliation: in-scope row-sum must equal the timeseries totals.
+ * Totals reconciliation: PHP row-sum vs an INDEPENDENT SQL SUM() aggregate.
  *
- * Both come from the same store, so a mismatch means the read model itself is
- * broken — a regression signal. This is the one check where 'fail' is warranted
- * on a numeric disagreement (the integrity of the read path).
+ * Non-tautological by design: the independent_totals come from MySQL's SUM()
+ * aggregator (get_scope_totals) over the canonical scope, while the row-sum is
+ * a PHP loop over get_rows() — two genuinely different read paths. A divergence
+ * is a read-path regression signal (row hydration, type coercion, a silent row
+ * cap), NOT a Mediavine data issue. This is the one check where 'fail' is
+ * warranted on a numeric disagreement.
  *
- * @param array $rows Normalized rows.
- * @param array $ts   Timeseries totals { views, revenue }.
+ * An empty scoped query is a warning (cannot reconcile nothing) so it never
+ * silently passes.
+ *
+ * @param array $rows Normalized rows (the PHP-side sum).
+ * @param array $indep Independent SQL aggregate { rows, views, revenue }.
  * @return array Check.
  */
-function extrachill_analytics_revenue_diag_totals_reconciliation( array $rows, array $ts ) {
+function extrachill_analytics_revenue_diag_totals_reconciliation( array $rows, array $indep ) {
+	$sum_rows    = count( $rows );
 	$sum_views   = 0;
 	$sum_revenue = 0.0;
 	foreach ( $rows as $r ) {
@@ -510,24 +766,47 @@ function extrachill_analytics_revenue_diag_totals_reconciliation( array $rows, a
 	}
 	$sum_revenue = round( $sum_revenue, 4 );
 
-	$ts_views   = isset( $ts['views'] ) ? (int) $ts['views'] : 0;
-	$ts_revenue = round( isset( $ts['revenue'] ) ? (float) $ts['revenue'] : 0.0, 4 );
+	$indep_rows    = isset( $indep['rows'] ) ? (int) $indep['rows'] : 0;
+	$indep_views   = isset( $indep['views'] ) ? (int) $indep['views'] : 0;
+	$indep_revenue = round( isset( $indep['revenue'] ) ? (float) $indep['revenue'] : 0.0, 4 );
 
-	$views_match   = $sum_views === $ts_views;
-	$revenue_match = abs( $sum_revenue - $ts_revenue ) < 0.01;
-	$match         = $views_match && $revenue_match;
+	// Empty scoped query → cannot reconcile, never pass.
+	if ( 0 === $sum_rows && 0 === $indep_rows ) {
+		return array(
+			'check'    => 'totals_reconciliation',
+			'status'   => 'warning',
+			'evidence' => array( 'No rows in the requested scope — reconciliation cannot run, so the scope does not pass.', 'If a scope was expected, check the period/batch/window or import data.' ),
+			'totals'   => array(
+				'row_sum'     => array(
+					'rows'    => $sum_rows,
+					'views'   => $sum_views,
+					'revenue' => $sum_revenue,
+				),
+				'independent' => array(
+					'rows'    => $indep_rows,
+					'views'   => $indep_views,
+					'revenue' => $indep_revenue,
+				),
+				'reconciled'  => false,
+			),
+		);
+	}
 
+	$match    = ( $sum_rows === $indep_rows ) && ( $sum_views === $indep_views ) && ( abs( $sum_revenue - $indep_revenue ) < 0.01 );
 	$status   = $match ? 'pass' : 'fail';
 	$evidence = array();
 	if ( $match ) {
-		$evidence[] = "Row-sum reconciles with timeseries totals: {$sum_views} views, \${$sum_revenue} revenue.";
+		$evidence[] = "Row-sum reconciles with the independent SQL aggregate: {$sum_rows} row(s), {$sum_views} views, \${$sum_revenue} revenue.";
 	} else {
-		$evidence[] = 'Row-sum does NOT reconcile with timeseries totals.';
-		if ( ! $views_match ) {
-			$evidence[] = "Views: row-sum {$sum_views} vs timeseries {$ts_views}.";
+		$evidence[] = 'Row-sum does NOT reconcile with the independent SQL aggregate.';
+		if ( $sum_rows !== $indep_rows ) {
+			$evidence[] = "Rows: row-sum {$sum_rows} vs independent {$indep_rows}.";
 		}
-		if ( ! $revenue_match ) {
-			$evidence[] = "Revenue: row-sum {$sum_revenue} vs timeseries {$ts_revenue}.";
+		if ( $sum_views !== $indep_views ) {
+			$evidence[] = "Views: row-sum {$sum_views} vs independent {$indep_views}.";
+		}
+		if ( abs( $sum_revenue - $indep_revenue ) >= 0.01 ) {
+			$evidence[] = "Revenue: row-sum {$sum_revenue} vs independent {$indep_revenue}.";
 		}
 		$evidence[] = 'A reconciliation mismatch indicates the read model is self-inconsistent — a regression, not a Mediavine data issue.';
 	}
@@ -537,21 +816,103 @@ function extrachill_analytics_revenue_diag_totals_reconciliation( array $rows, a
 		'status'   => $status,
 		'evidence' => $evidence,
 		'totals'   => array(
-			'row_sum'    => array(
+			'row_sum'     => array(
+				'rows'    => $sum_rows,
 				'views'   => $sum_views,
 				'revenue' => $sum_revenue,
 			),
-			'timeseries' => array(
-				'views'   => $ts_views,
-				'revenue' => $ts_revenue,
+			'independent' => array(
+				'rows'    => $indep_rows,
+				'views'   => $indep_views,
+				'revenue' => $indep_revenue,
 			),
-			'reconciled' => $match,
+			'reconciled'  => $match,
 		),
 	);
 }
 
 /**
- * Resolution coverage: resolved published posts vs unresolved routes.
+ * Content/unresolved reconciliation: verify the resolved/unresolved partition
+ * and dedupe are lossless, and disclose stale stored post_ids.
+ *
+ * Meaningful checks:
+ *   - Every row is classified as exactly one of content / unresolved (partition
+ *     completeness).
+ *   - A row with a stored post_id > 0 that is NOT 'publish' is correctly routed
+ *     to unresolved (a stale post — trashed since import). Disclosed as evidence.
+ *
+ * @param array $rows Normalized rows.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_content_unresolved_reconciliation( array $rows ) {
+	$content_keys    = array();
+	$unresolved_keys = array();
+	$stale_post_ids  = 0;
+	$content_rows    = 0;
+	$unresolved_rows = 0;
+	$partition_views = 0;
+	$partition_rev   = 0.0;
+
+	foreach ( $rows as $r ) {
+		$key = ! empty( $r['is_content'] )
+			? 'p' . (int) $r['post_id']
+			: 'u' . md5( isset( $r['slug'] ) ? (string) $r['slug'] : '' );
+
+		if ( ! empty( $r['is_content'] ) ) {
+			$content_keys[ $key ] = true;
+			++$content_rows;
+		} else {
+			$unresolved_keys[ $key ] = true;
+			++$unresolved_rows;
+			// Stored a post_id at import that no longer resolves/publishes.
+			if ( ! empty( $r['stored_post_id'] ) && (int) $r['stored_post_id'] > 0 ) {
+				++$stale_post_ids;
+			}
+		}
+		$partition_views += isset( $r['views'] ) ? (int) $r['views'] : 0;
+		$partition_rev   += isset( $r['revenue'] ) ? (float) $r['revenue'] : 0.0;
+	}
+
+	$content_n    = count( $content_keys );
+	$unresolved_n = count( $unresolved_keys );
+	$distinct_n   = $content_n + $unresolved_n;
+	$raw_n        = count( $rows );
+	$complete     = ( $content_rows + $unresolved_rows ) === $raw_n;
+
+	// The partition is complete by construction (every row is one or the other).
+	// The meaningful signal here is the stale-post-id count and the
+	// distinct-vs-raw ratio (dedupe losslessness is reported as a ratio).
+	$status     = $complete ? 'pass' : 'fail';
+	$evidence   = array();
+	$evidence[] = "{$content_n} distinct resolved page(s), {$unresolved_n} distinct unresolved page(s), {$distinct_n} distinct total ({$raw_n} raw row(s)).";
+	if ( $stale_post_ids > 0 ) {
+		$status     = $complete ? 'warning' : 'fail';
+		$evidence[] = "{$stale_post_ids} unresolved row(s) carry a stored post_id that is no longer published (stale — the post was trashed since import).";
+		$evidence[] = 'These are correctly routed to the unresolved cohort (not counted as content).';
+	}
+
+	return array(
+		'check'    => 'content_unresolved_reconciliation',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'raw_rows'           => $raw_n,
+			'distinct_pages'     => $distinct_n,
+			'resolved_pages'     => $content_n,
+			'unresolved_pages'   => $unresolved_n,
+			'stale_post_id_rows' => $stale_post_ids,
+			'partition_complete' => $complete,
+			'content_rows'       => $content_rows,
+			'unresolved_rows'    => $unresolved_rows,
+			'partition_views'    => $partition_views,
+			'partition_revenue'  => round( $partition_rev, 4 ),
+		),
+	);
+}
+
+/**
+ * Resolution coverage: resolved published posts vs unresolved routes, counted on
+ * DEDUPED pages (not raw rows) so a post with N URL variants counts once.
  *
  * A high unresolved ratio is a coverage signal (much of the imported traffic is
  * non-content routes), not corruption.
@@ -560,38 +921,46 @@ function extrachill_analytics_revenue_diag_totals_reconciliation( array $rows, a
  * @return array Check.
  */
 function extrachill_analytics_revenue_diag_resolution_coverage( array $rows ) {
-	$total            = count( $rows );
-	$resolved         = 0;
-	$unresolved       = 0;
+	$resolved         = array();
+	$unresolved       = array();
+	$by_family        = array();
 	$resolved_views   = 0;
 	$unresolved_views = 0;
-	$by_family        = array();
 
 	foreach ( $rows as $r ) {
+		$key = ! empty( $r['is_content'] )
+			? 'p' . (int) $r['post_id']
+			: 'u' . md5( isset( $r['slug'] ) ? (string) $r['slug'] : '' );
+
 		if ( ! empty( $r['is_content'] ) ) {
-			++$resolved;
-			$resolved_views += isset( $r['views'] ) ? (int) $r['views'] : 0;
+			$resolved[ $key ] = true;
+			$resolved_views  += isset( $r['views'] ) ? (int) $r['views'] : 0;
 		} else {
-			++$unresolved;
-			$unresolved_views += isset( $r['views'] ) ? (int) $r['views'] : 0;
-			$family            = isset( $r['route_family'] ) ? (string) $r['route_family'] : 'other';
-			if ( ! isset( $by_family[ $family ] ) ) {
-				$by_family[ $family ] = 0;
+			if ( ! isset( $unresolved[ $key ] ) ) {
+				$family = isset( $r['route_family'] ) ? (string) $r['route_family'] : 'other';
+				if ( ! isset( $by_family[ $family ] ) ) {
+					$by_family[ $family ] = 0;
+				}
+				++$by_family[ $family ];
 			}
-			++$by_family[ $family ];
+			$unresolved[ $key ] = true;
+			$unresolved_views  += isset( $r['views'] ) ? (int) $r['views'] : 0;
 		}
 	}
 
-	$ratio = $total > 0 ? $unresolved / $total : 0.0;
-	// Warn above 50% — most of the imported traffic is non-content routes.
+	$resolved_n   = count( $resolved );
+	$unresolved_n = count( $unresolved );
+	$total        = $resolved_n + $unresolved_n;
+	$ratio        = $total > 0 ? $unresolved_n / $total : 0.0;
+	// Warn above 50% — most distinct pages are non-content routes.
 	$status     = ( $total > 0 && $ratio > 0.50 ) ? 'warning' : 'pass';
 	$evidence   = array();
-	$evidence[] = "{$resolved} resolved published row(s), {$unresolved} unresolved route row(s) of {$total} total.";
+	$evidence[] = "{$resolved_n} distinct resolved page(s), {$unresolved_n} distinct unresolved page(s) of {$total} total (deduped).";
 	if ( $total > 0 ) {
 		$evidence[] = sprintf( 'Unresolved ratio: %.1f%%.', $ratio * 100 );
 	}
 	if ( 'warning' === $status ) {
-		$evidence[] = 'More than half of imported rows are unresolved routes — coverage signal, not corruption. Legacy .html ghosts, taxonomy archives, and app/account routes are expected here.';
+		$evidence[] = 'More than half of distinct pages are unresolved routes — coverage signal, not corruption. Legacy .html ghosts, taxonomy archives, and app/account routes are expected here.';
 	}
 	arsort( $by_family );
 
@@ -600,9 +969,9 @@ function extrachill_analytics_revenue_diag_resolution_coverage( array $rows ) {
 		'status'   => $status,
 		'evidence' => $evidence,
 		'totals'   => array(
-			'total_rows'       => $total,
-			'resolved_rows'    => $resolved,
-			'unresolved_rows'  => $unresolved,
+			'total_pages'      => $total,
+			'resolved_pages'   => $resolved_n,
+			'unresolved_pages' => $unresolved_n,
 			'resolved_views'   => $resolved_views,
 			'unresolved_views' => $unresolved_views,
 			'unresolved_ratio' => round( $ratio, 4 ),
@@ -612,7 +981,8 @@ function extrachill_analytics_revenue_diag_resolution_coverage( array $rows ) {
 }
 
 /**
- * Content-format coverage: resolved posts that classified as 'uncategorized'.
+ * Content-format coverage: resolved posts that classified as 'uncategorized',
+ * counted on DEDUPED pages (not raw rows).
  *
  * A high uncategorized ratio means the format classifier has no mapping for
  * many posts — a taxonomy gap, not corruption. Unresolved routes are excluded
@@ -622,15 +992,20 @@ function extrachill_analytics_revenue_diag_resolution_coverage( array $rows ) {
  * @return array Check.
  */
 function extrachill_analytics_revenue_diag_format_coverage( array $rows ) {
-	$resolved_total = 0;
-	$uncategorized  = 0;
-	$by_format      = array();
+	$by_format     = array();
+	$uncategorized = 0;
 
 	foreach ( $rows as $r ) {
 		if ( empty( $r['is_content'] ) ) {
 			continue;
 		}
-		++$resolved_total;
+		// Dedupe by post id — one vote per resolved page.
+		$key = 'p' . (int) $r['post_id'];
+		if ( isset( $by_format['_seen'][ $key ] ) ) {
+			continue;
+		}
+		$by_format['_seen'][ $key ] = true;
+
 		$format = isset( $r['format'] ) ? (string) $r['format'] : 'uncategorized';
 		if ( '' === $format ) {
 			$format = 'uncategorized';
@@ -643,16 +1018,22 @@ function extrachill_analytics_revenue_diag_format_coverage( array $rows ) {
 			++$uncategorized;
 		}
 	}
+	unset( $by_format['_seen'] );
+
+	$resolved_total = 0;
+	foreach ( $by_format as $count ) {
+		$resolved_total += $count;
+	}
 
 	$ratio = $resolved_total > 0 ? $uncategorized / $resolved_total : 0.0;
-	// Warn above 30% — a lot of resolved posts fall outside every format bucket.
+	// Warn above 30% — a lot of distinct resolved pages fall outside every bucket.
 	$status     = ( $resolved_total > 0 && $ratio > 0.30 ) ? 'warning' : 'pass';
 	$evidence   = array();
-	$evidence[] = "{$uncategorized} of {$resolved_total} resolved published row(s) classified as 'uncategorized'.";
+	$evidence[] = "{$uncategorized} of {$resolved_total} distinct resolved page(s) classified as 'uncategorized'.";
 	if ( 'warning' === $status ) {
-		$evidence[] = 'Over 30% of resolved posts match no content-format bucket — a taxonomy-mapping gap. Add their category slugs to extrachill_analytics_format_category_map().';
+		$evidence[] = 'Over 30% of resolved pages match no content-format bucket — a taxonomy-mapping gap. Add their category slugs to extrachill_analytics_format_category_map().';
 	} else {
-		$evidence[] = 'Format classifier covers the majority of resolved posts.';
+		$evidence[] = 'Format classifier covers the majority of resolved pages.';
 	}
 	arsort( $by_format );
 
@@ -661,8 +1042,8 @@ function extrachill_analytics_revenue_diag_format_coverage( array $rows ) {
 		'status'   => $status,
 		'evidence' => $evidence,
 		'totals'   => array(
-			'resolved_rows'       => $resolved_total,
-			'uncategorized_rows'  => $uncategorized,
+			'resolved_pages'      => $resolved_total,
+			'uncategorized_pages' => $uncategorized,
 			'uncategorized_ratio' => round( $ratio, 4 ),
 			'by_format'           => $by_format,
 		),
@@ -743,7 +1124,7 @@ function extrachill_analytics_revenue_diag_views_zero_revenue( array $rows ) {
 	}
 
 	$ratio = $total_rows > 0 ? $count / $total_rows : 0.0;
-	// Warn above 20% — a sizeable share of viewed pages earned nothing.
+	// Warn above 20% — a sizeable share of rows earned nothing.
 	$status     = ( $total_rows > 0 && $ratio > 0.20 ) ? 'warning' : 'pass';
 	$evidence   = array();
 	$evidence[] = "{$count} row(s) with {$views} views report zero revenue.";
@@ -764,9 +1145,17 @@ function extrachill_analytics_revenue_diag_views_zero_revenue( array $rows ) {
 }
 
 /**
- * Negative / impossible values: negative views/revenue/rpm/cpm, or RPM/CPM that
- * imply impossible rates. This is the one check where 'fail' is warranted on a
+ * Negative / impossible values: negative views/revenue/rpm/cpm, OR rates/views
+ * outside plausible ranges. This is the one check where 'fail' is warranted on a
  * genuine data-integrity violation.
+ *
+ * Range contract:
+ *   - views, revenue, rpm, cpm: must be >= 0.
+ *   - viewability, fill_rate: must be in [0, 100] (percentages).
+ *   - source/derived rpm, cpm: flagged as impossibly high above 1000.
+ *   - impressions/pageview: must be in [0, 1000].
+ *   - views: flagged as impossibly high above 1,000,000,000.
+ *   - every floating-point metric must be finite.
  *
  * @param array $rows Normalized rows.
  * @return array Check.
@@ -776,14 +1165,37 @@ function extrachill_analytics_revenue_diag_negative_impossible_values( array $ro
 	$samples = array();
 
 	foreach ( $rows as $r ) {
-		$issues = array();
-		$views  = isset( $r['views'] ) ? (int) $r['views'] : 0;
-		$rev    = isset( $r['revenue'] ) ? (float) $r['revenue'] : 0.0;
-		$rpm    = isset( $r['source_rpm'] ) ? (float) $r['source_rpm'] : 0.0;
-		$cpm    = isset( $r['cpm'] ) ? (float) $r['cpm'] : 0.0;
+		$issues      = array();
+		$slug        = isset( $r['slug'] ) ? (string) $r['slug'] : '';
+		$views       = isset( $r['views'] ) ? (int) $r['views'] : 0;
+		$rev         = isset( $r['revenue'] ) ? (float) $r['revenue'] : 0.0;
+		$rpm         = isset( $r['source_rpm'] ) ? (float) $r['source_rpm'] : 0.0;
+		$derived_rpm = isset( $r['derived_rpm'] ) ? (float) $r['derived_rpm'] : 0.0;
+		$cpm         = isset( $r['cpm'] ) ? (float) $r['cpm'] : 0.0;
+		$viewability = isset( $r['viewability'] ) ? (float) $r['viewability'] : 0.0;
+		$fill_rate   = isset( $r['fill_rate'] ) ? (float) $r['fill_rate'] : 0.0;
+		$impressions = isset( $r['impressions_per_pageview'] ) ? (float) $r['impressions_per_pageview'] : 0.0;
+
+		$finite_metrics = array(
+			'revenue'                  => $rev,
+			'source rpm'               => $rpm,
+			'derived rpm'              => $derived_rpm,
+			'cpm'                      => $cpm,
+			'viewability'              => $viewability,
+			'fill_rate'                => $fill_rate,
+			'impressions per pageview' => $impressions,
+		);
+		foreach ( $finite_metrics as $label => $value ) {
+			if ( ! is_finite( $value ) ) {
+				$issues[] = "non-finite {$label}";
+			}
+		}
 
 		if ( $views < 0 ) {
 			$issues[] = "negative views ({$views})";
+		}
+		if ( $views > 1000000000 ) {
+			$issues[] = "impossibly high views ({$views})";
 		}
 		if ( $rev < 0 ) {
 			$issues[] = "negative revenue ({$rev})";
@@ -794,12 +1206,30 @@ function extrachill_analytics_revenue_diag_negative_impossible_values( array $ro
 		if ( $cpm < 0 ) {
 			$issues[] = "negative cpm ({$cpm})";
 		}
+		if ( $rpm > 1000 ) {
+			$issues[] = "impossibly high source rpm ({$rpm})";
+		}
+		if ( $derived_rpm < 0 || $derived_rpm > 1000 ) {
+			$issues[] = "derived rpm out of [0,1000] ({$derived_rpm})";
+		}
+		if ( $cpm > 1000 ) {
+			$issues[] = "impossibly high cpm ({$cpm})";
+		}
+		if ( $viewability < 0 || $viewability > 100 ) {
+			$issues[] = "viewability out of [0,100] ({$viewability})";
+		}
+		if ( $fill_rate < 0 || $fill_rate > 100 ) {
+			$issues[] = "fill_rate out of [0,100] ({$fill_rate})";
+		}
+		if ( $impressions < 0 || $impressions > 1000 ) {
+			$issues[] = "impressions_per_pageview out of [0,1000] ({$impressions})";
+		}
 
 		if ( ! empty( $issues ) ) {
 			$bad[] = $r;
 			if ( count( $samples ) < 5 ) {
 				$samples[] = array(
-					'slug'   => isset( $r['slug'] ) ? (string) $r['slug'] : '',
+					'slug'   => $slug,
 					'issues' => $issues,
 				);
 			}
@@ -809,13 +1239,13 @@ function extrachill_analytics_revenue_diag_negative_impossible_values( array $ro
 	$status   = empty( $bad ) ? 'pass' : 'fail';
 	$evidence = array();
 	if ( empty( $bad ) ) {
-		$evidence[] = 'No negative or impossible values detected.';
+		$evidence[] = 'No negative, non-finite, or out-of-range values detected (views/revenue/rpm/cpm >= 0 and capped; viewability/fill_rate in [0,100]; impressions/pageview in [0,1000]).';
 	} else {
 		$evidence[] = count( $bad ) . ' row(s) with negative or impossible values:';
 		foreach ( $samples as $s ) {
 			$evidence[] = "  {$s['slug']}: " . implode( '; ', $s['issues'] );
 		}
-		$evidence[] = 'Negative revenue/views/rates are genuine integrity violations — investigate the import source.';
+		$evidence[] = 'Negative/out-of-range values are genuine integrity violations — investigate the import source.';
 	}
 
 	return array(

--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -260,7 +260,13 @@ function extrachill_analytics_revenue_diagnostic_totals_schema() {
 		),
 		'period_labels'       => array( 'type' => 'integer' ),
 		'duplicate_labels'    => array( 'type' => 'integer' ),
-		'duplicates'          => array( 'type' => 'object' ),
+		'duplicates'          => array(
+			'type'                 => 'object',
+			'additionalProperties' => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
+		),
 		'row_sum'             => $aggregate,
 		'independent'         => $aggregate,
 		'reconciled'          => array( 'type' => 'boolean' ),
@@ -278,10 +284,16 @@ function extrachill_analytics_revenue_diagnostic_totals_schema() {
 		'resolved_views'      => array( 'type' => 'integer' ),
 		'unresolved_views'    => array( 'type' => 'integer' ),
 		'unresolved_ratio'    => array( 'type' => 'number' ),
-		'by_route_family'     => array( 'type' => 'object' ),
+		'by_route_family'     => array(
+			'type'                 => 'object',
+			'additionalProperties' => array( 'type' => 'integer' ),
+		),
 		'uncategorized_pages' => array( 'type' => 'integer' ),
 		'uncategorized_ratio' => array( 'type' => 'number' ),
-		'by_format'           => array( 'type' => 'object' ),
+		'by_format'           => array(
+			'type'                 => 'object',
+			'additionalProperties' => array( 'type' => 'integer' ),
+		),
 		'revenue'             => array( 'type' => 'number' ),
 		'samples'             => array(
 			'type'  => 'array',

--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -86,8 +86,8 @@ function extrachill_analytics_register_content_revenue_diagnostics_ability() {
 					),
 					'hostname'     => array(
 						'type'        => 'string',
-						'description' => __( 'Hostname for resolving any still-unresolved slugs to posts (default: extrachill.com).', 'extrachill-analytics' ),
-						'default'     => 'extrachill.com',
+						'description' => __( 'Optional hostname for resolving relative slugs to posts. Empty = the target blog hostname.', 'extrachill-analytics' ),
+						'default'     => '',
 					),
 				),
 			),
@@ -325,7 +325,7 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 	$period_end   = isset( $input['period_end'] ) ? (string) $input['period_end'] : '';
 	$import_batch = isset( $input['import_batch'] ) ? (string) $input['import_batch'] : '';
 	$blog_id      = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : get_current_blog_id();
-	$hostname     = ! empty( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com';
+	$hostname     = isset( $input['hostname'] ) ? trim( (string) $input['hostname'] ) : '';
 
 	$scope_args = array(
 		'blog_id'      => $blog_id,
@@ -389,6 +389,7 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 		$blog_id,
 		static function () use ( $rows, $hostname ) {
 			$normalized = array();
+			$hostname   = extrachill_analytics_revenue_resolution_hostname( $hostname );
 			foreach ( $rows as $row ) {
 				$post_id = (int) $row->post_id;
 				if ( $post_id <= 0 && '' !== $row->slug ) {

--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -1,0 +1,936 @@
+<?php
+/**
+ * Get Content Revenue Diagnostics Ability
+ *
+ * Structured data-integrity lens for the Mediavine revenue store. Where
+ * extrachill/get-content-revenue rolls up revenue and extrachill/get-content-
+ * revenue-pages ranks individual pages, THIS ability reports the HEALTH of the
+ * store itself: is the latest import fresh, are monthly periods contiguous,
+ * are any periods double-imported, does the read model reconcile, how much
+ * traffic is unresolved, are there zero-view-revenue or negative-value rows,
+ * and does stored RPM agree with derived RPM?
+ *
+ * Why a sibling and not a diagnostic flag on the rollup: the rollup output
+ * contract is rollups/totals/unresolved — it has no place for an array of
+ * independent checks each carrying status/evidence/totals. The issue explicitly
+ * permits narrowly scoped siblings. This ability reuses the SAME store, resolver,
+ * and classifiers — no new tables, no parallel aggregation.
+ *
+ * Status contract: each check returns one of 'pass', 'warning', or 'fail'.
+ *   - 'fail' is reserved for genuine data-integrity violations that make the
+ *     numbers untrustworthy (negative/impossible values, a read model that does
+ *     not reconcile). Source quirks (zero-view revenue, duplicate batches, RPM
+ *     variance) are NEVER 'fail' without evidence — they are 'warning' so the
+ *     analyst sees them without the system crying wolf. The issue is explicit:
+ *     do not claim source anomalies are corruption without evidence.
+ *   - The overall status is fail if any check fails, else warning if any warns,
+ *     else pass.
+ *
+ * Reconciliation note: totals_reconciliation compares the in-scope row-sum
+ * against the in-scope timeseries aggregation. Both come from the same table, so
+ * a pass confirms the read path is self-consistent; a fail means the read model
+ * itself is broken (a regression signal, not a Mediavine data issue).
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.28.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-content-revenue-diagnostics ability.
+ */
+function extrachill_analytics_register_content_revenue_diagnostics_ability() {
+	wp_register_ability(
+		'extrachill/get-content-revenue-diagnostics',
+		array(
+			'label'               => __( 'Get Content Revenue Diagnostics Lens', 'extrachill-analytics' ),
+			'description'         => __( 'Structured data-integrity checks for the Mediavine revenue store. Returns an array of independent checks — latest-period freshness, missing periods, duplicate period/batch imports, totals reconciliation, resolution and content-format coverage, revenue with zero pageviews, views with zero revenue, negative/impossible values, stored-vs-derived RPM variance, and source/import provenance coverage — each with a stable pass|warning|fail status, evidence, and totals. Source quirks (zero-view revenue, duplicate batches, RPM variance) are warnings, never corruption claims without evidence; fail is reserved for genuine integrity violations (negative values, a read model that does not reconcile). Reuses the same store, resolver, and classifiers as the rollup/pages abilities — no new tables. CLI consumers map args and format output only.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'period'       => array(
+						'type'        => 'string',
+						'description' => __( 'Scope diagnostics to one time bucket, e.g. "2026-05" or "all-time". Empty = every bucket combined (the whole-store integrity view).', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'period_start' => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive window start (Y-m-d). With period_end, scopes to snapshots imported for that window.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'period_end'   => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive window end (Y-m-d). See period_start.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'import_batch' => array(
+						'type'        => 'string',
+						'description' => __( 'Restrict to one import batch. Empty = all batches.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'blog_id'      => array(
+						'type'        => 'integer',
+						'description' => __( 'Blog ID whose revenue to diagnose. 0 = current blog.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'hostname'     => array(
+						'type'        => 'string',
+						'description' => __( 'Hostname for resolving any still-unresolved slugs to posts (default: extrachill.com).', 'extrachill-analytics' ),
+						'default'     => 'extrachill.com',
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'checks array (each: check, status pass|warning|fail, evidence, totals), overall_status, summary { pass, warning, fail, total }, scope metadata, and caveats.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_content_revenue_diagnostics',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-content-revenue-diagnostics ability.
+ *
+ * Owns the WordPress-dependent half: SQL (via the shared store helpers), slug->
+ * post resolution, and the publish-status classification gate. Builds a
+ * normalized snapshot — period batches, normalized rows with classification and
+ * derived metrics, and timeseries totals — and hands it to the pure builder.
+ *
+ * @param array $input Input parameters.
+ * @return array Diagnostics response.
+ */
+function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) {
+	$period       = isset( $input['period'] ) ? (string) $input['period'] : '';
+	$period_start = isset( $input['period_start'] ) ? (string) $input['period_start'] : '';
+	$period_end   = isset( $input['period_end'] ) ? (string) $input['period_end'] : '';
+	$import_batch = isset( $input['import_batch'] ) ? (string) $input['import_batch'] : '';
+	$blog_id      = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : get_current_blog_id();
+	$hostname     = ! empty( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com';
+
+	$rows = extrachill_analytics_revenue_get_rows(
+		array(
+			'blog_id'      => $blog_id,
+			'import_batch' => $import_batch,
+			'period_label' => $period,
+			'period_start' => $period_start,
+			'period_end'   => $period_end,
+		)
+	);
+
+	// Normalize rows + classify resolved/unresolved (the same publish-status
+	// gate as the rollup/pages abilities). Derived RPM is precomputed per row so
+	// the pure builder can compare it to source RPM without re-deriving.
+	$normalized = array();
+	foreach ( $rows as $row ) {
+		$post_id = (int) $row->post_id;
+		if ( $post_id <= 0 && '' !== $row->slug ) {
+			$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
+		}
+		$is_content = $post_id > 0 && 'publish' === get_post_status( $post_id );
+
+		$views   = (int) $row->views;
+		$revenue = (float) $row->revenue;
+
+		$normalized[] = array(
+			'period_label'             => (string) $row->period_label,
+			'import_batch'             => (string) $row->import_batch,
+			'period_start'             => $row->period_start ? (string) $row->period_start : null,
+			'period_end'               => $row->period_end ? (string) $row->period_end : null,
+			'imported_at'              => (string) $row->imported_at,
+			'slug'                     => (string) $row->slug,
+			'post_id'                  => $is_content ? $post_id : 0,
+			'is_content'               => $is_content,
+			'route_family'             => $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $row->url ? $row->url : $row->slug ),
+			'format'                   => $is_content ? extrachill_analytics_classify_format( $post_id ) : '',
+			'views'                    => $views,
+			'revenue'                  => $revenue,
+			'source_rpm'               => (float) $row->rpm,
+			'cpm'                      => (float) $row->cpm,
+			'viewability'              => (float) $row->viewability,
+			'fill_rate'                => (float) $row->fill_rate,
+			'impressions_per_pageview' => (float) $row->impressions_per_pageview,
+			'derived_rpm'              => $views > 0 ? round( $revenue / ( $views / 1000 ), 4 ) : 0.0,
+		);
+	}
+
+	// Period-batch aggregates for the scope (from the SAME store, unscoped by
+	// period/window so freshness/missing-period/duplicate-batch checks see the
+	// whole per-blog history; period/window/batch scoping is applied to the
+	// row-level checks only).
+	$period_aggs = extrachill_analytics_revenue_list_batches( $blog_id );
+
+	$periods = array();
+	foreach ( $period_aggs as $p ) {
+		$periods[] = array(
+			'period_label' => (string) $p->period_label,
+			'import_batch' => (string) $p->import_batch,
+			'period_start' => $p->period_start ? (string) $p->period_start : null,
+			'period_end'   => $p->period_end ? (string) $p->period_end : null,
+			'rows'         => (int) $p->rows_count,
+			'revenue'      => (float) $p->revenue,
+			'views'        => (int) $p->views,
+			'imported_at'  => (string) $p->imported_at,
+		);
+	}
+
+	// Timeseries totals for the scope — the reconciliation check compares the
+	// in-scope row-sum against this. Computed from the in-scope rows directly so
+	// reconciliation is a self-consistency check on the normalized snapshot.
+	$ts_views   = 0;
+	$ts_revenue = 0.0;
+	foreach ( $normalized as $r ) {
+		$ts_views   += $r['views'];
+		$ts_revenue += $r['revenue'];
+	}
+
+	$built = extrachill_analytics_revenue_build_diagnostics(
+		array(
+			'scope'             => array(
+				'blog_id'      => $blog_id,
+				'period'       => $period,
+				'period_start' => $period_start,
+				'period_end'   => $period_end,
+				'import_batch' => $import_batch,
+			),
+			'periods'           => $periods,
+			'rows'              => $normalized,
+			'timeseries_totals' => array(
+				'views'   => $ts_views,
+				'revenue' => round( $ts_revenue, 4 ),
+			),
+		)
+	);
+
+	return array(
+		'success'        => true,
+		'blog_id'        => $blog_id,
+		'window'         => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
+		'checks'         => $built['checks'],
+		'overall_status' => $built['overall_status'],
+		'summary'        => $built['summary'],
+		'scope'          => $built['scope'],
+		'caveat'         => __( 'Source quirks (zero-view revenue, duplicate period batches, stored-vs-derived RPM variance, unresolved routes) are warnings — disclosure, not corruption claims. fail is reserved for genuine integrity violations: negative/impossible values or a read model that does not reconcile. Freshness/missing-period/duplicate-batch checks consider the whole per-blog history (unscoped); row-level checks honor the requested period/window/batch scope. Resolution coverage uses the same publish-status gate as the rollup/pages abilities.', 'extrachill-analytics' ),
+	);
+}
+
+/**
+ * Build the diagnostics checks from a normalized store snapshot.
+ *
+ * PURE — no WordPress / DB dependency — so every check's status/evidence/totals
+ * contract is unit-testable in isolation. The execute_callback owns querying and
+ * resolution; this function owns the integrity logic.
+ *
+ * Snapshot shape:
+ *   {
+ *     scope: { blog_id, period, period_start, period_end, import_batch },
+ *     periods: [ { period_label, import_batch, period_start, period_end, rows, revenue, views, imported_at }, ... ],
+ *     rows: [ { period_label, import_batch, ..., is_content, route_family, format, views, revenue, source_rpm, derived_rpm, ... }, ... ],
+ *     timeseries_totals: { views, revenue },
+ *   }
+ *
+ * @param array $snapshot Normalized snapshot.
+ * @return array { checks, overall_status, summary, scope }
+ */
+function extrachill_analytics_revenue_build_diagnostics( array $snapshot ) {
+	$periods = isset( $snapshot['periods'] ) && is_array( $snapshot['periods'] ) ? $snapshot['periods'] : array();
+	$rows    = isset( $snapshot['rows'] ) && is_array( $snapshot['rows'] ) ? $snapshot['rows'] : array();
+	$ts      = isset( $snapshot['timeseries_totals'] ) && is_array( $snapshot['timeseries_totals'] ) ? $snapshot['timeseries_totals'] : array(
+		'views'   => 0,
+		'revenue' => 0.0,
+	);
+	$scope   = isset( $snapshot['scope'] ) && is_array( $snapshot['scope'] ) ? $snapshot['scope'] : array();
+
+	$checks   = array();
+	$checks[] = extrachill_analytics_revenue_diag_latest_period_freshness( $periods, $rows );
+	$checks[] = extrachill_analytics_revenue_diag_missing_periods( $periods );
+	$checks[] = extrachill_analytics_revenue_diag_duplicate_period_batches( $periods );
+	$checks[] = extrachill_analytics_revenue_diag_totals_reconciliation( $rows, $ts );
+	$checks[] = extrachill_analytics_revenue_diag_resolution_coverage( $rows );
+	$checks[] = extrachill_analytics_revenue_diag_format_coverage( $rows );
+	$checks[] = extrachill_analytics_revenue_diag_zero_view_revenue( $rows );
+	$checks[] = extrachill_analytics_revenue_diag_views_zero_revenue( $rows );
+	$checks[] = extrachill_analytics_revenue_diag_negative_impossible_values( $rows );
+	$checks[] = extrachill_analytics_revenue_diag_rpm_variance( $rows );
+	$checks[] = extrachill_analytics_revenue_diag_provenance_coverage( $rows );
+
+	$summary = array(
+		'pass'    => 0,
+		'warning' => 0,
+		'fail'    => 0,
+		'total'   => count( $checks ),
+	);
+	foreach ( $checks as $c ) {
+		$status = isset( $c['status'] ) ? $c['status'] : 'warning';
+		if ( isset( $summary[ $status ] ) ) {
+			++$summary[ $status ];
+		}
+	}
+
+	if ( $summary['fail'] > 0 ) {
+		$overall = 'fail';
+	} elseif ( $summary['warning'] > 0 ) {
+		$overall = 'warning';
+	} else {
+		$overall = 'pass';
+	}
+
+	return array(
+		'checks'         => $checks,
+		'overall_status' => $overall,
+		'summary'        => $summary,
+		'scope'          => $scope,
+	);
+}
+
+/**
+ * Latest-period freshness: is there a dated period, and how recent is it?
+ *
+ * @param array $periods Period-batch aggregates.
+ * @param array $rows    Normalized rows (used for the empty-store case).
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_latest_period_freshness( array $periods, array $rows ) {
+	if ( empty( $rows ) && empty( $periods ) ) {
+		return array(
+			'check'    => 'latest_period_freshness',
+			'status'   => 'fail',
+			'evidence' => array( 'No revenue snapshots imported for this blog.' ),
+			'totals'   => array(
+				'periods' => 0,
+				'rows'    => 0,
+			),
+		);
+	}
+
+	// Find the most recent DATED period (period_start not null). The flat
+	// "all-time" bucket has no date and does not count as fresh.
+	$latest_label = '';
+	$latest_at    = '';
+	$has_dated    = false;
+	foreach ( $periods as $p ) {
+		if ( ! empty( $p['period_start'] ) ) {
+			$has_dated = true;
+			if ( '' === $latest_at || ( isset( $p['imported_at'] ) && $p['imported_at'] > $latest_at ) ) {
+				$latest_at    = isset( $p['imported_at'] ) ? (string) $p['imported_at'] : '';
+				$latest_label = isset( $p['period_label'] ) ? (string) $p['period_label'] : '';
+			}
+		}
+	}
+
+	$totals = array(
+		'periods'            => count( $periods ),
+		'has_dated'          => $has_dated,
+		'latest_period'      => $latest_label,
+		'latest_imported_at' => $latest_at,
+	);
+
+	if ( ! $has_dated ) {
+		return array(
+			'check'    => 'latest_period_freshness',
+			'status'   => 'warning',
+			'evidence' => array( 'Only the flat "all-time" bucket is present — no dated (monthly) periods imported. Import date-ranged CSVs with --period=YYYY-MM to build the arc and enable freshness tracking.' ),
+			'totals'   => $totals,
+		);
+	}
+
+	// Warn if the newest dated import is older than 45 days (a quarter-ish).
+	$stale    = false;
+	$age_days = null;
+	if ( '' !== $latest_at ) {
+		$ts = strtotime( $latest_at );
+		if ( false !== $ts ) {
+			$age_days = (int) floor( ( time() - $ts ) / DAY_IN_SECONDS );
+			$stale    = $age_days > 45;
+		}
+	}
+
+	$evidence   = array();
+	$status     = 'pass';
+	$evidence[] = "Newest dated period: {$latest_label} (imported {$latest_at}).";
+	if ( null !== $age_days ) {
+		$evidence[] = "Imported {$age_days} day(s) ago.";
+	}
+	if ( $stale ) {
+		$status     = 'warning';
+		$evidence[] = 'Newest dated import is older than 45 days — the revenue arc may be stale.';
+	}
+	$totals['age_days'] = $age_days;
+
+	return array(
+		'check'    => 'latest_period_freshness',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => $totals,
+	);
+}
+
+/**
+ * Missing-period detection: are there gaps in the YYYY-MM dated sequence?
+ *
+ * @param array $periods Period-batch aggregates.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_missing_periods( array $periods ) {
+	$dated = array();
+	foreach ( $periods as $p ) {
+		$label = isset( $p['period_label'] ) ? (string) $p['period_label'] : '';
+		if ( preg_match( '/^\d{4}-\d{2}$/', $label ) ) {
+			$dated[ $label ] = true;
+		}
+	}
+
+	$sorted = array_keys( $dated );
+	sort( $sorted );
+	$n = count( $sorted );
+
+	$missing = array();
+	if ( $n >= 2 ) {
+		$first  = $sorted[0];
+		$last   = $sorted[ $n - 1 ];
+		$cursor = strtotime( $first . '-01' );
+		$end_ts = strtotime( $last . '-01' );
+		while ( false !== $cursor && false !== $end_ts && $cursor <= $end_ts ) {
+			$bucket = gmdate( 'Y-m', $cursor );
+			if ( ! isset( $dated[ $bucket ] ) ) {
+				$missing[] = $bucket;
+			}
+			$cursor = strtotime( '+1 month', $cursor );
+		}
+	}
+
+	$status   = empty( $missing ) ? 'pass' : 'warning';
+	$evidence = array();
+	if ( empty( $missing ) ) {
+		$evidence[] = $n >= 2
+			? sprintf( 'Dated periods are contiguous from %s to %s (%d period(s)).', $sorted[0], $sorted[ $n - 1 ], $n )
+			: sprintf( '%d dated period(s) — no sequence to gap-check.', $n );
+	} else {
+		$evidence[] = sprintf( 'Gap(s) in the monthly sequence: %s.', implode( ', ', $missing ) );
+		$evidence[] = 'A gap may mean a month was never imported, or was imported under a non-YYYY-MM label.';
+	}
+
+	return array(
+		'check'    => 'missing_periods',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'dated_periods'   => $n,
+			'missing_periods' => count( $missing ),
+			'missing'         => $missing,
+		),
+	);
+}
+
+/**
+ * Duplicate-period-batch detection: same period_label across multiple batches.
+ *
+ * This is NOT corruption — re-imports are idempotent via REPLACE INTO on the
+ * unique (blog, slug, period, batch) key. But if two DIFFERENT batches carry the
+ * SAME period_label, a rollup that ignores batch can double-count. Disclose it.
+ *
+ * @param array $periods Period-batch aggregates.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_duplicate_period_batches( array $periods ) {
+	$by_label = array();
+	foreach ( $periods as $p ) {
+		$label = isset( $p['period_label'] ) ? (string) $p['period_label'] : '';
+		if ( '' === $label ) {
+			continue;
+		}
+		if ( ! isset( $by_label[ $label ] ) ) {
+			$by_label[ $label ] = array();
+		}
+		$by_label[ $label ][] = isset( $p['import_batch'] ) ? (string) $p['import_batch'] : '';
+	}
+
+	$duplicates = array();
+	foreach ( $by_label as $label => $batches ) {
+		$unique = array_unique( $batches );
+		if ( count( $unique ) > 1 ) {
+			$duplicates[ $label ] = array_values( $unique );
+		}
+	}
+
+	$status   = empty( $duplicates ) ? 'pass' : 'warning';
+	$evidence = array();
+	if ( empty( $duplicates ) ) {
+		$evidence[] = 'No period label spans more than one import batch.';
+	} else {
+		$evidence[] = 'One or more period labels appear across multiple import batches — a rollup that ignores --batch may double-count these:';
+		foreach ( $duplicates as $label => $batches ) {
+			$evidence[] = "  {$label}: " . implode( ', ', $batches );
+		}
+		$evidence[] = 'Pass --batch to scope, or re-import under one batch to collapse them.';
+	}
+
+	return array(
+		'check'    => 'duplicate_period_batches',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'period_labels'    => count( $by_label ),
+			'duplicate_labels' => count( $duplicates ),
+			'duplicates'       => $duplicates,
+		),
+	);
+}
+
+/**
+ * Totals reconciliation: in-scope row-sum must equal the timeseries totals.
+ *
+ * Both come from the same store, so a mismatch means the read model itself is
+ * broken — a regression signal. This is the one check where 'fail' is warranted
+ * on a numeric disagreement (the integrity of the read path).
+ *
+ * @param array $rows Normalized rows.
+ * @param array $ts   Timeseries totals { views, revenue }.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_totals_reconciliation( array $rows, array $ts ) {
+	$sum_views   = 0;
+	$sum_revenue = 0.0;
+	foreach ( $rows as $r ) {
+		$sum_views   += isset( $r['views'] ) ? (int) $r['views'] : 0;
+		$sum_revenue += isset( $r['revenue'] ) ? (float) $r['revenue'] : 0.0;
+	}
+	$sum_revenue = round( $sum_revenue, 4 );
+
+	$ts_views   = isset( $ts['views'] ) ? (int) $ts['views'] : 0;
+	$ts_revenue = round( isset( $ts['revenue'] ) ? (float) $ts['revenue'] : 0.0, 4 );
+
+	$views_match   = $sum_views === $ts_views;
+	$revenue_match = abs( $sum_revenue - $ts_revenue ) < 0.01;
+	$match         = $views_match && $revenue_match;
+
+	$status   = $match ? 'pass' : 'fail';
+	$evidence = array();
+	if ( $match ) {
+		$evidence[] = "Row-sum reconciles with timeseries totals: {$sum_views} views, \${$sum_revenue} revenue.";
+	} else {
+		$evidence[] = 'Row-sum does NOT reconcile with timeseries totals.';
+		if ( ! $views_match ) {
+			$evidence[] = "Views: row-sum {$sum_views} vs timeseries {$ts_views}.";
+		}
+		if ( ! $revenue_match ) {
+			$evidence[] = "Revenue: row-sum {$sum_revenue} vs timeseries {$ts_revenue}.";
+		}
+		$evidence[] = 'A reconciliation mismatch indicates the read model is self-inconsistent — a regression, not a Mediavine data issue.';
+	}
+
+	return array(
+		'check'    => 'totals_reconciliation',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'row_sum'    => array(
+				'views'   => $sum_views,
+				'revenue' => $sum_revenue,
+			),
+			'timeseries' => array(
+				'views'   => $ts_views,
+				'revenue' => $ts_revenue,
+			),
+			'reconciled' => $match,
+		),
+	);
+}
+
+/**
+ * Resolution coverage: resolved published posts vs unresolved routes.
+ *
+ * A high unresolved ratio is a coverage signal (much of the imported traffic is
+ * non-content routes), not corruption.
+ *
+ * @param array $rows Normalized rows.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_resolution_coverage( array $rows ) {
+	$total            = count( $rows );
+	$resolved         = 0;
+	$unresolved       = 0;
+	$resolved_views   = 0;
+	$unresolved_views = 0;
+	$by_family        = array();
+
+	foreach ( $rows as $r ) {
+		if ( ! empty( $r['is_content'] ) ) {
+			++$resolved;
+			$resolved_views += isset( $r['views'] ) ? (int) $r['views'] : 0;
+		} else {
+			++$unresolved;
+			$unresolved_views += isset( $r['views'] ) ? (int) $r['views'] : 0;
+			$family            = isset( $r['route_family'] ) ? (string) $r['route_family'] : 'other';
+			if ( ! isset( $by_family[ $family ] ) ) {
+				$by_family[ $family ] = 0;
+			}
+			++$by_family[ $family ];
+		}
+	}
+
+	$ratio = $total > 0 ? $unresolved / $total : 0.0;
+	// Warn above 50% — most of the imported traffic is non-content routes.
+	$status     = ( $total > 0 && $ratio > 0.50 ) ? 'warning' : 'pass';
+	$evidence   = array();
+	$evidence[] = "{$resolved} resolved published row(s), {$unresolved} unresolved route row(s) of {$total} total.";
+	if ( $total > 0 ) {
+		$evidence[] = sprintf( 'Unresolved ratio: %.1f%%.', $ratio * 100 );
+	}
+	if ( 'warning' === $status ) {
+		$evidence[] = 'More than half of imported rows are unresolved routes — coverage signal, not corruption. Legacy .html ghosts, taxonomy archives, and app/account routes are expected here.';
+	}
+	arsort( $by_family );
+
+	return array(
+		'check'    => 'resolution_coverage',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'total_rows'       => $total,
+			'resolved_rows'    => $resolved,
+			'unresolved_rows'  => $unresolved,
+			'resolved_views'   => $resolved_views,
+			'unresolved_views' => $unresolved_views,
+			'unresolved_ratio' => round( $ratio, 4 ),
+			'by_route_family'  => $by_family,
+		),
+	);
+}
+
+/**
+ * Content-format coverage: resolved posts that classified as 'uncategorized'.
+ *
+ * A high uncategorized ratio means the format classifier has no mapping for
+ * many posts — a taxonomy gap, not corruption. Unresolved routes are excluded
+ * (they never reach the classifier).
+ *
+ * @param array $rows Normalized rows.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_format_coverage( array $rows ) {
+	$resolved_total = 0;
+	$uncategorized  = 0;
+	$by_format      = array();
+
+	foreach ( $rows as $r ) {
+		if ( empty( $r['is_content'] ) ) {
+			continue;
+		}
+		++$resolved_total;
+		$format = isset( $r['format'] ) ? (string) $r['format'] : 'uncategorized';
+		if ( '' === $format ) {
+			$format = 'uncategorized';
+		}
+		if ( ! isset( $by_format[ $format ] ) ) {
+			$by_format[ $format ] = 0;
+		}
+		++$by_format[ $format ];
+		if ( 'uncategorized' === $format ) {
+			++$uncategorized;
+		}
+	}
+
+	$ratio = $resolved_total > 0 ? $uncategorized / $resolved_total : 0.0;
+	// Warn above 30% — a lot of resolved posts fall outside every format bucket.
+	$status     = ( $resolved_total > 0 && $ratio > 0.30 ) ? 'warning' : 'pass';
+	$evidence   = array();
+	$evidence[] = "{$uncategorized} of {$resolved_total} resolved published row(s) classified as 'uncategorized'.";
+	if ( 'warning' === $status ) {
+		$evidence[] = 'Over 30% of resolved posts match no content-format bucket — a taxonomy-mapping gap. Add their category slugs to extrachill_analytics_format_category_map().';
+	} else {
+		$evidence[] = 'Format classifier covers the majority of resolved posts.';
+	}
+	arsort( $by_format );
+
+	return array(
+		'check'    => 'format_coverage',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'resolved_rows'       => $resolved_total,
+			'uncategorized_rows'  => $uncategorized,
+			'uncategorized_ratio' => round( $ratio, 4 ),
+			'by_format'           => $by_format,
+		),
+	);
+}
+
+/**
+ * Zero-view revenue: rows with revenue > 0 but views = 0.
+ *
+ * A Mediavine source quirk (rounding, sub-threshold fills, a missed views cell).
+ * Disclosed as a warning — never corruption.
+ *
+ * @param array $rows Normalized rows.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_zero_view_revenue( array $rows ) {
+	$count   = 0;
+	$revenue = 0.0;
+	$samples = array();
+
+	foreach ( $rows as $r ) {
+		$views = isset( $r['views'] ) ? (int) $r['views'] : 0;
+		$rev   = isset( $r['revenue'] ) ? (float) $r['revenue'] : 0.0;
+		if ( $views <= 0 && $rev > 0 ) {
+			++$count;
+			$revenue += $rev;
+			if ( count( $samples ) < 5 ) {
+				$samples[] = array(
+					'slug'    => isset( $r['slug'] ) ? (string) $r['slug'] : '',
+					'revenue' => round( $rev, 4 ),
+					'views'   => 0,
+				);
+			}
+		}
+	}
+
+	$status   = $count > 0 ? 'warning' : 'pass';
+	$evidence = array();
+	if ( 0 === $count ) {
+		$evidence[] = 'No rows report revenue with zero pageviews.';
+	} else {
+		$evidence[] = "{$count} row(s) report revenue (total \${$revenue}) with zero pageviews.";
+		$evidence[] = 'A Mediavine source quirk — the pages-ability flags these zero_views with derived_rpm = 0 and revenue preserved.';
+	}
+
+	return array(
+		'check'    => 'zero_view_revenue',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'rows'    => $count,
+			'revenue' => round( $revenue, 4 ),
+			'samples' => $samples,
+		),
+	);
+}
+
+/**
+ * Views-with-zero-revenue: rows with views > 0 but revenue = 0.
+ *
+ * Usually sub-threshold ad fills on low-traffic pages. Warning at high volume.
+ *
+ * @param array $rows Normalized rows.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_views_zero_revenue( array $rows ) {
+	$count      = 0;
+	$views      = 0;
+	$total_rows = count( $rows );
+
+	foreach ( $rows as $r ) {
+		$v   = isset( $r['views'] ) ? (int) $r['views'] : 0;
+		$rev = isset( $r['revenue'] ) ? (float) $r['revenue'] : 0.0;
+		if ( $v > 0 && $rev <= 0 ) {
+			++$count;
+			$views += $v;
+		}
+	}
+
+	$ratio = $total_rows > 0 ? $count / $total_rows : 0.0;
+	// Warn above 20% — a sizeable share of viewed pages earned nothing.
+	$status     = ( $total_rows > 0 && $ratio > 0.20 ) ? 'warning' : 'pass';
+	$evidence   = array();
+	$evidence[] = "{$count} row(s) with {$views} views report zero revenue.";
+	if ( 'warning' === $status ) {
+		$evidence[] = sprintf( 'Over 20%% of rows (%.1f%%) are viewed-but-zero-revenue — typically sub-threshold ad fills on low-traffic pages.', $ratio * 100 );
+	}
+
+	return array(
+		'check'    => 'views_zero_revenue',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'rows'  => $count,
+			'views' => $views,
+			'ratio' => round( $ratio, 4 ),
+		),
+	);
+}
+
+/**
+ * Negative / impossible values: negative views/revenue/rpm/cpm, or RPM/CPM that
+ * imply impossible rates. This is the one check where 'fail' is warranted on a
+ * genuine data-integrity violation.
+ *
+ * @param array $rows Normalized rows.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_negative_impossible_values( array $rows ) {
+	$bad     = array();
+	$samples = array();
+
+	foreach ( $rows as $r ) {
+		$issues = array();
+		$views  = isset( $r['views'] ) ? (int) $r['views'] : 0;
+		$rev    = isset( $r['revenue'] ) ? (float) $r['revenue'] : 0.0;
+		$rpm    = isset( $r['source_rpm'] ) ? (float) $r['source_rpm'] : 0.0;
+		$cpm    = isset( $r['cpm'] ) ? (float) $r['cpm'] : 0.0;
+
+		if ( $views < 0 ) {
+			$issues[] = "negative views ({$views})";
+		}
+		if ( $rev < 0 ) {
+			$issues[] = "negative revenue ({$rev})";
+		}
+		if ( $rpm < 0 ) {
+			$issues[] = "negative source rpm ({$rpm})";
+		}
+		if ( $cpm < 0 ) {
+			$issues[] = "negative cpm ({$cpm})";
+		}
+
+		if ( ! empty( $issues ) ) {
+			$bad[] = $r;
+			if ( count( $samples ) < 5 ) {
+				$samples[] = array(
+					'slug'   => isset( $r['slug'] ) ? (string) $r['slug'] : '',
+					'issues' => $issues,
+				);
+			}
+		}
+	}
+
+	$status   = empty( $bad ) ? 'pass' : 'fail';
+	$evidence = array();
+	if ( empty( $bad ) ) {
+		$evidence[] = 'No negative or impossible values detected.';
+	} else {
+		$evidence[] = count( $bad ) . ' row(s) with negative or impossible values:';
+		foreach ( $samples as $s ) {
+			$evidence[] = "  {$s['slug']}: " . implode( '; ', $s['issues'] );
+		}
+		$evidence[] = 'Negative revenue/views/rates are genuine integrity violations — investigate the import source.';
+	}
+
+	return array(
+		'check'    => 'negative_impossible_values',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'rows'    => count( $bad ),
+			'samples' => $samples,
+		),
+	);
+}
+
+/**
+ * Stored-vs-derived RPM variance: where Mediavine's reported rpm disagrees with
+ * revenue/(views/1000). Disclosure — the two RPMs are kept distinct on purpose.
+ *
+ * @param array $rows Normalized rows.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_rpm_variance( array $rows ) {
+	$high_variance = 0;
+	$checked       = 0;
+	$samples       = array();
+
+	foreach ( $rows as $r ) {
+		$views = isset( $r['views'] ) ? (int) $r['views'] : 0;
+		if ( $views <= 0 ) {
+			continue;
+		}
+		++$checked;
+
+		$derived = isset( $r['derived_rpm'] ) ? (float) $r['derived_rpm'] : 0.0;
+		$source  = isset( $r['source_rpm'] ) ? (float) $r['source_rpm'] : 0.0;
+
+		$denom    = max( abs( $source ), 0.0001 );
+		$relative = abs( $derived - $source ) / $denom;
+
+		if ( $relative > 0.20 ) {
+			++$high_variance;
+			if ( count( $samples ) < 5 ) {
+				$samples[] = array(
+					'slug'        => isset( $r['slug'] ) ? (string) $r['slug'] : '',
+					'source_rpm'  => round( $source, 4 ),
+					'derived_rpm' => round( $derived, 4 ),
+					'relative'    => round( $relative, 4 ),
+				);
+			}
+		}
+	}
+
+	$ratio = $checked > 0 ? $high_variance / $checked : 0.0;
+	// Warn above 10% — a sizeable share of rows disagree by more than 20%.
+	$status     = ( $checked > 0 && $ratio > 0.10 ) ? 'warning' : 'pass';
+	$evidence   = array();
+	$evidence[] = "{$high_variance} of {$checked} views-positive row(s) differ by >20% between source rpm and derived rpm.";
+	if ( 'warning' === $status ) {
+		$evidence[] = 'The two RPMs disagree widely — they are reported separately on purpose (source_rpm vs derived_rpm). Rank on whichever fits the question.';
+	}
+
+	return array(
+		'check'    => 'stored_vs_derived_rpm_variance',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'checked'       => $checked,
+			'high_variance' => $high_variance,
+			'ratio'         => round( $ratio, 4 ),
+			'samples'       => $samples,
+		),
+	);
+}
+
+/**
+ * Source/import provenance coverage: rows missing an import_batch or period_label.
+ *
+ * The import path always stamps both, so any gap is a regression signal.
+ *
+ * @param array $rows Normalized rows.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_provenance_coverage( array $rows ) {
+	$total          = count( $rows );
+	$missing_batch  = 0;
+	$missing_period = 0;
+
+	foreach ( $rows as $r ) {
+		$batch = isset( $r['import_batch'] ) ? (string) $r['import_batch'] : '';
+		$label = isset( $r['period_label'] ) ? (string) $r['period_label'] : '';
+		if ( '' === $batch ) {
+			++$missing_batch;
+		}
+		if ( '' === $label ) {
+			++$missing_period;
+		}
+	}
+
+	$missing  = $missing_batch + $missing_period;
+	$status   = ( $total > 0 && $missing > 0 ) ? 'warning' : 'pass';
+	$evidence = array();
+	if ( 0 === $missing ) {
+		$evidence[] = "All {$total} row(s) carry import_batch and period_label provenance.";
+	} else {
+		$evidence[] = "{$missing_batch} row(s) missing import_batch, {$missing_period} missing period_label.";
+		$evidence[] = 'The import path always stamps both — a gap suggests a write-path regression.';
+	}
+
+	return array(
+		'check'    => 'provenance_coverage',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'rows'           => $total,
+			'missing_batch'  => $missing_batch,
+			'missing_period' => $missing_period,
+		),
+	);
+}

--- a/inc/core/abilities/get-content-revenue-pages.php
+++ b/inc/core/abilities/get-content-revenue-pages.php
@@ -23,19 +23,33 @@
  * analyst can rank on either and spot variance. They are never blended into one
  * "rpm" field.
  *
+ * Source-rate averaging across collapsed URL variants: when multiple rows share
+ * a page_key (URL variants, or multiple snapshots queried together), volume
+ * (views/revenue) is SUMMED, but the rate columns (source_rpm, cpm,
+ * viewability, fill_rate, impressions_per_pageview) are simple-averaged — NOT
+ * views-weighted — because their true denominators (impressions/requests for
+ * CPM/viewability/fill_rate) are NOT stored, so views-weighting would invent a
+ * denominator. derived_rpm remains the correct aggregated RPM (recomputed from
+ * the summed revenue/views). A caveat discloses this.
+ *
  * Zero-view revenue handling: a Mediavine row CAN report revenue > 0 with views
  * = 0 (rounding, sub-threshold fills, a missed views cell). derived_rpm is set
  * to 0.0 (NEVER a division error, NEVER infinity), the page is flagged
  * `zero_views => true`, and the revenue is preserved and visible — never hidden.
- * A caveat discloses the cohort so the analyst is never misled.
  *
- * Benchmark opportunity (optional, defensible): a page qualifies when it shows
- * genuinely strong RPM AT meaningful volume — derived_rpm >= 1.5x the cohort
- * median derived_rpm AND views >= the cohort median views (both medians taken
- * over pages with views > 0). High RPM on tiny volume never qualifies ("high RPM
- * on tiny volume = pennies"). Requires at least 5 views-positive pages or the
- * flag is suppressed (insufficient sample). This is an analytical signal ("this
- * page is worth studying"), not a recommendation engine.
+ * Default window contract: with no explicit period/window/batch, the query
+ * scopes to the FRESHEST DATED period (the most recent monthly bucket by
+ * period_end) — it never silently combines the flat "all-time" file with
+ * monthly buckets and duplicate batches (which would double-count). Pass
+ * period=all-time, or period_start/period_end, or import_batch for an explicit
+ * combined/lifetime view. The response exposes selected_periods and
+ * selected_batches so the caller always knows what was queried.
+ *
+ * Network/blog authorization: a current-site manage_options holder may read
+ * their own blog; a CROSS-blog read requires manage_network_options (network
+ * admin / super admin). WP_CLI is allowed (server-side operator). All slug->post
+ * resolution and post-metadata lookup run switch_to_blog($blog_id) so post IDs
+ * resolve in the correct blog context.
  *
  * @package ExtraChill\Analytics
  * @since 0.28.0
@@ -51,19 +65,19 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 		'extrachill/get-content-revenue-pages',
 		array(
 			'label'               => __( 'Get Content Revenue Pages Lens', 'extrachill-analytics' ),
-			'description'         => __( 'Page-level Mediavine revenue lens. Returns every resolved published post (or unresolved route) as its own ranked row with the full delivery stack: views, revenue, DERIVED RPM (revenue / views/1000), SOURCE RPM (Mediavine-reported), CPM, viewability, fill rate, impressions/pageview, plus post metadata (ID, title, URL/path, category, content format, publication date) when resolved. Derived and source RPM are kept distinct — they can disagree and both are sort keys. Revenue rows with zero pageviews are flagged zero_views and preserved (derived_rpm = 0, never a division error). Supports cohort (resolved/unresolved/all), minimum-views threshold, stable sorting by any metric, limit, and an optional defensible benchmark-opportunity flag (high RPM at meaningful volume). Reuses the same store, resolver, and classifiers as extrachill/get-content-revenue — no new tables. CLI consumers map args and format output only.', 'extrachill-analytics' ),
+			'description'         => __( 'Page-level Mediavine revenue lens. Returns every resolved published post (or unresolved route) as its own ranked row with the full delivery stack: views, revenue, DERIVED RPM (revenue / views/1000), SOURCE RPM (Mediavine-reported), CPM, viewability, fill rate, impressions/pageview, plus post metadata (ID, title, URL/path, category, content format, publication date) when resolved. Derived and source RPM are kept distinct. Revenue rows with zero pageviews are flagged zero_views and preserved (derived_rpm = 0, never a division error). Supports cohort (resolved/unresolved/all), minimum-views threshold, stable sorting by any metric, limit, and an optional defensible benchmark-opportunity flag. Default window is the FRESHEST DATED period (never silently combines all-time + monthly + duplicates); pass period/window/batch explicitly for a combined view. Cross-blog reads require network admin. Reuses the same store, resolver, and classifiers as extrachill/get-content-revenue — no new tables. CLI consumers map args and format output only.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
 					'period'            => array(
 						'type'        => 'string',
-						'description' => __( 'Scope to one time bucket, e.g. "2026-05" or "all-time". Empty = every bucket combined.', 'extrachill-analytics' ),
+						'description' => __( 'Scope to one time bucket, e.g. "2026-05" or "all-time". Empty = default to the freshest dated period (see window contract).', 'extrachill-analytics' ),
 						'default'     => '',
 					),
 					'period_start'      => array(
 						'type'        => 'string',
-						'description' => __( 'Inclusive window start (Y-m-d). With period_end, restricts to snapshots imported for that window (the recent lens).', 'extrachill-analytics' ),
+						'description' => __( 'Inclusive window start (Y-m-d). With period_end, restricts to snapshots imported for that window.', 'extrachill-analytics' ),
 						'default'     => '',
 					),
 					'period_end'        => array(
@@ -73,12 +87,12 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 					),
 					'import_batch'      => array(
 						'type'        => 'string',
-						'description' => __( 'Restrict to one import batch so multiple imports are never double-counted. Empty = all batches.', 'extrachill-analytics' ),
+						'description' => __( 'Restrict to one import batch. Empty = all batches in the scope.', 'extrachill-analytics' ),
 						'default'     => '',
 					),
 					'blog_id'           => array(
 						'type'        => 'integer',
-						'description' => __( 'Blog ID whose revenue to read. 0 = current blog.', 'extrachill-analytics' ),
+						'description' => __( 'Blog ID whose revenue to read. 0 = current blog. Cross-blog reads require manage_network_options.', 'extrachill-analytics' ),
 						'default'     => 0,
 					),
 					'hostname'          => array(
@@ -88,6 +102,7 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 					),
 					'cohort'            => array(
 						'type'        => 'string',
+						'enum'        => array( 'resolved', 'unresolved', 'all' ),
 						'description' => __( 'Page cohort: "resolved" (published content only, default), "unresolved" (route cohort), or "all".', 'extrachill-analytics' ),
 						'default'     => 'resolved',
 					),
@@ -98,12 +113,14 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 					),
 					'sort_by'           => array(
 						'type'        => 'string',
-						'description' => __( 'Sort key: views, revenue, derived_rpm, source_rpm, cpm, viewability, fill_rate, impressions_per_pageview, dollars_per_page, or benchmark_opportunity. Default derived_rpm.', 'extrachill-analytics' ),
+						'enum'        => array( 'views', 'revenue', 'derived_rpm', 'source_rpm', 'cpm', 'viewability', 'fill_rate', 'impressions_per_pageview', 'dollars_per_page', 'benchmark_opportunity' ),
+						'description' => __( 'Sort key. Default derived_rpm.', 'extrachill-analytics' ),
 						'default'     => 'derived_rpm',
 					),
 					'order'             => array(
 						'type'        => 'string',
-						'description' => __( 'Sort direction: "desc" (default) or "asc".', 'extrachill-analytics' ),
+						'enum'        => array( 'desc', 'asc' ),
+						'description' => __( 'Sort direction. Default desc.', 'extrachill-analytics' ),
 						'default'     => 'desc',
 					),
 					'limit'             => array(
@@ -119,12 +136,248 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 				),
 			),
 			'output_schema'       => array(
-				'type'        => 'object',
-				'description' => __( 'pages array (each: page_key, cohort, post_id, title, url, path, categories, format, route_family, published_date, views, revenue, derived_rpm, source_rpm, cpm, viewability, fill_rate, impressions_per_pageview, dollars_per_page, zero_views, benchmark_opportunity, benchmark_score), plus totals, sample metadata, sort/window labels, and caveats.', 'extrachill-analytics' ),
+				'type'       => 'object',
+				'properties' => array(
+					'success' => array(
+						'type'        => 'boolean',
+						'description' => 'Whether the read succeeded.',
+					),
+					'rows'    => array(
+						'type'        => 'integer',
+						'description' => 'Snapshot rows examined in scope.',
+					),
+					'blog_id' => array(
+						'type'        => 'integer',
+						'description' => 'Blog ID the revenue was read for.',
+					),
+					'window'  => array(
+						'type'        => 'string',
+						'description' => 'Human-readable window label.',
+					),
+					'cohort'  => array(
+						'type'        => 'string',
+						'enum'        => array( 'resolved', 'unresolved', 'all' ),
+						'description' => 'Cohort filter applied.',
+					),
+					'sort_by' => array(
+						'type'        => 'string',
+						'description' => 'Sort key applied.',
+					),
+					'order'   => array(
+						'type'        => 'string',
+						'enum'        => array( 'desc', 'asc' ),
+						'description' => 'Sort direction applied.',
+					),
+					'scope'   => array(
+						'type'       => 'object',
+						'properties' => array(
+							'requested_period' => array(
+								'type'        => 'string',
+								'description' => 'Period the caller passed ("" = none).',
+							),
+							'effective_period' => array(
+								'type'        => 'string',
+								'description' => 'Period actually queried (the default when none requested).',
+							),
+							'effective_batch'  => array(
+								'type'        => 'string',
+								'description' => 'Import batch actually queried when the scope was defaulted.',
+							),
+							'defaulted'        => array(
+								'type'        => 'boolean',
+								'description' => 'True when the scope defaulted to the freshest dated period.',
+							),
+							'selected_periods' => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Distinct period_labels present in the result rows.',
+							),
+							'selected_batches' => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Distinct import_batches present in the result rows.',
+							),
+						),
+						'required'   => array( 'requested_period', 'effective_period', 'effective_batch', 'defaulted', 'selected_periods', 'selected_batches' ),
+					),
+					'pages'   => array(
+						'type'        => 'array',
+						'description' => 'Ranked page rows.',
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'page_key'                 => array(
+									'type'        => 'string',
+									'description' => 'Dedupe key: "p"+post_id (resolved) or "u"+hash(slug) (unresolved).',
+								),
+								'cohort'                   => array(
+									'type'        => 'string',
+									'enum'        => array( 'resolved', 'unresolved' ),
+									'description' => 'Which cohort this page belongs to.',
+								),
+								'post_id'                  => array(
+									'type'        => 'integer',
+									'description' => 'WordPress post ID (0 when unresolved).',
+								),
+								'title'                    => array(
+									'type'        => 'string',
+									'description' => 'Post title (resolved only, when include_post_meta).',
+								),
+								'url'                      => array(
+									'type'        => 'string',
+									'description' => 'Canonical URL or raw slug.',
+								),
+								'path'                     => array(
+									'type'        => 'string',
+									'description' => 'Site-relative path (resolved only).',
+								),
+								'categories'               => array(
+									'type'        => 'array',
+									'items'       => array( 'type' => 'string' ),
+									'description' => 'Category slugs (resolved only; ["uncategorized"] when none assigned).',
+								),
+								'format'                   => array(
+									'type'        => 'string',
+									'description' => 'Content format (resolved only).',
+								),
+								'route_family'             => array(
+									'type'        => 'string',
+									'description' => 'Route family (unresolved only).',
+								),
+								'published_date'           => array(
+									'type'        => 'string',
+									'description' => 'Post publication date (resolved only).',
+								),
+								'views'                    => array(
+									'type'        => 'integer',
+									'description' => 'Pageviews (summed across collapsed variants).',
+								),
+								'revenue'                  => array(
+									'type'        => 'number',
+									'description' => 'Ad revenue in dollars (summed).',
+								),
+								'derived_rpm'              => array(
+									'type'        => 'number',
+									'description' => 'revenue / (views/1000), recomputed. 0.0 when views=0.',
+								),
+								'source_rpm'               => array(
+									'type'        => 'number',
+									'description' => 'Mediavine-reported rpm (simple-averaged across variants).',
+								),
+								'cpm'                      => array(
+									'type'        => 'number',
+									'description' => 'Source CPM (simple-averaged).',
+								),
+								'viewability'              => array(
+									'type'        => 'number',
+									'description' => 'Source viewability (simple-averaged).',
+								),
+								'fill_rate'                => array(
+									'type'        => 'number',
+									'description' => 'Source fill rate (simple-averaged).',
+								),
+								'impressions_per_pageview' => array(
+									'type'        => 'number',
+									'description' => 'Source impressions/pageview (simple-averaged).',
+								),
+								'dollars_per_page'         => array(
+									'type'        => 'number',
+									'description' => 'Revenue for this single page (= revenue at page granularity).',
+								),
+								'zero_views'               => array(
+									'type'        => 'boolean',
+									'description' => 'True when views=0 but revenue may be >0.',
+								),
+								'benchmark_opportunity'    => array(
+									'type'        => 'boolean',
+									'description' => 'True when high RPM at meaningful volume (defensible).',
+								),
+								'benchmark_score'          => array(
+									'type'        => array( 'number', 'null' ),
+									'description' => 'derived_rpm / cohort_median_rpm, or null when benchmark not computed.',
+								),
+							),
+							'required'   => array( 'page_key', 'cohort', 'post_id', 'views', 'revenue', 'derived_rpm', 'source_rpm', 'zero_views', 'benchmark_opportunity' ),
+						),
+						'required'    => array( 'pages_before_limit', 'pages_returned', 'cohort_pages', 'zero_views_pages', 'views', 'revenue' ),
+					),
+					'totals'  => array(
+						'type'       => 'object',
+						'properties' => array(
+							'pages_before_limit' => array(
+								'type'        => 'integer',
+								'description' => 'Distinct pages matching cohort+min_views BEFORE the limit (full cohort).',
+							),
+							'pages_returned'     => array(
+								'type'        => 'integer',
+								'description' => 'Pages returned after the limit.',
+							),
+							'cohort_pages'       => array(
+								'type'        => 'integer',
+								'description' => 'Distinct pages in the cohort (before min_views).',
+							),
+							'zero_views_pages'   => array(
+								'type'        => 'integer',
+								'description' => 'Pages in the returned cohort with zero views.',
+							),
+							'views'              => array(
+								'type'        => 'integer',
+								'description' => 'Sum of views across the full cohort (before limit).',
+							),
+							'revenue'            => array(
+								'type'        => 'number',
+								'description' => 'Sum of revenue across the full cohort (before limit).',
+							),
+						),
+						'required'   => array( 'rows_in_window', 'resolved_pages', 'unresolved_pages', 'after_min_views', 'truncated', 'benchmark_computed', 'sufficient_for_benchmark' ),
+					),
+					'sample'  => array(
+						'type'       => 'object',
+						'properties' => array(
+							'rows_in_window'           => array(
+								'type'        => 'integer',
+								'description' => 'Raw snapshot rows in scope.',
+							),
+							'resolved_pages'           => array(
+								'type'        => 'integer',
+								'description' => 'Distinct resolved pages.',
+							),
+							'unresolved_pages'         => array(
+								'type'        => 'integer',
+								'description' => 'Distinct unresolved pages.',
+							),
+							'after_min_views'          => array(
+								'type'        => 'integer',
+								'description' => 'Distinct pages after the min_views floor.',
+							),
+							'truncated'                => array(
+								'type'        => 'boolean',
+								'description' => 'True when the limit cut the cohort.',
+							),
+							'benchmark_computed'       => array(
+								'type'        => 'boolean',
+								'description' => 'Whether benchmark was computed.',
+							),
+							'sufficient_for_benchmark' => array(
+								'type'        => 'boolean',
+								'description' => 'Whether the cohort met the benchmark sample floor.',
+							),
+						),
+					),
+					'caveat'  => array(
+						'type'        => 'string',
+						'description' => 'Stable analyst caveat.',
+					),
+					'error'   => array(
+						'type'        => 'string',
+						'description' => 'Error message when success is false.',
+					),
+				),
+				'required'   => array( 'success', 'rows', 'blog_id', 'window', 'cohort', 'sort_by', 'order', 'scope', 'pages', 'totals', 'sample', 'caveat' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_content_revenue_pages',
 			'permission_callback' => function () {
-				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+				return current_user_can( 'manage_options' ) || current_user_can( 'manage_network_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
 			},
 			'meta'                => array(
 				'show_in_rest' => false,
@@ -141,17 +394,17 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 /**
  * Execute callback for get-content-revenue-pages ability.
  *
- * Owns the WordPress-dependent half: SQL (via the shared store helper),
- * slug->post resolution, the publish-status gate, term/format/post-metadata
- * lookup. Hands one record per resolved row to the pure builder, which owns
- * dedupe, aggregation, metric derivation, thresholding, sorting, and the
- * benchmark computation.
+ * Owns the WordPress-dependent half: network/blog authorization, the default
+ * window contract, switch_to_blog-scoped slug->post resolution + the
+ * publish-status gate + term/format/path/metadata lookup. Hands one record per
+ * resolved row to the pure builder, which owns dedupe, aggregation, metric
+ * derivation, thresholding, sorting, and the benchmark computation.
  *
  * @param array $input Input parameters.
- * @return array Page-level response.
+ * @return array Page-level response (consistent shape whether empty or not).
  */
 function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
-	$period            = isset( $input['period'] ) ? (string) $input['period'] : '';
+	$requested_period  = isset( $input['period'] ) ? (string) $input['period'] : '';
 	$period_start      = isset( $input['period_start'] ) ? (string) $input['period_start'] : '';
 	$period_end        = isset( $input['period_end'] ) ? (string) $input['period_end'] : '';
 	$import_batch      = isset( $input['import_batch'] ) ? (string) $input['import_batch'] : '';
@@ -187,30 +440,36 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 		$sort_by = 'derived_rpm';
 	}
 
-	$rows = extrachill_analytics_revenue_get_rows(
-		array(
-			'blog_id'      => $blog_id,
-			'import_batch' => $import_batch,
-			'period_label' => $period,
-			'period_start' => $period_start,
-			'period_end'   => $period_end,
-		)
-	);
-
-	if ( empty( $rows ) ) {
+	// Network/blog authorization. permission_callback gates on the current
+	// blog's manage_options; a CROSS-blog read additionally requires network
+	// admin. WP_CLI is allowed (server-side operator).
+	$auth = extrachill_analytics_revenue_authorize_blog_read( $blog_id );
+	if ( true !== $auth ) {
 		return array(
-			'success' => true,
+			'success' => false,
+			'error'   => is_string( $auth ) ? $auth : 'Permission denied.',
 			'rows'    => 0,
 			'blog_id' => $blog_id,
-			'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
+			'window'  => '',
 			'cohort'  => $cohort,
 			'sort_by' => $sort_by,
 			'order'   => $order,
+			'scope'   => array(
+				'requested_period' => $requested_period,
+				'effective_period' => '',
+				'effective_batch'  => '',
+				'defaulted'        => false,
+				'selected_periods' => array(),
+				'selected_batches' => array(),
+			),
 			'pages'   => array(),
 			'totals'  => array(
 				'pages_before_limit' => 0,
 				'pages_returned'     => 0,
+				'cohort_pages'       => 0,
 				'zero_views_pages'   => 0,
+				'views'              => 0,
+				'revenue'            => 0.0,
 			),
 			'sample'  => array(
 				'rows_in_window'           => 0,
@@ -221,85 +480,172 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 				'benchmark_computed'       => false,
 				'sufficient_for_benchmark' => false,
 			),
-			'caveat'  => __( 'No revenue snapshots for this blog/window. Import a Mediavine Pages CSV first: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' ),
+			'caveat'  => __( 'Permission denied.', 'extrachill-analytics' ),
 		);
 	}
 
-	// Resolve each snapshot row to a content record or an unresolved-route
-	// record — the SAME classification gate as the rollup (publish-status
-	// recheck keeps stale post IDs out of content). Post metadata is attached
-	// once per resolved post_id (cached) so variant rows of one post share it.
-	$records    = array();
-	$post_cache = array();
+	// Default window contract: with no explicit scope, default to the FRESHEST
+	// DATED period so the query never silently combines all-time + monthly +
+	// duplicate batches (double-counting). Explicit period/window/batch is used
+	// as-is.
+	$resolved_scope   = extrachill_analytics_revenue_resolve_default_period(
+		$blog_id,
+		$requested_period,
+		$period_start,
+		$period_end,
+		$import_batch
+	);
+	$effective_period = $resolved_scope['effective_period'];
+	$effective_batch  = $resolved_scope['effective_batch'];
+	$defaulted        = $resolved_scope['defaulted'];
 
-	foreach ( $rows as $row ) {
-		$post_id = (int) $row->post_id;
-		if ( $post_id <= 0 && '' !== $row->slug ) {
-			$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
-		}
+	$rows = extrachill_analytics_revenue_get_rows(
+		array(
+			'blog_id'      => $blog_id,
+			'import_batch' => $effective_batch,
+			'period_label' => $effective_period,
+			'period_start' => $period_start,
+			'period_end'   => $period_end,
+		)
+	);
 
-		$is_content = $post_id > 0 && 'publish' === get_post_status( $post_id );
+	$selected_periods = array();
+	$selected_batches = array();
+	foreach ( $rows as $r ) {
+		$selected_periods[ (string) $r->period_label ] = true;
+		$selected_batches[ (string) $r->import_batch ] = true;
+	}
 
-		$title          = '';
-		$url            = $row->url ? $row->url : $row->slug;
-		$path           = '';
-		$categories     = array();
-		$format         = '';
-		$published_date = '';
-		$route_family   = '';
+	$scope_block = array(
+		'requested_period' => $requested_period,
+		'effective_period' => $effective_period,
+		'effective_batch'  => $effective_batch,
+		'defaulted'        => $defaulted,
+		'selected_periods' => array_keys( $selected_periods ),
+		'selected_batches' => array_keys( $selected_batches ),
+	);
 
-		if ( $is_content ) {
-			if ( ! isset( $post_cache[ $post_id ] ) ) {
-				$post = get_post( $post_id );
-				if ( $post ) {
-					$permalink              = get_permalink( $post_id );
-					$categories_list        = get_the_terms( $post_id, 'category' );
-					$post_cache[ $post_id ] = array(
-						'title'          => $post->post_title,
-						'url'            => is_string( $permalink ) ? $permalink : '',
-						'published_date' => $post->post_date,
-						'categories'     => ( is_array( $categories_list ) && ! empty( $categories_list ) )
-							? wp_list_pluck( $categories_list, 'slug' )
-							: array( 'uncategorized' ),
-						'format'         => extrachill_analytics_classify_format( $post_id ),
-					);
-				} else {
-					$post_cache[ $post_id ] = null;
+	$empty_totals = array(
+		'pages_before_limit' => 0,
+		'pages_returned'     => 0,
+		'cohort_pages'       => 0,
+		'zero_views_pages'   => 0,
+		'views'              => 0,
+		'revenue'            => 0.0,
+	);
+	$empty_sample = array(
+		'rows_in_window'           => 0,
+		'resolved_pages'           => 0,
+		'unresolved_pages'         => 0,
+		'after_min_views'          => 0,
+		'truncated'                => false,
+		'benchmark_computed'       => false,
+		'sufficient_for_benchmark' => false,
+	);
+
+	if ( empty( $rows ) ) {
+		return array(
+			'success' => true,
+			'rows'    => 0,
+			'blog_id' => $blog_id,
+			'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end, $effective_period ),
+			'cohort'  => $cohort,
+			'sort_by' => $sort_by,
+			'order'   => $order,
+			'scope'   => $scope_block,
+			'pages'   => array(),
+			'totals'  => $empty_totals,
+			'sample'  => $empty_sample,
+			'caveat'  => $defaulted
+				? __( 'No revenue snapshots for this blog. Import a Mediavine Pages CSV first: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' )
+				: __( 'No revenue snapshots match the requested scope for this blog. Check period/batch, or import: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' ),
+		);
+	}
+
+	// switch_to_blog so slug->post resolution, publish-status, terms, permalink,
+	// and format classification all run against the TARGET blog. A row stamped
+	// for blog N must resolve against blog N's post table — without this, a
+	// cross-blog read resolves every slug against the wrong posts.
+	$records = extrachill_analytics_revenue_run_in_blog(
+		$blog_id,
+		static function () use ( $rows, $hostname, $include_post_meta ) {
+			$records    = array();
+			$post_cache = array();
+
+			foreach ( $rows as $row ) {
+				$post_id = (int) $row->post_id;
+				if ( $post_id <= 0 && '' !== $row->slug ) {
+					$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
 				}
+
+				$is_content = $post_id > 0 && 'publish' === get_post_status( $post_id );
+
+				$title          = '';
+				$url            = $row->url ? $row->url : $row->slug;
+				$path           = '';
+				$categories     = array();
+				$format         = '';
+				$published_date = '';
+				$route_family   = '';
+
+				if ( $is_content ) {
+					if ( ! isset( $post_cache[ $post_id ] ) ) {
+						$post = get_post( $post_id );
+						if ( $post ) {
+							$permalink              = get_permalink( $post_id );
+							$categories_list        = get_the_terms( $post_id, 'category' );
+							$post_cache[ $post_id ] = array(
+								'title'          => $post->post_title,
+								'url'            => is_string( $permalink ) ? $permalink : '',
+								'path'           => is_string( $permalink ) ? wp_make_link_relative( $permalink ) : '',
+								'published_date' => $post->post_date,
+								'categories'     => ( is_array( $categories_list ) && ! empty( $categories_list ) )
+								? wp_list_pluck( $categories_list, 'slug' )
+								: array( 'uncategorized' ),
+								'format'         => extrachill_analytics_classify_format( $post_id ),
+							);
+						} else {
+							$post_cache[ $post_id ] = null;
+						}
+					}
+
+					$cached = $post_cache[ $post_id ];
+					if ( is_array( $cached ) ) {
+						$title          = $include_post_meta ? $cached['title'] : '';
+						$url            = $include_post_meta ? $cached['url'] : ( $row->url ? $row->url : $row->slug );
+						$path           = $include_post_meta ? $cached['path'] : '';
+						$published_date = $include_post_meta ? $cached['published_date'] : '';
+						$categories     = $cached['categories'];
+						$format         = $cached['format'];
+					}
+				} else {
+					$route_family = extrachill_analytics_revenue_classify_route_family( $row->url ? $row->url : $row->slug );
+				}
+
+				$records[] = array(
+					'page_key'                 => $is_content ? 'p' . $post_id : 'u' . md5( (string) $row->slug ),
+					'is_content'               => $is_content,
+					'post_id'                  => $is_content ? $post_id : 0,
+					'format'                   => $format,
+					'categories'               => $categories,
+					'route_family'             => $route_family,
+					'views'                    => (int) $row->views,
+					'revenue'                  => (float) $row->revenue,
+					'source_rpm'               => (float) $row->rpm,
+					'cpm'                      => (float) $row->cpm,
+					'viewability'              => (float) $row->viewability,
+					'fill_rate'                => (float) $row->fill_rate,
+					'impressions_per_pageview' => (float) $row->impressions_per_pageview,
+					'url'                      => $url,
+					'title'                    => $title,
+					'path'                     => $path,
+					'published_date'           => $published_date,
+				);
 			}
 
-			$cached = $post_cache[ $post_id ];
-			if ( is_array( $cached ) ) {
-				$title          = $include_post_meta ? $cached['title'] : '';
-				$url            = $include_post_meta ? $cached['url'] : ( $row->url ? $row->url : $row->slug );
-				$published_date = $include_post_meta ? $cached['published_date'] : '';
-				$categories     = $cached['categories'];
-				$format         = $cached['format'];
-			}
-		} else {
-			$route_family = extrachill_analytics_revenue_classify_route_family( $row->url ? $row->url : $row->slug );
+			return $records;
 		}
-
-		$records[] = array(
-			'page_key'                 => $is_content ? 'p' . $post_id : 'u' . md5( (string) $row->slug ),
-			'is_content'               => $is_content,
-			'post_id'                  => $is_content ? $post_id : 0,
-			'format'                   => $format,
-			'categories'               => $categories,
-			'route_family'             => $route_family,
-			'views'                    => (int) $row->views,
-			'revenue'                  => (float) $row->revenue,
-			'source_rpm'               => (float) $row->rpm,
-			'cpm'                      => (float) $row->cpm,
-			'viewability'              => (float) $row->viewability,
-			'fill_rate'                => (float) $row->fill_rate,
-			'impressions_per_pageview' => (float) $row->impressions_per_pageview,
-			'url'                      => $url,
-			'title'                    => $title,
-			'path'                     => $path,
-			'published_date'           => $published_date,
-		);
-	}
+	);
 
 	$built = extrachill_analytics_revenue_build_pages(
 		$records,
@@ -316,14 +662,160 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 		'success' => true,
 		'rows'    => count( $rows ),
 		'blog_id' => $blog_id,
-		'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
+		'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end, $effective_period ),
 		'cohort'  => $cohort,
 		'sort_by' => $sort_by,
 		'order'   => $order,
+		'scope'   => $scope_block,
 		'pages'   => $built['pages'],
 		'totals'  => $built['totals'],
 		'sample'  => $built['sample'],
-		'caveat'  => __( 'Pages cover the requested cohort. derived_rpm = revenue / (views/1000), recomputed here; source_rpm is the Mediavine-reported rpm column — they can disagree and are kept distinct (rank on either). Pages with revenue but zero views are flagged zero_views with derived_rpm = 0 (never a division error) and revenue preserved. benchmark_opportunity flags genuinely strong RPM at meaningful volume (>= 1.5x cohort median RPM AND >= cohort median views; requires >= 5 views-positive pages). URL-variant rows of one post collapse by page_key; rate metrics are views-weighted averages across variants. Revenue is Mediavine-imported (the only source of ad income); never estimated.', 'extrachill-analytics' ),
+		'caveat'  => __( 'Pages cover the requested cohort. derived_rpm = revenue / (views/1000), recomputed here; source_rpm is the Mediavine-reported rpm column — they can disagree and are kept distinct (rank on either). Pages with revenue but zero views are flagged zero_views with derived_rpm = 0 (never a division error) and revenue preserved. benchmark_opportunity flags genuinely strong RPM at meaningful volume (>= 1.5x cohort median RPM AND >= cohort median views; requires >= 5 views-positive pages). URL-variant rows of one post collapse by page_key: volume is summed, while rate metrics (source_rpm, cpm, viewability, fill_rate, impressions_per_pageview) are simple-averaged because their true impression/request denominators are not stored — derived_rpm stays the correct aggregated RPM. With no explicit scope the query defaults to the freshest dated period (never silently combines all-time + monthly + duplicates). Revenue is Mediavine-imported (the only source of ad income); never estimated.', 'extrachill-analytics' ),
+	);
+}
+
+/**
+ * Authorize a revenue read for a target blog.
+ *
+ * The current site's manage_options holder may read their OWN blog. A CROSS-blog
+ * read additionally requires manage_network_options (network admin / super
+ * admin). WP_CLI is allowed (server-side operator). This is the single authority
+ * check for both revenue read abilities.
+ *
+ * @param int $blog_id Target blog ID.
+ * @return true|string True when authorized, or an error message string.
+ */
+function extrachill_analytics_revenue_authorize_blog_read( $blog_id ) {
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return true;
+	}
+
+	$current = get_current_blog_id();
+	if ( (int) $blog_id === $current ) {
+		return current_user_can( 'manage_options' ) ? true : __( 'Permission denied: manage_options is required to read revenue.', 'extrachill-analytics' );
+	}
+
+	return current_user_can( 'manage_network_options' )
+		? true
+		: __( 'Permission denied: reading another blog\'s revenue requires manage_network_options.', 'extrachill-analytics' );
+}
+
+/**
+ * Switch to the target blog unless it is already current.
+ *
+ * @param int $blog_id Target blog ID.
+ * @return bool True if switched (caller must restore).
+ */
+function extrachill_analytics_revenue_maybe_switch_to_blog( $blog_id ) {
+	if ( function_exists( 'switch_to_blog' ) && (int) $blog_id > 0 && get_current_blog_id() !== (int) $blog_id ) {
+		return (bool) switch_to_blog( $blog_id );
+	}
+	return false;
+}
+
+/**
+ * Restore the current blog only when a switch happened.
+ *
+ * @param bool $switched Whether switch_to_blog was called.
+ */
+function extrachill_analytics_revenue_maybe_restore_blog( $switched ) {
+	if ( $switched && function_exists( 'restore_current_blog' ) ) {
+		restore_current_blog();
+	}
+}
+
+/**
+ * Run a callback in the target blog and always restore the original context.
+ *
+ * @param int      $blog_id Target blog ID.
+ * @param callable $callback Callback to run in the target blog.
+ * @return mixed Callback result.
+ */
+function extrachill_analytics_revenue_run_in_blog( $blog_id, $callback ) {
+	$switched = extrachill_analytics_revenue_maybe_switch_to_blog( $blog_id );
+
+	try {
+		return call_user_func( $callback );
+	} finally {
+		extrachill_analytics_revenue_maybe_restore_blog( $switched );
+	}
+}
+
+/**
+ * Resolve the default window scope for a revenue read.
+ *
+ * CONTRACT (issue #141 review): with no explicit period/window/batch, the query
+ * must NOT silently combine all-time, monthly, and duplicate snapshots. So the
+ * default is the FRESHEST DATED period_label (most recent by period_end). If
+ * only the flat "all-time" bucket exists, it is used. If nothing exists, the
+ * effective period is '' (empty result).
+ *
+ * @param int    $blog_id      Target blog.
+ * @param string $period       Requested period_label.
+ * @param string $period_start Requested window start.
+ * @param string $period_end   Requested window end.
+ * @param string $import_batch Requested batch.
+ * @return array { effective_period, effective_batch, defaulted }
+ */
+function extrachill_analytics_revenue_resolve_default_period( $blog_id, $period, $period_start, $period_end, $import_batch ) {
+	// Explicit scope is used as-is.
+	if ( '' !== $period || ( '' !== $period_start && '' !== $period_end ) || '' !== $import_batch ) {
+		return array(
+			'effective_period' => $period,
+			'effective_batch'  => $import_batch,
+			'defaulted'        => false,
+		);
+	}
+
+	$batches = extrachill_analytics_revenue_list_batches( $blog_id );
+
+	return extrachill_analytics_revenue_select_default_scope( $batches );
+}
+
+/**
+ * Select one freshest period/batch pair for an implicit page read.
+ *
+ * The batch list is ordered newest-first by the store reader, so equal period
+ * boundaries retain the newest batch and cannot duplicate a snapshot.
+ *
+ * @param array $batches Period/batch aggregate rows, newest import first.
+ * @return array { effective_period, effective_batch, defaulted }
+ */
+function extrachill_analytics_revenue_select_default_scope( array $batches ) {
+	$best       = '';
+	$best_batch = '';
+	$best_end   = '';
+
+	// Freshest DATED period by period_end (the data's own boundary, not the
+	// import timestamp — see the freshness-check review note).
+	foreach ( $batches as $b ) {
+		$label = isset( $b->period_label ) ? (string) $b->period_label : '';
+		if ( 'all-time' === $label || empty( $b->period_end ) ) {
+			continue;
+		}
+		$end = (string) $b->period_end;
+		if ( '' === $best_end || $end > $best_end ) {
+			$best_end   = $end;
+			$best       = $label;
+			$best_batch = isset( $b->import_batch ) ? (string) $b->import_batch : '';
+		}
+	}
+
+	if ( '' === $best ) {
+		// Fall back to all-time if that's the only thing imported.
+		foreach ( $batches as $b ) {
+			if ( 'all-time' === ( isset( $b->period_label ) ? (string) $b->period_label : '' ) ) {
+				$best       = 'all-time';
+				$best_batch = isset( $b->import_batch ) ? (string) $b->import_batch : '';
+				break;
+			}
+		}
+	}
+
+	return array(
+		'effective_period' => $best,
+		'effective_batch'  => $best_batch,
+		'defaulted'        => '' !== $best,
 	);
 }
 
@@ -332,28 +824,32 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
  *
  * PURE — no WordPress / DB dependency — so dedupe, aggregation, metric
  * derivation, thresholding, sorting, and the benchmark computation are all
- * unit-testable in isolation. The execute_callback owns resolution and
- * post-metadata; this function owns the analytical contract.
+ * unit-testable in isolation. The execute_callback owns authorization,
+ * resolution, window scope, and post-metadata; this function owns the
+ * analytical contract.
  *
  * CONTRACT (issue #141):
  *   - One record per ROW is passed in; this function dedupes by page_key (the
  *     same 'p'.post_id / 'u'.hash(slug) convention as the rollup) so URL
- *     variants of one post collapse into one page row, summing views/revenue.
+ *     variants of one post collapse into one page row, SUMMING views/revenue.
  *   - Rate metrics (source_rpm, cpm, viewability, fill_rate,
- *     impressions_per_pageview) are views-weighted averages across collapsed
- *     variants — rates are never summed.
- *   - derived_rpm = revenue / (views/1000), recomputed AFTER aggregation. It is
- *     NEVER averaged from source values and NEVER collides with source_rpm.
- *   - Zero-view revenue: derived_rpm = 0.0, zero_views = true, revenue kept.
+ *     impressions_per_pageview) are simple-averaged across collapsed variants —
+ *     NOT views-weighted — because their true denominators (impressions/
+ *     requests) are not stored. derived_rpm is recomputed from the summed
+ *     revenue/views and is the correct aggregated RPM.
  *   - Cohort filter (resolved/unresolved/all) and min_views threshold are
  *     applied AFTER aggregation (so a page's full volume counts toward the
  *     floor) and BEFORE sorting.
+ *   - Totals (pages_before_limit, views, revenue, zero_views_pages) are computed
+ *     over the full filtered cohort BEFORE the limit — they reflect the whole
+ *     cohort, not just the truncated top-N.
  *   - Sorting is stable: the primary sort key is followed by a deterministic
  *     page_key tiebreaker so output is machine-stable across runs.
  *
  * @param array $records Pre-classified per-row records (see execute_callback).
  * @param array $args {
- *     Build options.
+ *     Builder arguments.
+ *
  *     @type string $cohort    'resolved' | 'unresolved' | 'all'.
  *     @type int    $min_views Minimum views floor.
  *     @type string $sort_by   Sort key.
@@ -373,6 +869,8 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 	$unresolved_pages = 0;
 
 	// 1. Aggregate by page_key, carrying metadata from the first variant.
+	// Volume (views/revenue) is SUMMED; rate metrics collect their values for a
+	// simple average at finalize (no invented denominators).
 	$agg = array();
 	foreach ( $records as $rec ) {
 		$key = (string) ( isset( $rec['page_key'] ) ? $rec['page_key'] : '' );
@@ -389,28 +887,23 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 				++$unresolved_pages;
 			}
 			$agg[ $key ] = array(
-				'page_key'            => $key,
-				'is_content'          => $is_content,
-				'post_id'             => (int) ( isset( $rec['post_id'] ) ? $rec['post_id'] : 0 ),
-				'format'              => isset( $rec['format'] ) ? (string) $rec['format'] : '',
-				'categories'          => isset( $rec['categories'] ) && is_array( $rec['categories'] ) ? array_values( $rec['categories'] ) : array(),
-				'route_family'        => isset( $rec['route_family'] ) ? (string) $rec['route_family'] : '',
-				'views'               => 0,
-				'revenue'             => 0.0,
-				'source_rpm_values'   => array(),
-				'source_rpm_weights'  => array(),
-				'cpm_values'          => array(),
-				'cpm_weights'         => array(),
-				'viewability_values'  => array(),
-				'viewability_weights' => array(),
-				'fill_rate_values'    => array(),
-				'fill_rate_weights'   => array(),
-				'impressions_values'  => array(),
-				'impressions_weights' => array(),
-				'url'                 => isset( $rec['url'] ) ? (string) $rec['url'] : '',
-				'title'               => isset( $rec['title'] ) ? (string) $rec['title'] : '',
-				'path'                => isset( $rec['path'] ) ? (string) $rec['path'] : '',
-				'published_date'      => isset( $rec['published_date'] ) ? (string) $rec['published_date'] : '',
+				'page_key'           => $key,
+				'is_content'         => $is_content,
+				'post_id'            => (int) ( isset( $rec['post_id'] ) ? $rec['post_id'] : 0 ),
+				'format'             => isset( $rec['format'] ) ? (string) $rec['format'] : '',
+				'categories'         => isset( $rec['categories'] ) && is_array( $rec['categories'] ) ? array_values( $rec['categories'] ) : array(),
+				'route_family'       => isset( $rec['route_family'] ) ? (string) $rec['route_family'] : '',
+				'views'              => 0,
+				'revenue'            => 0.0,
+				'source_rpm_values'  => array(),
+				'cpm_values'         => array(),
+				'viewability_values' => array(),
+				'fill_rate_values'   => array(),
+				'impressions_values' => array(),
+				'url'                => isset( $rec['url'] ) ? (string) $rec['url'] : '',
+				'title'              => isset( $rec['title'] ) ? (string) $rec['title'] : '',
+				'path'               => isset( $rec['path'] ) ? (string) $rec['path'] : '',
+				'published_date'     => isset( $rec['published_date'] ) ? (string) $rec['published_date'] : '',
 			);
 		}
 
@@ -419,18 +912,15 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 		$a['views']   += $views;
 		$a['revenue'] += (float) ( isset( $rec['revenue'] ) ? $rec['revenue'] : 0.0 );
 
-		$a['source_rpm_values'][]   = (float) ( isset( $rec['source_rpm'] ) ? $rec['source_rpm'] : 0.0 );
-		$a['source_rpm_weights'][]  = $views;
-		$a['cpm_values'][]          = (float) ( isset( $rec['cpm'] ) ? $rec['cpm'] : 0.0 );
-		$a['cpm_weights'][]         = $views;
-		$a['viewability_values'][]  = (float) ( isset( $rec['viewability'] ) ? $rec['viewability'] : 0.0 );
-		$a['viewability_weights'][] = $views;
-		$a['fill_rate_values'][]    = (float) ( isset( $rec['fill_rate'] ) ? $rec['fill_rate'] : 0.0 );
-		$a['fill_rate_weights'][]   = $views;
-		$a['impressions_values'][]  = (float) ( isset( $rec['impressions_per_pageview'] ) ? $rec['impressions_per_pageview'] : 0.0 );
-		$a['impressions_weights'][] = $views;
+		$a['source_rpm_values'][]  = (float) ( isset( $rec['source_rpm'] ) ? $rec['source_rpm'] : 0.0 );
+		$a['cpm_values'][]         = (float) ( isset( $rec['cpm'] ) ? $rec['cpm'] : 0.0 );
+		$a['viewability_values'][] = (float) ( isset( $rec['viewability'] ) ? $rec['viewability'] : 0.0 );
+		$a['fill_rate_values'][]   = (float) ( isset( $rec['fill_rate'] ) ? $rec['fill_rate'] : 0.0 );
+		$a['impressions_values'][] = (float) ( isset( $rec['impressions_per_pageview'] ) ? $rec['impressions_per_pageview'] : 0.0 );
 		unset( $a );
 	}
+
+	$cohort_pages = 0;
 
 	// 2. Finalize per-page derived metrics + cohort/min_views filtering.
 	$pages = array();
@@ -445,17 +935,20 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 		if ( 'unresolved' === $cohort && $a['is_content'] ) {
 			continue;
 		}
+		++$cohort_pages;
 
 		// min_views floor (applied AFTER aggregation so full volume counts).
 		if ( $views < $min_views ) {
 			continue;
 		}
 
-		$source_rpm  = extrachill_analytics_revenue_weighted_average( $a['source_rpm_values'], $a['source_rpm_weights'] );
-		$cpm         = extrachill_analytics_revenue_weighted_average( $a['cpm_values'], $a['cpm_weights'] );
-		$viewability = extrachill_analytics_revenue_weighted_average( $a['viewability_values'], $a['viewability_weights'] );
-		$fill_rate   = extrachill_analytics_revenue_weighted_average( $a['fill_rate_values'], $a['fill_rate_weights'] );
-		$impressions = extrachill_analytics_revenue_weighted_average( $a['impressions_values'], $a['impressions_weights'] );
+		// Rate metrics: simple average across collapsed variants (no invented
+		// denominators — true impression/request weights are not stored).
+		$source_rpm  = extrachill_analytics_revenue_simple_average( $a['source_rpm_values'] );
+		$cpm         = extrachill_analytics_revenue_simple_average( $a['cpm_values'] );
+		$viewability = extrachill_analytics_revenue_simple_average( $a['viewability_values'] );
+		$fill_rate   = extrachill_analytics_revenue_simple_average( $a['fill_rate_values'] );
+		$impressions = extrachill_analytics_revenue_simple_average( $a['impressions_values'] );
 
 		$zero_views  = $views <= 0;
 		$derived_rpm = $views > 0 ? round( $revenue / ( $views / 1000 ), 4 ) : 0.0;
@@ -526,26 +1019,28 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 		}
 	}
 
-	// 4. Stable sort: primary key then page_key tiebreaker.
-	$pages = extrachill_analytics_revenue_sort_pages( array_values( $pages ), $sort_by, $order );
-
-	// 5. Limit.
+	// 4. Compute cohort totals BEFORE the limit — totals reflect the whole
+	// matching cohort, not just the truncated top-N.
+	$cohort_views       = 0;
+	$cohort_revenue     = 0.0;
+	$cohort_zero_views  = 0;
 	$pages_before_limit = count( $pages );
-	$truncated          = false;
-	if ( $limit > 0 && $pages_before_limit > $limit ) {
-		$pages     = array_slice( $pages, 0, $limit );
-		$truncated = true;
+	foreach ( $pages as $p ) {
+		$cohort_views   += $p['views'];
+		$cohort_revenue += $p['revenue'];
+		if ( ! empty( $p['zero_views'] ) ) {
+			++$cohort_zero_views;
+		}
 	}
 
-	$zero_views_pages = 0;
-	$total_views      = 0;
-	$total_revenue    = 0.0;
-	foreach ( $pages as $p ) {
-		if ( ! empty( $p['zero_views'] ) ) {
-			++$zero_views_pages;
-		}
-		$total_views   += $p['views'];
-		$total_revenue += $p['revenue'];
+	// 5. Stable sort: primary key then page_key tiebreaker.
+	$pages = extrachill_analytics_revenue_sort_pages( array_values( $pages ), $sort_by, $order );
+
+	// 6. Limit.
+	$truncated = false;
+	if ( $limit > 0 && count( $pages ) > $limit ) {
+		$pages     = array_slice( $pages, 0, $limit );
+		$truncated = true;
 	}
 
 	return array(
@@ -553,9 +1048,10 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 		'totals' => array(
 			'pages_before_limit' => $pages_before_limit,
 			'pages_returned'     => count( $pages ),
-			'zero_views_pages'   => $zero_views_pages,
-			'views'              => $total_views,
-			'revenue'            => round( $total_revenue, 4 ),
+			'cohort_pages'       => $cohort_pages,
+			'zero_views_pages'   => $cohort_zero_views,
+			'views'              => $cohort_views,
+			'revenue'            => round( $cohort_revenue, 4 ),
 		),
 		'sample' => array(
 			'rows_in_window'           => count( $records ),
@@ -567,6 +1063,29 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 			'sufficient_for_benchmark' => $sufficient_for_benchmark,
 		),
 	);
+}
+
+/**
+ * Simple (unweighted) average of a numeric list.
+ *
+ * Used for source rate metrics across collapsed URL variants: their true
+ * denominators (impressions/requests) are not stored, so views-weighting would
+ * invent a denominator. The single-variant case (the common path) passes the
+ * value through unchanged.
+ *
+ * @param array $values Numeric values.
+ * @return float
+ */
+function extrachill_analytics_revenue_simple_average( array $values ) {
+	$n = count( $values );
+	if ( 0 === $n ) {
+		return 0.0;
+	}
+	$sum = 0.0;
+	foreach ( $values as $v ) {
+		$sum += (float) $v;
+	}
+	return $sum / $n;
 }
 
 /**
@@ -644,8 +1163,6 @@ function extrachill_analytics_revenue_sort_value( array $page, $sort_by ) {
 		case 'impressions_per_pageview':
 			return (float) $page['impressions_per_pageview'];
 		case 'benchmark_opportunity':
-			// Composite: flag (0/1) in the high band, score in the low band.
-			// flag=1 sorts above flag=0; within flag, higher score sorts above.
 			if ( null === $page['benchmark_score'] ) {
 				return null;
 			}
@@ -653,37 +1170,6 @@ function extrachill_analytics_revenue_sort_value( array $page, $sort_by ) {
 		default:
 			return (float) $page['derived_rpm'];
 	}
-}
-
-/**
- * Views-weighted average of a set of values; falls back to a simple average
- * when the total weight is zero (all-zero views) so rate metrics stay sane.
- *
- * @param array $values  Numeric values.
- * @param array $weights Parallel non-negative weights.
- * @return float
- */
-function extrachill_analytics_revenue_weighted_average( array $values, array $weights ) {
-	$total_weight = 0.0;
-	$weighted_sum = 0.0;
-	$simple_sum   = 0.0;
-	$count        = count( $values );
-
-	for ( $i = 0; $i < $count; $i++ ) {
-		$v             = isset( $values[ $i ] ) ? (float) $values[ $i ] : 0.0;
-		$w             = isset( $weights[ $i ] ) ? (float) $weights[ $i ] : 0.0;
-		$weighted_sum += $v * $w;
-		$total_weight += $w;
-		$simple_sum   += $v;
-	}
-
-	if ( $total_weight > 0 ) {
-		return $weighted_sum / $total_weight;
-	}
-	if ( $count > 0 ) {
-		return $simple_sum / $count;
-	}
-	return 0.0;
 }
 
 /**

--- a/inc/core/abilities/get-content-revenue-pages.php
+++ b/inc/core/abilities/get-content-revenue-pages.php
@@ -1,0 +1,715 @@
+<?php
+/**
+ * Get Content Revenue Pages Ability
+ *
+ * Page-level sibling of extrachill/get-content-revenue. The rollup ability owns
+ * format/category/timeseries buckets; this ability owns the FLAT per-page lens —
+ * every resolved published post (or unresolved route) as its own ranked row with
+ * the full Mediavine delivery stack (views, revenue, derived RPM, source RPM,
+ * CPM, viewability, fill rate, impressions/pageview) plus post metadata.
+ *
+ * Why a sibling and not a new group_by axis on the rollup: the rollup output
+ * contract is rollups/totals/unresolved — it cannot cleanly represent a flat,
+ * machine-sortable page list with per-page rate metrics and a benchmark flag.
+ * The issue explicitly permits narrowly scoped siblings where the existing
+ * contract cannot represent the new lens. This ability reuses the SAME store,
+ * resolver, content-format classifier, and route-family classifier as the
+ * rollup — no new tables, no parallel aggregation, no client.
+ *
+ * Derived vs source RPM (kept distinct, on purpose): derived_rpm is recomputed
+ * here as revenue / (views / 1000); source_rpm is the Mediavine-reported `rpm`
+ * column from the CSV. They can disagree (Mediavine rounds; its denominator may
+ * differ from pageviews). Both are reported and both are sort keys, so the
+ * analyst can rank on either and spot variance. They are never blended into one
+ * "rpm" field.
+ *
+ * Zero-view revenue handling: a Mediavine row CAN report revenue > 0 with views
+ * = 0 (rounding, sub-threshold fills, a missed views cell). derived_rpm is set
+ * to 0.0 (NEVER a division error, NEVER infinity), the page is flagged
+ * `zero_views => true`, and the revenue is preserved and visible — never hidden.
+ * A caveat discloses the cohort so the analyst is never misled.
+ *
+ * Benchmark opportunity (optional, defensible): a page qualifies when it shows
+ * genuinely strong RPM AT meaningful volume — derived_rpm >= 1.5x the cohort
+ * median derived_rpm AND views >= the cohort median views (both medians taken
+ * over pages with views > 0). High RPM on tiny volume never qualifies ("high RPM
+ * on tiny volume = pennies"). Requires at least 5 views-positive pages or the
+ * flag is suppressed (insufficient sample). This is an analytical signal ("this
+ * page is worth studying"), not a recommendation engine.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.28.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the get-content-revenue-pages ability.
+ */
+function extrachill_analytics_register_content_revenue_pages_ability() {
+	wp_register_ability(
+		'extrachill/get-content-revenue-pages',
+		array(
+			'label'               => __( 'Get Content Revenue Pages Lens', 'extrachill-analytics' ),
+			'description'         => __( 'Page-level Mediavine revenue lens. Returns every resolved published post (or unresolved route) as its own ranked row with the full delivery stack: views, revenue, DERIVED RPM (revenue / views/1000), SOURCE RPM (Mediavine-reported), CPM, viewability, fill rate, impressions/pageview, plus post metadata (ID, title, URL/path, category, content format, publication date) when resolved. Derived and source RPM are kept distinct — they can disagree and both are sort keys. Revenue rows with zero pageviews are flagged zero_views and preserved (derived_rpm = 0, never a division error). Supports cohort (resolved/unresolved/all), minimum-views threshold, stable sorting by any metric, limit, and an optional defensible benchmark-opportunity flag (high RPM at meaningful volume). Reuses the same store, resolver, and classifiers as extrachill/get-content-revenue — no new tables. CLI consumers map args and format output only.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'period'            => array(
+						'type'        => 'string',
+						'description' => __( 'Scope to one time bucket, e.g. "2026-05" or "all-time". Empty = every bucket combined.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'period_start'      => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive window start (Y-m-d). With period_end, restricts to snapshots imported for that window (the recent lens).', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'period_end'        => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive window end (Y-m-d). See period_start.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'import_batch'      => array(
+						'type'        => 'string',
+						'description' => __( 'Restrict to one import batch so multiple imports are never double-counted. Empty = all batches.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'blog_id'           => array(
+						'type'        => 'integer',
+						'description' => __( 'Blog ID whose revenue to read. 0 = current blog.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'hostname'          => array(
+						'type'        => 'string',
+						'description' => __( 'Hostname for resolving any still-unresolved slugs to posts (default: extrachill.com).', 'extrachill-analytics' ),
+						'default'     => 'extrachill.com',
+					),
+					'cohort'            => array(
+						'type'        => 'string',
+						'description' => __( 'Page cohort: "resolved" (published content only, default), "unresolved" (route cohort), or "all".', 'extrachill-analytics' ),
+						'default'     => 'resolved',
+					),
+					'min_views'         => array(
+						'type'        => 'integer',
+						'description' => __( 'Exclude pages with fewer than this many views. Default 0 (no floor).', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'sort_by'           => array(
+						'type'        => 'string',
+						'description' => __( 'Sort key: views, revenue, derived_rpm, source_rpm, cpm, viewability, fill_rate, impressions_per_pageview, dollars_per_page, or benchmark_opportunity. Default derived_rpm.', 'extrachill-analytics' ),
+						'default'     => 'derived_rpm',
+					),
+					'order'             => array(
+						'type'        => 'string',
+						'description' => __( 'Sort direction: "desc" (default) or "asc".', 'extrachill-analytics' ),
+						'default'     => 'desc',
+					),
+					'limit'             => array(
+						'type'        => 'integer',
+						'description' => __( 'Maximum pages to return. 0 = unlimited. Default 50.', 'extrachill-analytics' ),
+						'default'     => 50,
+					),
+					'include_post_meta' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Include post metadata (title, URL, path, category, format, publication date) on resolved pages. Default true.', 'extrachill-analytics' ),
+						'default'     => true,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'pages array (each: page_key, cohort, post_id, title, url, path, categories, format, route_family, published_date, views, revenue, derived_rpm, source_rpm, cpm, viewability, fill_rate, impressions_per_pageview, dollars_per_page, zero_views, benchmark_opportunity, benchmark_score), plus totals, sample metadata, sort/window labels, and caveats.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_content_revenue_pages',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-content-revenue-pages ability.
+ *
+ * Owns the WordPress-dependent half: SQL (via the shared store helper),
+ * slug->post resolution, the publish-status gate, term/format/post-metadata
+ * lookup. Hands one record per resolved row to the pure builder, which owns
+ * dedupe, aggregation, metric derivation, thresholding, sorting, and the
+ * benchmark computation.
+ *
+ * @param array $input Input parameters.
+ * @return array Page-level response.
+ */
+function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
+	$period            = isset( $input['period'] ) ? (string) $input['period'] : '';
+	$period_start      = isset( $input['period_start'] ) ? (string) $input['period_start'] : '';
+	$period_end        = isset( $input['period_end'] ) ? (string) $input['period_end'] : '';
+	$import_batch      = isset( $input['import_batch'] ) ? (string) $input['import_batch'] : '';
+	$blog_id           = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : get_current_blog_id();
+	$hostname          = ! empty( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com';
+	$cohort            = isset( $input['cohort'] ) ? (string) $input['cohort'] : 'resolved';
+	$min_views         = isset( $input['min_views'] ) ? max( 0, (int) $input['min_views'] ) : 0;
+	$sort_by           = isset( $input['sort_by'] ) ? (string) $input['sort_by'] : 'derived_rpm';
+	$order             = isset( $input['order'] ) ? (string) $input['order'] : 'desc';
+	$limit             = isset( $input['limit'] ) ? max( 0, (int) $input['limit'] ) : 50;
+	$include_post_meta = isset( $input['include_post_meta'] ) ? (bool) $input['include_post_meta'] : true;
+
+	if ( ! in_array( $cohort, array( 'resolved', 'unresolved', 'all' ), true ) ) {
+		$cohort = 'resolved';
+	}
+	if ( ! in_array( $order, array( 'desc', 'asc' ), true ) ) {
+		$order = 'desc';
+	}
+
+	$valid_sorts = array(
+		'views',
+		'revenue',
+		'derived_rpm',
+		'source_rpm',
+		'cpm',
+		'viewability',
+		'fill_rate',
+		'impressions_per_pageview',
+		'dollars_per_page',
+		'benchmark_opportunity',
+	);
+	if ( ! in_array( $sort_by, $valid_sorts, true ) ) {
+		$sort_by = 'derived_rpm';
+	}
+
+	$rows = extrachill_analytics_revenue_get_rows(
+		array(
+			'blog_id'      => $blog_id,
+			'import_batch' => $import_batch,
+			'period_label' => $period,
+			'period_start' => $period_start,
+			'period_end'   => $period_end,
+		)
+	);
+
+	if ( empty( $rows ) ) {
+		return array(
+			'success' => true,
+			'rows'    => 0,
+			'blog_id' => $blog_id,
+			'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
+			'cohort'  => $cohort,
+			'sort_by' => $sort_by,
+			'order'   => $order,
+			'pages'   => array(),
+			'totals'  => array(
+				'pages_before_limit' => 0,
+				'pages_returned'     => 0,
+				'zero_views_pages'   => 0,
+			),
+			'sample'  => array(
+				'rows_in_window'           => 0,
+				'resolved_pages'           => 0,
+				'unresolved_pages'         => 0,
+				'after_min_views'          => 0,
+				'truncated'                => false,
+				'benchmark_computed'       => false,
+				'sufficient_for_benchmark' => false,
+			),
+			'caveat'  => __( 'No revenue snapshots for this blog/window. Import a Mediavine Pages CSV first: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' ),
+		);
+	}
+
+	// Resolve each snapshot row to a content record or an unresolved-route
+	// record — the SAME classification gate as the rollup (publish-status
+	// recheck keeps stale post IDs out of content). Post metadata is attached
+	// once per resolved post_id (cached) so variant rows of one post share it.
+	$records    = array();
+	$post_cache = array();
+
+	foreach ( $rows as $row ) {
+		$post_id = (int) $row->post_id;
+		if ( $post_id <= 0 && '' !== $row->slug ) {
+			$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
+		}
+
+		$is_content = $post_id > 0 && 'publish' === get_post_status( $post_id );
+
+		$title          = '';
+		$url            = $row->url ? $row->url : $row->slug;
+		$path           = '';
+		$categories     = array();
+		$format         = '';
+		$published_date = '';
+		$route_family   = '';
+
+		if ( $is_content ) {
+			if ( ! isset( $post_cache[ $post_id ] ) ) {
+				$post = get_post( $post_id );
+				if ( $post ) {
+					$permalink              = get_permalink( $post_id );
+					$categories_list        = get_the_terms( $post_id, 'category' );
+					$post_cache[ $post_id ] = array(
+						'title'          => $post->post_title,
+						'url'            => is_string( $permalink ) ? $permalink : '',
+						'published_date' => $post->post_date,
+						'categories'     => ( is_array( $categories_list ) && ! empty( $categories_list ) )
+							? wp_list_pluck( $categories_list, 'slug' )
+							: array( 'uncategorized' ),
+						'format'         => extrachill_analytics_classify_format( $post_id ),
+					);
+				} else {
+					$post_cache[ $post_id ] = null;
+				}
+			}
+
+			$cached = $post_cache[ $post_id ];
+			if ( is_array( $cached ) ) {
+				$title          = $include_post_meta ? $cached['title'] : '';
+				$url            = $include_post_meta ? $cached['url'] : ( $row->url ? $row->url : $row->slug );
+				$published_date = $include_post_meta ? $cached['published_date'] : '';
+				$categories     = $cached['categories'];
+				$format         = $cached['format'];
+			}
+		} else {
+			$route_family = extrachill_analytics_revenue_classify_route_family( $row->url ? $row->url : $row->slug );
+		}
+
+		$records[] = array(
+			'page_key'                 => $is_content ? 'p' . $post_id : 'u' . md5( (string) $row->slug ),
+			'is_content'               => $is_content,
+			'post_id'                  => $is_content ? $post_id : 0,
+			'format'                   => $format,
+			'categories'               => $categories,
+			'route_family'             => $route_family,
+			'views'                    => (int) $row->views,
+			'revenue'                  => (float) $row->revenue,
+			'source_rpm'               => (float) $row->rpm,
+			'cpm'                      => (float) $row->cpm,
+			'viewability'              => (float) $row->viewability,
+			'fill_rate'                => (float) $row->fill_rate,
+			'impressions_per_pageview' => (float) $row->impressions_per_pageview,
+			'url'                      => $url,
+			'title'                    => $title,
+			'path'                     => $path,
+			'published_date'           => $published_date,
+		);
+	}
+
+	$built = extrachill_analytics_revenue_build_pages(
+		$records,
+		array(
+			'cohort'    => $cohort,
+			'min_views' => $min_views,
+			'sort_by'   => $sort_by,
+			'order'     => $order,
+			'limit'     => $limit,
+		)
+	);
+
+	return array(
+		'success' => true,
+		'rows'    => count( $rows ),
+		'blog_id' => $blog_id,
+		'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
+		'cohort'  => $cohort,
+		'sort_by' => $sort_by,
+		'order'   => $order,
+		'pages'   => $built['pages'],
+		'totals'  => $built['totals'],
+		'sample'  => $built['sample'],
+		'caveat'  => __( 'Pages cover the requested cohort. derived_rpm = revenue / (views/1000), recomputed here; source_rpm is the Mediavine-reported rpm column — they can disagree and are kept distinct (rank on either). Pages with revenue but zero views are flagged zero_views with derived_rpm = 0 (never a division error) and revenue preserved. benchmark_opportunity flags genuinely strong RPM at meaningful volume (>= 1.5x cohort median RPM AND >= cohort median views; requires >= 5 views-positive pages). URL-variant rows of one post collapse by page_key; rate metrics are views-weighted averages across variants. Revenue is Mediavine-imported (the only source of ad income); never estimated.', 'extrachill-analytics' ),
+	);
+}
+
+/**
+ * Build the page-level lens from pre-classified revenue records.
+ *
+ * PURE — no WordPress / DB dependency — so dedupe, aggregation, metric
+ * derivation, thresholding, sorting, and the benchmark computation are all
+ * unit-testable in isolation. The execute_callback owns resolution and
+ * post-metadata; this function owns the analytical contract.
+ *
+ * CONTRACT (issue #141):
+ *   - One record per ROW is passed in; this function dedupes by page_key (the
+ *     same 'p'.post_id / 'u'.hash(slug) convention as the rollup) so URL
+ *     variants of one post collapse into one page row, summing views/revenue.
+ *   - Rate metrics (source_rpm, cpm, viewability, fill_rate,
+ *     impressions_per_pageview) are views-weighted averages across collapsed
+ *     variants — rates are never summed.
+ *   - derived_rpm = revenue / (views/1000), recomputed AFTER aggregation. It is
+ *     NEVER averaged from source values and NEVER collides with source_rpm.
+ *   - Zero-view revenue: derived_rpm = 0.0, zero_views = true, revenue kept.
+ *   - Cohort filter (resolved/unresolved/all) and min_views threshold are
+ *     applied AFTER aggregation (so a page's full volume counts toward the
+ *     floor) and BEFORE sorting.
+ *   - Sorting is stable: the primary sort key is followed by a deterministic
+ *     page_key tiebreaker so output is machine-stable across runs.
+ *
+ * @param array $records Pre-classified per-row records (see execute_callback).
+ * @param array $args {
+ *     Build options.
+ *     @type string $cohort    'resolved' | 'unresolved' | 'all'.
+ *     @type int    $min_views Minimum views floor.
+ *     @type string $sort_by   Sort key.
+ *     @type string $order     'desc' | 'asc'.
+ *     @type int    $limit     Max pages (0 = unlimited).
+ * }
+ * @return array { pages, totals, sample }
+ */
+function extrachill_analytics_revenue_build_pages( array $records, array $args ) {
+	$cohort    = isset( $args['cohort'] ) ? (string) $args['cohort'] : 'resolved';
+	$min_views = isset( $args['min_views'] ) ? max( 0, (int) $args['min_views'] ) : 0;
+	$sort_by   = isset( $args['sort_by'] ) ? (string) $args['sort_by'] : 'derived_rpm';
+	$order     = isset( $args['order'] ) && 'asc' === $args['order'] ? 'asc' : 'desc';
+	$limit     = isset( $args['limit'] ) ? max( 0, (int) $args['limit'] ) : 0;
+
+	$resolved_pages   = 0;
+	$unresolved_pages = 0;
+
+	// 1. Aggregate by page_key, carrying metadata from the first variant.
+	$agg = array();
+	foreach ( $records as $rec ) {
+		$key = (string) ( isset( $rec['page_key'] ) ? $rec['page_key'] : '' );
+		if ( '' === $key ) {
+			continue;
+		}
+
+		$is_content = ! empty( $rec['is_content'] );
+
+		if ( ! isset( $agg[ $key ] ) ) {
+			if ( $is_content ) {
+				++$resolved_pages;
+			} else {
+				++$unresolved_pages;
+			}
+			$agg[ $key ] = array(
+				'page_key'            => $key,
+				'is_content'          => $is_content,
+				'post_id'             => (int) ( isset( $rec['post_id'] ) ? $rec['post_id'] : 0 ),
+				'format'              => isset( $rec['format'] ) ? (string) $rec['format'] : '',
+				'categories'          => isset( $rec['categories'] ) && is_array( $rec['categories'] ) ? array_values( $rec['categories'] ) : array(),
+				'route_family'        => isset( $rec['route_family'] ) ? (string) $rec['route_family'] : '',
+				'views'               => 0,
+				'revenue'             => 0.0,
+				'source_rpm_values'   => array(),
+				'source_rpm_weights'  => array(),
+				'cpm_values'          => array(),
+				'cpm_weights'         => array(),
+				'viewability_values'  => array(),
+				'viewability_weights' => array(),
+				'fill_rate_values'    => array(),
+				'fill_rate_weights'   => array(),
+				'impressions_values'  => array(),
+				'impressions_weights' => array(),
+				'url'                 => isset( $rec['url'] ) ? (string) $rec['url'] : '',
+				'title'               => isset( $rec['title'] ) ? (string) $rec['title'] : '',
+				'path'                => isset( $rec['path'] ) ? (string) $rec['path'] : '',
+				'published_date'      => isset( $rec['published_date'] ) ? (string) $rec['published_date'] : '',
+			);
+		}
+
+		$a             = &$agg[ $key ];
+		$views         = (int) ( isset( $rec['views'] ) ? $rec['views'] : 0 );
+		$a['views']   += $views;
+		$a['revenue'] += (float) ( isset( $rec['revenue'] ) ? $rec['revenue'] : 0.0 );
+
+		$a['source_rpm_values'][]   = (float) ( isset( $rec['source_rpm'] ) ? $rec['source_rpm'] : 0.0 );
+		$a['source_rpm_weights'][]  = $views;
+		$a['cpm_values'][]          = (float) ( isset( $rec['cpm'] ) ? $rec['cpm'] : 0.0 );
+		$a['cpm_weights'][]         = $views;
+		$a['viewability_values'][]  = (float) ( isset( $rec['viewability'] ) ? $rec['viewability'] : 0.0 );
+		$a['viewability_weights'][] = $views;
+		$a['fill_rate_values'][]    = (float) ( isset( $rec['fill_rate'] ) ? $rec['fill_rate'] : 0.0 );
+		$a['fill_rate_weights'][]   = $views;
+		$a['impressions_values'][]  = (float) ( isset( $rec['impressions_per_pageview'] ) ? $rec['impressions_per_pageview'] : 0.0 );
+		$a['impressions_weights'][] = $views;
+		unset( $a );
+	}
+
+	// 2. Finalize per-page derived metrics + cohort/min_views filtering.
+	$pages = array();
+	foreach ( $agg as $key => $a ) {
+		$views   = (int) $a['views'];
+		$revenue = (float) $a['revenue'];
+
+		// Cohort filter.
+		if ( 'resolved' === $cohort && ! $a['is_content'] ) {
+			continue;
+		}
+		if ( 'unresolved' === $cohort && $a['is_content'] ) {
+			continue;
+		}
+
+		// min_views floor (applied AFTER aggregation so full volume counts).
+		if ( $views < $min_views ) {
+			continue;
+		}
+
+		$source_rpm  = extrachill_analytics_revenue_weighted_average( $a['source_rpm_values'], $a['source_rpm_weights'] );
+		$cpm         = extrachill_analytics_revenue_weighted_average( $a['cpm_values'], $a['cpm_weights'] );
+		$viewability = extrachill_analytics_revenue_weighted_average( $a['viewability_values'], $a['viewability_weights'] );
+		$fill_rate   = extrachill_analytics_revenue_weighted_average( $a['fill_rate_values'], $a['fill_rate_weights'] );
+		$impressions = extrachill_analytics_revenue_weighted_average( $a['impressions_values'], $a['impressions_weights'] );
+
+		$zero_views  = $views <= 0;
+		$derived_rpm = $views > 0 ? round( $revenue / ( $views / 1000 ), 4 ) : 0.0;
+
+		$pages[ $key ] = array(
+			'page_key'                 => $key,
+			'cohort'                   => $a['is_content'] ? 'resolved' : 'unresolved',
+			'post_id'                  => $a['post_id'],
+			'title'                    => $a['title'],
+			'url'                      => $a['url'],
+			'path'                     => $a['path'],
+			'categories'               => $a['categories'],
+			'format'                   => $a['is_content'] ? $a['format'] : '',
+			'route_family'             => $a['is_content'] ? '' : $a['route_family'],
+			'published_date'           => $a['published_date'],
+			'views'                    => $views,
+			'revenue'                  => round( $revenue, 4 ),
+			'derived_rpm'              => $derived_rpm,
+			'source_rpm'               => round( $source_rpm, 4 ),
+			'cpm'                      => round( $cpm, 4 ),
+			'viewability'              => round( $viewability, 4 ),
+			'fill_rate'                => round( $fill_rate, 4 ),
+			'impressions_per_pageview' => round( $impressions, 4 ),
+			'dollars_per_page'         => round( $revenue, 4 ),
+			'zero_views'               => $zero_views,
+			'benchmark_opportunity'    => false,
+			'benchmark_score'          => null,
+		);
+	}
+
+	// 3. Benchmark opportunity — computed over the in-cohort, post-threshold
+	// pages with views > 0. Conservative: requires >= 5 views-positive pages.
+	$benchmark_computed       = false;
+	$sufficient_for_benchmark = false;
+	$views_positive           = array();
+	foreach ( $pages as $p ) {
+		if ( $p['views'] > 0 ) {
+			$views_positive[] = $p;
+		}
+	}
+
+	if ( count( $views_positive ) >= 5 ) {
+		$sufficient_for_benchmark = true;
+		$benchmark_computed       = true;
+		$rpm_values               = array_map(
+			static function ( $p ) {
+				return $p['derived_rpm'];
+			},
+			$views_positive
+		);
+		$views_values             = array_map(
+			static function ( $p ) {
+				return $p['views'];
+			},
+			$views_positive
+		);
+		$median_rpm               = extrachill_analytics_revenue_median( $rpm_values );
+		$median_views             = extrachill_analytics_revenue_median( $views_values );
+
+		foreach ( $pages as $key => $p ) {
+			if ( $p['views'] <= 0 || $median_rpm <= 0 ) {
+				$pages[ $key ]['benchmark_score'] = $p['views'] > 0 ? 0.0 : null;
+				continue;
+			}
+			$score                                  = round( $p['derived_rpm'] / $median_rpm, 4 );
+			$pages[ $key ]['benchmark_score']       = $score;
+			$pages[ $key ]['benchmark_opportunity'] = ( $score >= 1.5 && $p['views'] >= $median_views );
+		}
+	}
+
+	// 4. Stable sort: primary key then page_key tiebreaker.
+	$pages = extrachill_analytics_revenue_sort_pages( array_values( $pages ), $sort_by, $order );
+
+	// 5. Limit.
+	$pages_before_limit = count( $pages );
+	$truncated          = false;
+	if ( $limit > 0 && $pages_before_limit > $limit ) {
+		$pages     = array_slice( $pages, 0, $limit );
+		$truncated = true;
+	}
+
+	$zero_views_pages = 0;
+	$total_views      = 0;
+	$total_revenue    = 0.0;
+	foreach ( $pages as $p ) {
+		if ( ! empty( $p['zero_views'] ) ) {
+			++$zero_views_pages;
+		}
+		$total_views   += $p['views'];
+		$total_revenue += $p['revenue'];
+	}
+
+	return array(
+		'pages'  => $pages,
+		'totals' => array(
+			'pages_before_limit' => $pages_before_limit,
+			'pages_returned'     => count( $pages ),
+			'zero_views_pages'   => $zero_views_pages,
+			'views'              => $total_views,
+			'revenue'            => round( $total_revenue, 4 ),
+		),
+		'sample' => array(
+			'rows_in_window'           => count( $records ),
+			'resolved_pages'           => $resolved_pages,
+			'unresolved_pages'         => $unresolved_pages,
+			'after_min_views'          => $pages_before_limit,
+			'truncated'                => $truncated,
+			'benchmark_computed'       => $benchmark_computed,
+			'sufficient_for_benchmark' => $sufficient_for_benchmark,
+		),
+	);
+}
+
+/**
+ * Sort a pages array by the requested key with a deterministic page_key tiebreaker.
+ *
+ * Stable: ties on the primary key are broken by page_key (ascending) so two
+ * runs over the same input produce identical output — the contract a
+ * machine-readable lens needs.
+ *
+ * @param array  $pages   Page rows.
+ * @param string $sort_by Sort key.
+ * @param string $order   'desc' | 'asc'.
+ * @return array Sorted pages.
+ */
+function extrachill_analytics_revenue_sort_pages( array $pages, $sort_by, $order ) {
+	$desc = 'asc' !== $order;
+
+	usort(
+		$pages,
+		static function ( $a, $b ) use ( $sort_by, $desc ) {
+			$av = extrachill_analytics_revenue_sort_value( $a, $sort_by );
+			$bv = extrachill_analytics_revenue_sort_value( $b, $sort_by );
+
+			// Primary key. Nulls sort last regardless of direction.
+			if ( null === $av && null !== $bv ) {
+				return 1;
+			}
+			if ( null === $bv && null !== $av ) {
+				return -1;
+			}
+			if ( null === $av && null === $bv ) {
+				$cmp = 0;
+			} else {
+				$cmp = ( $av <=> $bv );
+			}
+			if ( 0 !== $cmp ) {
+				return $desc ? -$cmp : $cmp;
+			}
+
+			// Deterministic tiebreaker on page_key (always ascending).
+			return strcmp( (string) $a['page_key'], (string) $b['page_key'] );
+		}
+	);
+
+	return $pages;
+}
+
+/**
+ * Resolve a sort key to the comparable scalar on a page row.
+ *
+ * The benchmark_opportunity sort maps to a composite value so the flag wins
+ * and the score orders within. Null scores sort last.
+ *
+ * @param array  $page    Page row.
+ * @param string $sort_by Sort key.
+ * @return float|int|null Comparable value.
+ */
+function extrachill_analytics_revenue_sort_value( array $page, $sort_by ) {
+	switch ( $sort_by ) {
+		case 'views':
+			return (int) $page['views'];
+		case 'revenue':
+		case 'dollars_per_page':
+			return (float) $page['revenue'];
+		case 'derived_rpm':
+			return (float) $page['derived_rpm'];
+		case 'source_rpm':
+			return (float) $page['source_rpm'];
+		case 'cpm':
+			return (float) $page['cpm'];
+		case 'viewability':
+			return (float) $page['viewability'];
+		case 'fill_rate':
+			return (float) $page['fill_rate'];
+		case 'impressions_per_pageview':
+			return (float) $page['impressions_per_pageview'];
+		case 'benchmark_opportunity':
+			// Composite: flag (0/1) in the high band, score in the low band.
+			// flag=1 sorts above flag=0; within flag, higher score sorts above.
+			if ( null === $page['benchmark_score'] ) {
+				return null;
+			}
+			return ( ! empty( $page['benchmark_opportunity'] ) ? 1000000 : 0 ) + (float) $page['benchmark_score'];
+		default:
+			return (float) $page['derived_rpm'];
+	}
+}
+
+/**
+ * Views-weighted average of a set of values; falls back to a simple average
+ * when the total weight is zero (all-zero views) so rate metrics stay sane.
+ *
+ * @param array $values  Numeric values.
+ * @param array $weights Parallel non-negative weights.
+ * @return float
+ */
+function extrachill_analytics_revenue_weighted_average( array $values, array $weights ) {
+	$total_weight = 0.0;
+	$weighted_sum = 0.0;
+	$simple_sum   = 0.0;
+	$count        = count( $values );
+
+	for ( $i = 0; $i < $count; $i++ ) {
+		$v             = isset( $values[ $i ] ) ? (float) $values[ $i ] : 0.0;
+		$w             = isset( $weights[ $i ] ) ? (float) $weights[ $i ] : 0.0;
+		$weighted_sum += $v * $w;
+		$total_weight += $w;
+		$simple_sum   += $v;
+	}
+
+	if ( $total_weight > 0 ) {
+		return $weighted_sum / $total_weight;
+	}
+	if ( $count > 0 ) {
+		return $simple_sum / $count;
+	}
+	return 0.0;
+}
+
+/**
+ * Median of a numeric list (averages the two middle values on even counts).
+ *
+ * @param array $values Numeric values.
+ * @return float
+ */
+function extrachill_analytics_revenue_median( array $values ) {
+	$values = array_values(
+		array_filter(
+			$values,
+			static function ( $v ) {
+				return null !== $v;
+			}
+		)
+	);
+	$n      = count( $values );
+	if ( 0 === $n ) {
+		return 0.0;
+	}
+	sort( $values, SORT_NUMERIC );
+	if ( 1 === $n % 2 ) {
+		return (float) $values[ (int) floor( $n / 2 ) ];
+	}
+	$lo = (float) $values[ ( $n / 2 ) - 1 ];
+	$hi = (float) $values[ $n / 2 ];
+	return ( $lo + $hi ) / 2.0;
+}

--- a/inc/core/abilities/get-content-revenue-pages.php
+++ b/inc/core/abilities/get-content-revenue-pages.php
@@ -297,9 +297,8 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 									'description' => 'derived_rpm / cohort_median_rpm, or null when benchmark not computed.',
 								),
 							),
-							'required'   => array( 'page_key', 'cohort', 'post_id', 'views', 'revenue', 'derived_rpm', 'source_rpm', 'zero_views', 'benchmark_opportunity' ),
+							'required'   => array( 'page_key', 'cohort', 'post_id', 'title', 'url', 'path', 'categories', 'format', 'route_family', 'published_date', 'views', 'revenue', 'derived_rpm', 'source_rpm', 'cpm', 'viewability', 'fill_rate', 'impressions_per_pageview', 'dollars_per_page', 'zero_views', 'benchmark_opportunity', 'benchmark_score' ),
 						),
-						'required'    => array( 'pages_before_limit', 'pages_returned', 'cohort_pages', 'zero_views_pages', 'views', 'revenue' ),
 					),
 					'totals'  => array(
 						'type'       => 'object',
@@ -318,7 +317,7 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 							),
 							'zero_views_pages'   => array(
 								'type'        => 'integer',
-								'description' => 'Pages in the returned cohort with zero views.',
+								'description' => 'Pages in the full filtered cohort with zero views.',
 							),
 							'views'              => array(
 								'type'        => 'integer',
@@ -329,7 +328,7 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 								'description' => 'Sum of revenue across the full cohort (before limit).',
 							),
 						),
-						'required'   => array( 'rows_in_window', 'resolved_pages', 'unresolved_pages', 'after_min_views', 'truncated', 'benchmark_computed', 'sufficient_for_benchmark' ),
+						'required'   => array( 'pages_before_limit', 'pages_returned', 'cohort_pages', 'zero_views_pages', 'views', 'revenue' ),
 					),
 					'sample'  => array(
 						'type'       => 'object',
@@ -363,6 +362,7 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 								'description' => 'Whether the cohort met the benchmark sample floor.',
 							),
 						),
+						'required'   => array( 'rows_in_window', 'resolved_pages', 'unresolved_pages', 'after_min_views', 'truncated', 'benchmark_computed', 'sufficient_for_benchmark' ),
 					),
 					'caveat'  => array(
 						'type'        => 'string',
@@ -501,11 +501,12 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 
 	$rows = extrachill_analytics_revenue_get_rows(
 		array(
-			'blog_id'      => $blog_id,
-			'import_batch' => $effective_batch,
-			'period_label' => $effective_period,
-			'period_start' => $period_start,
-			'period_end'   => $period_end,
+			'blog_id'               => $blog_id,
+			'import_batch'          => $effective_batch,
+			'restrict_import_batch' => $defaulted,
+			'period_label'          => $effective_period,
+			'period_start'          => $period_start,
+			'period_end'            => $period_end,
 		)
 	);
 
@@ -686,6 +687,10 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
  * @return true|string True when authorized, or an error message string.
  */
 function extrachill_analytics_revenue_authorize_blog_read( $blog_id ) {
+	if ( (int) $blog_id <= 0 || ( function_exists( 'get_site' ) && ! get_site( $blog_id ) ) ) {
+		return __( 'Permission denied: target blog does not exist.', 'extrachill-analytics' );
+	}
+
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		return true;
 	}

--- a/inc/core/abilities/get-content-revenue-pages.php
+++ b/inc/core/abilities/get-content-revenue-pages.php
@@ -97,8 +97,8 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 					),
 					'hostname'          => array(
 						'type'        => 'string',
-						'description' => __( 'Hostname for resolving any still-unresolved slugs to posts (default: extrachill.com).', 'extrachill-analytics' ),
-						'default'     => 'extrachill.com',
+						'description' => __( 'Optional hostname for resolving relative slugs to posts. Empty = the target blog hostname.', 'extrachill-analytics' ),
+						'default'     => '',
 					),
 					'cohort'            => array(
 						'type'        => 'string',
@@ -409,7 +409,7 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 	$period_end        = isset( $input['period_end'] ) ? (string) $input['period_end'] : '';
 	$import_batch      = isset( $input['import_batch'] ) ? (string) $input['import_batch'] : '';
 	$blog_id           = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : get_current_blog_id();
-	$hostname          = ! empty( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com';
+	$hostname          = isset( $input['hostname'] ) ? trim( (string) $input['hostname'] ) : '';
 	$cohort            = isset( $input['cohort'] ) ? (string) $input['cohort'] : 'resolved';
 	$min_views         = isset( $input['min_views'] ) ? max( 0, (int) $input['min_views'] ) : 0;
 	$sort_by           = isset( $input['sort_by'] ) ? (string) $input['sort_by'] : 'derived_rpm';
@@ -572,6 +572,7 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 		static function () use ( $rows, $hostname, $include_post_meta ) {
 			$records    = array();
 			$post_cache = array();
+			$hostname   = extrachill_analytics_revenue_resolution_hostname( $hostname );
 
 			foreach ( $rows as $row ) {
 				$post_id = (int) $row->post_id;
@@ -744,6 +745,30 @@ function extrachill_analytics_revenue_run_in_blog( $blog_id, $callback ) {
 	} finally {
 		extrachill_analytics_revenue_maybe_restore_blog( $switched );
 	}
+}
+
+/**
+ * Get the hostname used to resolve a relative Mediavine path.
+ *
+ * This runs inside the target blog context. An explicit hostname remains an
+ * operator override; otherwise the target blog's home URL supplies the host so
+ * paths from a cross-blog read never resolve against the caller's site.
+ *
+ * @param string $hostname Optional explicit hostname.
+ * @return string Hostname, including port when present.
+ */
+function extrachill_analytics_revenue_resolution_hostname( $hostname = '' ) {
+	$hostname = trim( (string) $hostname );
+	if ( '' !== $hostname ) {
+		return $hostname;
+	}
+
+	$home = wp_parse_url( home_url( '/' ) );
+	if ( empty( $home['host'] ) ) {
+		return '';
+	}
+
+	return $home['host'] . ( isset( $home['port'] ) ? ':' . $home['port'] : '' );
 }
 
 /**

--- a/inc/database/mediavine-revenue-db.php
+++ b/inc/database/mediavine-revenue-db.php
@@ -207,6 +207,7 @@ function extrachill_analytics_revenue_upsert( array $row ) {
  *
  *     @type int    $blog_id      Blog ID (default: current blog).
  *     @type string $import_batch Restrict to one import batch (default: '' = any).
+ *     @type bool   $restrict_import_batch Match import_batch exactly, including an empty legacy batch.
  *     @type string $period_label Restrict to one time bucket, e.g. "2026-05" or "all-time" (default: '' = any).
  *     @type string $period_start Inclusive window start (Y-m-d), or '' for any.
  *     @type string $period_end   Inclusive window end (Y-m-d), or '' for any.
@@ -243,16 +244,17 @@ function extrachill_analytics_revenue_get_rows( array $args = array() ) {
  * @return array{0:string,1:array<int,mixed>} Tuple of (WHERE clause, values).
  */
 function extrachill_analytics_revenue_build_scope_clause( array $args = array() ) {
-	$blog_id      = isset( $args['blog_id'] ) ? (int) $args['blog_id'] : get_current_blog_id();
-	$import_batch = isset( $args['import_batch'] ) ? (string) $args['import_batch'] : '';
-	$period_label = isset( $args['period_label'] ) ? (string) $args['period_label'] : '';
-	$period_start = isset( $args['period_start'] ) ? (string) $args['period_start'] : '';
-	$period_end   = isset( $args['period_end'] ) ? (string) $args['period_end'] : '';
+	$blog_id        = isset( $args['blog_id'] ) ? (int) $args['blog_id'] : get_current_blog_id();
+	$import_batch   = isset( $args['import_batch'] ) ? (string) $args['import_batch'] : '';
+	$period_label   = isset( $args['period_label'] ) ? (string) $args['period_label'] : '';
+	$period_start   = isset( $args['period_start'] ) ? (string) $args['period_start'] : '';
+	$period_end     = isset( $args['period_end'] ) ? (string) $args['period_end'] : '';
+	$restrict_batch = ! empty( $args['restrict_import_batch'] );
 
 	$where  = array( 'blog_id = %d' );
 	$values = array( $blog_id );
 
-	if ( '' !== $import_batch ) {
+	if ( '' !== $import_batch || $restrict_batch ) {
 		$where[]  = 'import_batch = %s';
 		$values[] = $import_batch;
 	}

--- a/inc/database/mediavine-revenue-db.php
+++ b/inc/database/mediavine-revenue-db.php
@@ -201,6 +201,8 @@ function extrachill_analytics_revenue_upsert( array $row ) {
  * that mix multiple imports should pass an import_batch to avoid double-counting.
  *
  * @param array $args {
+ *     Query arguments.
+ *
  *     Query args.
  *
  *     @type int    $blog_id      Blog ID (default: current blog).
@@ -214,7 +216,33 @@ function extrachill_analytics_revenue_upsert( array $row ) {
 function extrachill_analytics_revenue_get_rows( array $args = array() ) {
 	global $wpdb;
 
-	$table        = extrachill_analytics_revenue_table();
+	$table = extrachill_analytics_revenue_table();
+
+	list( $where_clause, $values ) = extrachill_analytics_revenue_build_scope_clause( $args );
+	$sql                           = "SELECT * FROM {$table} WHERE {$where_clause}";
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	return (array) $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+}
+
+/**
+ * Build the canonical scope WHERE clause + bound values for a revenue query.
+ *
+ * Centralized so every read path (get_rows, get_scope_totals) constructs the
+ * identical scope from the same args — no drift. Pure: no DB access.
+ *
+ * @param array $args {
+ *     Query arguments.
+ *
+ *     @type int    $blog_id      Blog ID (default: current blog).
+ *     @type string $import_batch Restrict to one import batch (default: '' = any).
+ *     @type string $period_label Restrict to one time bucket (default: '' = any).
+ *     @type string $period_start Inclusive window start (Y-m-d), or '' for any.
+ *     @type string $period_end   Inclusive window end (Y-m-d), or '' for any.
+ * }
+ * @return array{0:string,1:array<int,mixed>} Tuple of (WHERE clause, values).
+ */
+function extrachill_analytics_revenue_build_scope_clause( array $args = array() ) {
 	$blog_id      = isset( $args['blog_id'] ) ? (int) $args['blog_id'] : get_current_blog_id();
 	$import_batch = isset( $args['import_batch'] ) ? (string) $args['import_batch'] : '';
 	$period_label = isset( $args['period_label'] ) ? (string) $args['period_label'] : '';
@@ -244,11 +272,34 @@ function extrachill_analytics_revenue_get_rows( array $args = array() ) {
 		$values[] = $period_end;
 	}
 
-	$where_clause = implode( ' AND ', $where );
-	$sql          = "SELECT * FROM {$table} WHERE {$where_clause}";
+	return array( implode( ' AND ', $where ), $values );
+}
+
+/**
+ * Independent SQL aggregate of rows, views, and revenue for a scope.
+ *
+ * Used by the diagnostics totals_reconciliation check as the INDEPENDENT
+ * read-model side: MySQL's SUM() aggregator over the canonical scope, compared
+ * against the PHP row-sum of get_rows() for the same scope. A divergence between
+ * the two is a meaningful read-path regression signal (row hydration, type
+ * coercion, a silent row cap) — the opposite of comparing a precomputed sum to
+ * itself.
+ *
+ * @param array $args See extrachill_analytics_revenue_build_scope_clause().
+ * @return object|null { rows_count, views, revenue } or null on error.
+ */
+function extrachill_analytics_revenue_get_scope_totals( array $args = array() ) {
+	global $wpdb;
+
+	$table = extrachill_analytics_revenue_table();
+
+	list( $where_clause, $values ) = extrachill_analytics_revenue_build_scope_clause( $args );
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $where_clause is built only from hardcoded fragments whose values are bound via prepare().
+	$sql = "SELECT COUNT(*) AS rows_count, COALESCE( SUM( views ), 0 ) AS views, COALESCE( SUM( revenue ), 0 ) AS revenue FROM {$table} WHERE {$where_clause}";
 
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	return (array) $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+	return $wpdb->get_row( $wpdb->prepare( $sql, $values ) );
 }
 
 /**

--- a/tests/GetContentRevenueDiagnosticsTest.php
+++ b/tests/GetContentRevenueDiagnosticsTest.php
@@ -1,0 +1,842 @@
+<?php
+/**
+ * Behavioral + contract tests for the content-revenue diagnostics lens (#141).
+ *
+ * The pure core (every check's status/evidence/totals + the summary rollup) is
+ * unit-tested directly against a synthesized snapshot; the WordPress-dependent
+ * resolution gate is locked down via a source-string contract on the callback.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue-diagnostics.php';
+
+/**
+ * Verify diagnostics contracts.
+ */
+final class GetContentRevenueDiagnosticsTest extends TestCase {
+
+	/**
+	 * Helper: a normalized row.
+	 *
+	 * @param array $over Overrides.
+	 * @return array
+	 */
+	private function row( array $over = array() ) {
+		return array_merge(
+			array(
+				'period_label'             => '2026-05',
+				'import_batch'             => 'mv-2026-05',
+				'period_start'             => '2026-05-01',
+				'period_end'               => '2026-05-31',
+				'imported_at'              => gmdate( 'Y-m-d H:i:s' ),
+				'slug'                     => '/some-post/',
+				'post_id'                  => 1,
+				'is_content'               => true,
+				'route_family'             => '',
+				'format'                   => 'song-meaning',
+				'views'                    => 1000,
+				'revenue'                  => 100.0,
+				'source_rpm'               => 100.0,
+				'cpm'                      => 5.0,
+				'viewability'              => 80.0,
+				'fill_rate'                => 90.0,
+				'impressions_per_pageview' => 2.0,
+				'derived_rpm'              => 100.0,
+			),
+			$over
+		);
+	}
+
+	/**
+	 * Helper: a period-batch aggregate.
+	 *
+	 * @param array $over Overrides.
+	 * @return array
+	 */
+	private function period( array $over = array() ) {
+		return array_merge(
+			array(
+				'period_label' => '2026-05',
+				'import_batch' => 'mv-2026-05',
+				'period_start' => '2026-05-01',
+				'period_end'   => '2026-05-31',
+				'rows'         => 100,
+				'revenue'      => 1000.0,
+				'views'        => 50000,
+				'imported_at'  => gmdate( 'Y-m-d H:i:s' ),
+			),
+			$over
+		);
+	}
+
+	/**
+	 * Helper: find one check by name in a built result.
+	 *
+	 * @param array  $built Built diagnostics.
+	 * @param string $name  Check name.
+	 * @return array|null
+	 */
+	private function check( array $built, $name ) {
+		foreach ( $built['checks'] as $c ) {
+			if ( $name === $c['check'] ) {
+				return $c;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Empty store → freshness fails, overall fail.
+	 */
+	public function test_empty_store_freshness_fails(): void {
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array(),
+				'rows'              => array(),
+				'timeseries_totals' => array(
+					'views'   => 0,
+					'revenue' => 0.0,
+				),
+			)
+		);
+
+		$freshness = $this->check( $built, 'latest_period_freshness' );
+		$this->assertSame( 'fail', $freshness['status'] );
+		$this->assertSame( 'fail', $built['overall_status'] );
+	}
+
+	/**
+	 * Only the flat "all-time" bucket → freshness warns (no dated periods).
+	 */
+	public function test_only_alltime_bucket_warns(): void {
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array(
+					$this->period(
+						array(
+							'period_label' => 'all-time',
+							'period_start' => null,
+							'period_end'   => null,
+						)
+					),
+				),
+				'rows'              => array( $this->row() ),
+				'timeseries_totals' => array(
+					'views'   => 1000,
+					'revenue' => 100.0,
+				),
+			)
+		);
+
+		$freshness = $this->check( $built, 'latest_period_freshness' );
+		$this->assertSame( 'warning', $freshness['status'] );
+	}
+
+	/**
+	 * A recent dated period → freshness passes.
+	 */
+	public function test_recent_dated_period_passes_freshness(): void {
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => array( $this->row() ),
+				'timeseries_totals' => array(
+					'views'   => 1000,
+					'revenue' => 100.0,
+				),
+			)
+		);
+
+		$freshness = $this->check( $built, 'latest_period_freshness' );
+		$this->assertSame( 'pass', $freshness['status'] );
+	}
+
+	/**
+	 * A dated period imported >45 days ago → freshness warns (stale).
+	 */
+	public function test_stale_dated_period_warns(): void {
+		$stale = gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) );
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period( array( 'imported_at' => $stale ) ) ),
+				'rows'              => array( $this->row( array( 'imported_at' => $stale ) ) ),
+				'timeseries_totals' => array(
+					'views'   => 1000,
+					'revenue' => 100.0,
+				),
+			)
+		);
+
+		$freshness = $this->check( $built, 'latest_period_freshness' );
+		$this->assertSame( 'warning', $freshness['status'] );
+	}
+
+	/**
+	 * Contiguous monthly periods → missing_periods passes.
+	 */
+	public function test_contiguous_periods_pass(): void {
+		$periods = array();
+		foreach ( array( '2026-03', '2026-04', '2026-05' ) as $label ) {
+			$periods[] = $this->period(
+				array(
+					'period_label' => $label,
+					'period_start' => $label . '-01',
+				)
+			);
+		}
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => $periods,
+				'rows'              => array( $this->row() ),
+				'timeseries_totals' => array(
+					'views'   => 1000,
+					'revenue' => 100.0,
+				),
+			)
+		);
+
+		$missing = $this->check( $built, 'missing_periods' );
+		$this->assertSame( 'pass', $missing['status'] );
+		$this->assertSame( 0, $missing['totals']['missing_periods'] );
+	}
+
+	/**
+	 * A gap in the monthly sequence → missing_periods warns with the gap listed.
+	 */
+	public function test_gap_in_periods_warns(): void {
+		$periods = array();
+		foreach ( array( '2026-03', '2026-05' ) as $label ) {
+			$periods[] = $this->period(
+				array(
+					'period_label' => $label,
+					'period_start' => $label . '-01',
+				)
+			);
+		}
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => $periods,
+				'rows'              => array( $this->row() ),
+				'timeseries_totals' => array(
+					'views'   => 1000,
+					'revenue' => 100.0,
+				),
+			)
+		);
+
+		$missing = $this->check( $built, 'missing_periods' );
+		$this->assertSame( 'warning', $missing['status'] );
+		$this->assertContains( '2026-04', $missing['totals']['missing'] );
+	}
+
+	/**
+	 * Same period_label across two batches → duplicate_period_batches warns.
+	 */
+	public function test_duplicate_period_batches_warns(): void {
+		$periods = array(
+			$this->period(
+				array(
+					'period_label' => '2026-05',
+					'import_batch' => 'batch-a',
+				)
+			),
+			$this->period(
+				array(
+					'period_label' => '2026-05',
+					'import_batch' => 'batch-b',
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => $periods,
+				'rows'              => array( $this->row() ),
+				'timeseries_totals' => array(
+					'views'   => 1000,
+					'revenue' => 100.0,
+				),
+			)
+		);
+
+		$dup = $this->check( $built, 'duplicate_period_batches' );
+		$this->assertSame( 'warning', $dup['status'] );
+		$this->assertSame( 1, $dup['totals']['duplicate_labels'] );
+		$this->assertArrayHasKey( '2026-05', $dup['totals']['duplicates'] );
+	}
+
+	/**
+	 * Row-sum equals timeseries → reconciliation passes.
+	 */
+	public function test_reconciliation_passes_when_row_sum_matches(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'views'   => 1000,
+					'revenue' => 100.0,
+				)
+			),
+			$this->row(
+				array(
+					'slug'    => '/other/',
+					'views'   => 500,
+					'revenue' => 25.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 1500,
+					'revenue' => 125.0,
+				),
+			)
+		);
+
+		$recon = $this->check( $built, 'totals_reconciliation' );
+		$this->assertSame( 'pass', $recon['status'] );
+		$this->assertTrue( $recon['totals']['reconciled'] );
+	}
+
+	/**
+	 * Row-sum diverges from timeseries → reconciliation FAILS.
+	 */
+	public function test_reconciliation_fails_on_mismatch(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'views'   => 1000,
+					'revenue' => 100.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 2000,
+					'revenue' => 999.0,
+				),
+			)
+		);
+
+		$recon = $this->check( $built, 'totals_reconciliation' );
+		$this->assertSame( 'fail', $recon['status'] );
+		$this->assertFalse( $recon['totals']['reconciled'] );
+	}
+
+	/**
+	 * High unresolved ratio → resolution_coverage warns; below threshold passes.
+	 */
+	public function test_resolution_coverage_thresholds(): void {
+		$rows = array();
+		// 2 resolved, 3 unresolved of 5 total = 60% unresolved → warning.
+		$rows[] = $this->row( array( 'is_content' => true ) );
+		$rows[] = $this->row(
+			array(
+				'slug'       => '/a/',
+				'is_content' => true,
+			)
+		);
+		$rows[] = $this->row(
+			array(
+				'slug'         => '/home/',
+				'is_content'   => false,
+				'route_family' => 'home',
+			)
+		);
+		$rows[] = $this->row(
+			array(
+				'slug'         => '/page/2/',
+				'is_content'   => false,
+				'route_family' => 'pagination',
+			)
+		);
+		$rows[] = $this->row(
+			array(
+				'slug'         => '/old.html',
+				'is_content'   => false,
+				'route_family' => 'legacy-html',
+			)
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 8000,
+					'revenue' => 107.0,
+				),
+			)
+		);
+
+		$cov = $this->check( $built, 'resolution_coverage' );
+		$this->assertSame( 'warning', $cov['status'] );
+		$this->assertSame( 3, $cov['totals']['unresolved_rows'] );
+
+		// Now mostly resolved → pass.
+		$rows2 = array();
+		for ( $i = 0; $i < 8; $i++ ) {
+			$rows2[] = $this->row(
+				array(
+					'slug'       => '/r' . $i . '/',
+					'is_content' => true,
+				)
+			);
+		}
+		$rows2[] = $this->row(
+			array(
+				'slug'         => '/home/',
+				'is_content'   => false,
+				'route_family' => 'home',
+			)
+		);
+
+		$ts_views = 0;
+		$ts_rev   = 0.0;
+		foreach ( $rows2 as $r ) {
+			$ts_views += $r['views'];
+			$ts_rev   += $r['revenue'];
+		}
+
+		$built2 = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows2,
+				'timeseries_totals' => array(
+					'views'   => $ts_views,
+					'revenue' => $ts_rev,
+				),
+			)
+		);
+
+		$cov2 = $this->check( $built2, 'resolution_coverage' );
+		$this->assertSame( 'pass', $cov2['status'] );
+	}
+
+	/**
+	 * High uncategorized ratio → format_coverage warns.
+	 */
+	public function test_format_coverage_warns_on_high_uncategorized(): void {
+		$rows = array();
+		// 2 classified, 3 uncategorized of 5 resolved = 60% → warning (>30%).
+		$rows[] = $this->row( array( 'format' => 'song-meaning' ) );
+		$rows[] = $this->row(
+			array(
+				'slug'   => '/b/',
+				'format' => 'news',
+			)
+		);
+		$rows[] = $this->row(
+			array(
+				'slug'   => '/c/',
+				'format' => 'uncategorized',
+			)
+		);
+		$rows[] = $this->row(
+			array(
+				'slug'   => '/d/',
+				'format' => 'uncategorized',
+			)
+		);
+		$rows[] = $this->row(
+			array(
+				'slug'   => '/e/',
+				'format' => 'uncategorized',
+			)
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 5000,
+					'revenue' => 500.0,
+				),
+			)
+		);
+
+		$fmt = $this->check( $built, 'format_coverage' );
+		$this->assertSame( 'warning', $fmt['status'] );
+		$this->assertSame( 3, $fmt['totals']['uncategorized_rows'] );
+	}
+
+	/**
+	 * Zero-view revenue → warning, revenue preserved in totals.
+	 */
+	public function test_zero_view_revenue_warns(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'slug'    => '/z/',
+					'views'   => 0,
+					'revenue' => 12.50,
+				)
+			),
+			$this->row(
+				array(
+					'slug'    => '/ok/',
+					'views'   => 1000,
+					'revenue' => 100.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 1000,
+					'revenue' => 112.5,
+				),
+			)
+		);
+
+		$zv = $this->check( $built, 'zero_view_revenue' );
+		$this->assertSame( 'warning', $zv['status'] );
+		$this->assertSame( 1, $zv['totals']['rows'] );
+		$this->assertEquals( 12.5, $zv['totals']['revenue'] );
+	}
+
+	/**
+	 * Views-positive zero-revenue rows → warning above 20%.
+	 */
+	public function test_views_zero_revenue_warns_above_threshold(): void {
+		$rows = array();
+		// 3 of 10 rows have views but $0 revenue = 30% → warning.
+		for ( $i = 0; $i < 7; $i++ ) {
+			$rows[] = $this->row(
+				array(
+					'slug'    => '/r' . $i . '/',
+					'views'   => 1000,
+					'revenue' => 10.0,
+				)
+			);
+		}
+		for ( $i = 0; $i < 3; $i++ ) {
+			$rows[] = $this->row(
+				array(
+					'slug'    => '/z' . $i . '/',
+					'views'   => 500,
+					'revenue' => 0.0,
+				)
+			);
+		}
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 8500,
+					'revenue' => 70.0,
+				),
+			)
+		);
+
+		$vz = $this->check( $built, 'views_zero_revenue' );
+		$this->assertSame( 'warning', $vz['status'] );
+		$this->assertSame( 3, $vz['totals']['rows'] );
+	}
+
+	/**
+	 * Negative revenue → negative_impossible_values FAILS.
+	 */
+	public function test_negative_values_fail(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'slug'    => '/bad/',
+					'revenue' => -5.0,
+				)
+			),
+			$this->row(
+				array(
+					'slug'    => '/ok/',
+					'revenue' => 10.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 2000,
+					'revenue' => 5.0,
+				),
+			)
+		);
+
+		$neg = $this->check( $built, 'negative_impossible_values' );
+		$this->assertSame( 'fail', $neg['status'] );
+		$this->assertSame( 1, $neg['totals']['rows'] );
+		// A fail here drives the overall status to fail.
+		$this->assertSame( 'fail', $built['overall_status'] );
+	}
+
+	/**
+	 * Negative views → also fail.
+	 */
+	public function test_negative_views_fail(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'slug'  => '/bad/',
+					'views' => -100,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => -100,
+					'revenue' => 100.0,
+				),
+			)
+		);
+
+		$neg = $this->check( $built, 'negative_impossible_values' );
+		$this->assertSame( 'fail', $neg['status'] );
+	}
+
+	/**
+	 * Source anomalies (zero-view revenue, variance) do NOT fail on their own.
+	 */
+	public function test_source_anomalies_are_warnings_not_failures(): void {
+		// 1000 views, $100 revenue → derived RPM 100. Source says 50 → 100% variance.
+		$rows = array(
+			$this->row(
+				array(
+					'slug'       => '/v/',
+					'views'      => 0,
+					'revenue'    => 5.0,
+					'source_rpm' => 0.0,
+				)
+			),
+			$this->row(
+				array(
+					'slug'        => '/ok/',
+					'views'       => 1000,
+					'revenue'     => 100.0,
+					'source_rpm'  => 50.0,
+					'derived_rpm' => 100.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 1000,
+					'revenue' => 105.0,
+				),
+			)
+		);
+
+		$this->assertSame( 'warning', $this->check( $built, 'zero_view_revenue' )['status'] );
+		$this->assertSame( 'warning', $this->check( $built, 'stored_vs_derived_rpm_variance' )['status'] );
+		$this->assertSame( 'pass', $this->check( $built, 'negative_impossible_values' )['status'] );
+		// No fail-level check → overall is warning, not fail.
+		$this->assertSame( 'warning', $built['overall_status'] );
+	}
+
+	/**
+	 * Stored-vs-derived RPM variance flags rows that disagree by >20%.
+	 */
+	public function test_rpm_variance_flags_high_disagreement(): void {
+		$rows = array();
+		// 6 views-positive rows; 2 disagree by >20% → 33% → warning (>10%).
+		// Agreeing: views 1000, revenue 100 → derived 100, source 100.
+		for ( $i = 0; $i < 4; $i++ ) {
+			$rows[] = $this->row(
+				array(
+					'slug'        => '/ok' . $i . '/',
+					'views'       => 1000,
+					'revenue'     => 100.0,
+					'source_rpm'  => 100.0,
+					'derived_rpm' => 100.0,
+				)
+			);
+		}
+		// Disagreeing: derived 100, source 50 → 100% variance.
+		for ( $i = 0; $i < 2; $i++ ) {
+			$rows[] = $this->row(
+				array(
+					'slug'        => '/v' . $i . '/',
+					'views'       => 1000,
+					'revenue'     => 100.0,
+					'source_rpm'  => 50.0,
+					'derived_rpm' => 100.0,
+				)
+			);
+		}
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 6000,
+					'revenue' => 600.0,
+				),
+			)
+		);
+
+		$var = $this->check( $built, 'stored_vs_derived_rpm_variance' );
+		$this->assertSame( 'warning', $var['status'] );
+		$this->assertSame( 6, $var['totals']['checked'] );
+		$this->assertSame( 2, $var['totals']['high_variance'] );
+	}
+
+	/**
+	 * Missing import_batch → provenance_coverage warns.
+	 */
+	public function test_provenance_coverage_warns_on_missing_batch(): void {
+		$rows = array(
+			$this->row( array( 'import_batch' => '' ) ),
+			$this->row( array( 'slug' => '/ok/' ) ),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 2000,
+					'revenue' => 200.0,
+				),
+			)
+		);
+
+		$prov = $this->check( $built, 'provenance_coverage' );
+		$this->assertSame( 'warning', $prov['status'] );
+		$this->assertSame( 1, $prov['totals']['missing_batch'] );
+	}
+
+	/**
+	 * A clean store → all pass, overall pass.
+	 */
+	public function test_clean_store_overall_pass(): void {
+		$periods = array();
+		foreach ( array( '2026-04', '2026-05', '2026-06' ) as $label ) {
+			$periods[] = $this->period(
+				array(
+					'period_label' => $label,
+					'period_start' => $label . '-01',
+				)
+			);
+		}
+
+		$rows = array();
+		for ( $i = 0; $i < 10; $i++ ) {
+			$rows[] = $this->row(
+				array(
+					'slug'        => '/r' . $i . '/',
+					'views'       => 1000,
+					'revenue'     => 100.0,
+					'source_rpm'  => 100.0,
+					'derived_rpm' => 100.0,
+					'format'      => 'song-meaning',
+				)
+			);
+		}
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => $periods,
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 10000,
+					'revenue' => 1000.0,
+				),
+			)
+		);
+
+		$this->assertSame( 'pass', $built['overall_status'] );
+		$this->assertSame( 11, $built['summary']['total'] );
+		$this->assertSame( 11, $built['summary']['pass'] );
+		$this->assertSame( 0, $built['summary']['warning'] );
+		$this->assertSame( 0, $built['summary']['fail'] );
+	}
+
+	/**
+	 * Overall status precedence: fail beats warning beats pass.
+	 */
+	public function test_overall_status_fail_beats_warning(): void {
+		// A negative value (fail) alongside a clean period.
+		$rows = array(
+			$this->row(
+				array(
+					'slug'    => '/bad/',
+					'revenue' => -1.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'           => array( $this->period() ),
+				'rows'              => $rows,
+				'timeseries_totals' => array(
+					'views'   => 1000,
+					'revenue' => -1.0,
+				),
+			)
+		);
+
+		$this->assertSame( 'fail', $built['overall_status'] );
+		$this->assertGreaterThan( 0, $built['summary']['fail'] );
+	}
+
+	/**
+	 * Source-string contract: the callback reuses the shared store resolver and
+	 * classifiers, publish-gates content, and delegates to the pure builder.
+	 */
+	public function test_callback_reuses_shared_substrate_and_delegates(): void {
+		$source = $this->ability_source();
+
+		$this->assertStringContainsString( "'publish' === get_post_status( \$post_id )", $source );
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_resolve_post_id', $source );
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_classify_route_family', $source );
+		$this->assertStringContainsString( 'extrachill_analytics_classify_format', $source );
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_get_rows', $source );
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_list_batches', $source );
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_build_diagnostics', $source );
+		// No new table creation inside this ability.
+		$this->assertStringNotContainsString( 'CREATE TABLE', $source );
+	}
+
+	/**
+	 * Read the production ability source.
+	 *
+	 * @return string
+	 */
+	private function ability_source() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local source file.
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue-diagnostics.php' );
+		$this->assertNotFalse( $source );
+
+		return $source;
+	}
+}

--- a/tests/GetContentRevenueDiagnosticsTest.php
+++ b/tests/GetContentRevenueDiagnosticsTest.php
@@ -33,6 +33,7 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 				'period_end'               => '2026-05-31',
 				'imported_at'              => gmdate( 'Y-m-d H:i:s' ),
 				'slug'                     => '/some-post/',
+				'stored_post_id'           => 1,
 				'post_id'                  => 1,
 				'is_content'               => true,
 				'route_family'             => '',
@@ -89,14 +90,35 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
+	 * Helper: build independent_totals that reconcile with a row set (pass case).
+	 *
+	 * @param array $rows Rows.
+	 * @return array
+	 */
+	private function reconciling_totals( array $rows ) {
+		$views   = 0;
+		$revenue = 0.0;
+		foreach ( $rows as $r ) {
+			$views   += isset( $r['views'] ) ? (int) $r['views'] : 0;
+			$revenue += isset( $r['revenue'] ) ? (float) $r['revenue'] : 0.0;
+		}
+		return array(
+			'rows'    => count( $rows ),
+			'views'   => $views,
+			'revenue' => round( $revenue, 4 ),
+		);
+	}
+
+	/**
 	 * Empty store → freshness fails, overall fail.
 	 */
 	public function test_empty_store_freshness_fails(): void {
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array(),
-				'rows'              => array(),
-				'timeseries_totals' => array(
+				'periods'            => array(),
+				'rows'               => array(),
+				'independent_totals' => array(
+					'rows'    => 0,
 					'views'   => 0,
 					'revenue' => 0.0,
 				),
@@ -112,9 +134,10 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	 * Only the flat "all-time" bucket → freshness warns (no dated periods).
 	 */
 	public function test_only_alltime_bucket_warns(): void {
+		$rows  = array( $this->row() );
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array(
+				'periods'            => array(
 					$this->period(
 						array(
 							'period_label' => 'all-time',
@@ -123,11 +146,8 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 						)
 					),
 				),
-				'rows'              => array( $this->row() ),
-				'timeseries_totals' => array(
-					'views'   => 1000,
-					'revenue' => 100.0,
-				),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -139,14 +159,13 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	 * A recent dated period → freshness passes.
 	 */
 	public function test_recent_dated_period_passes_freshness(): void {
+		// period_end is today → data age 0 days → pass.
+		$rows  = array( $this->row( array( 'period_end' => gmdate( 'Y-m-d' ) ) ) );
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => array( $this->row() ),
-				'timeseries_totals' => array(
-					'views'   => 1000,
-					'revenue' => 100.0,
-				),
+				'periods'            => array( $this->period( array( 'period_end' => gmdate( 'Y-m-d' ) ) ) ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -155,24 +174,41 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
-	 * A dated period imported >45 days ago → freshness warns (stale).
+	 * M2: freshness is driven by the period BOUNDARY (period_end), not import date.
+	 * A period whose data ended >45 days ago warns even if imported today.
 	 */
-	public function test_stale_dated_period_warns(): void {
-		$stale = gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) );
+	public function test_stale_data_by_period_boundary_warns(): void {
+		$old_end      = gmdate( 'Y-m-d', strtotime( '-60 days' ) ); // data ended 60d ago.
+		$imported_now = gmdate( 'Y-m-d H:i:s' ); // but imported just now.
+
+		$rows = array(
+			$this->row(
+				array(
+					'period_end'  => $old_end,
+					'imported_at' => $imported_now,
+				)
+			),
+		);
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period( array( 'imported_at' => $stale ) ) ),
-				'rows'              => array( $this->row( array( 'imported_at' => $stale ) ) ),
-				'timeseries_totals' => array(
-					'views'   => 1000,
-					'revenue' => 100.0,
+				'periods'            => array(
+					$this->period(
+						array(
+							'period_end'  => $old_end,
+							'imported_at' => $imported_now,
+						)
+					),
 				),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
 		$freshness = $this->check( $built, 'latest_period_freshness' );
+		// Imported NOW, but the data itself is 60 days old → still warns.
 		$this->assertSame( 'warning', $freshness['status'] );
+		$this->assertGreaterThan( 45, $freshness['totals']['data_age_days'] );
 	}
 
 	/**
@@ -185,18 +221,17 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 				array(
 					'period_label' => $label,
 					'period_start' => $label . '-01',
+					'period_end'   => gmdate( 'Y-m-t', strtotime( $label . '-01' ) ),
 				)
 			);
 		}
 
+		$rows  = array( $this->row() );
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => $periods,
-				'rows'              => array( $this->row() ),
-				'timeseries_totals' => array(
-					'views'   => 1000,
-					'revenue' => 100.0,
-				),
+				'periods'            => $periods,
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -219,14 +254,12 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 			);
 		}
 
+		$rows  = array( $this->row() );
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => $periods,
-				'rows'              => array( $this->row() ),
-				'timeseries_totals' => array(
-					'views'   => 1000,
-					'revenue' => 100.0,
-				),
+				'periods'            => $periods,
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -254,14 +287,12 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 			),
 		);
 
+		$rows  = array( $this->row() );
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => $periods,
-				'rows'              => array( $this->row() ),
-				'timeseries_totals' => array(
-					'views'   => 1000,
-					'revenue' => 100.0,
-				),
+				'periods'            => $periods,
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -272,9 +303,9 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
-	 * Row-sum equals timeseries → reconciliation passes.
+	 * B1: reconciliation passes when PHP row-sum matches the INDEPENDENT SQL aggregate.
 	 */
-	public function test_reconciliation_passes_when_row_sum_matches(): void {
+	public function test_reconciliation_passes_when_row_sum_matches_independent(): void {
 		$rows = array(
 			$this->row(
 				array(
@@ -293,9 +324,10 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => array(
+					'rows'    => 2,
 					'views'   => 1500,
 					'revenue' => 125.0,
 				),
@@ -308,9 +340,10 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
-	 * Row-sum diverges from timeseries → reconciliation FAILS.
+	 * B1: reconciliation FAILS when the row-sum diverges from the independent
+	 * aggregate (a read-path regression signal).
 	 */
-	public function test_reconciliation_fails_on_mismatch(): void {
+	public function test_reconciliation_fails_on_independent_mismatch(): void {
 		$rows = array(
 			$this->row(
 				array(
@@ -322,9 +355,10 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => array(
+					'rows'    => 2,
 					'views'   => 2000,
 					'revenue' => 999.0,
 				),
@@ -337,141 +371,266 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
-	 * High unresolved ratio → resolution_coverage warns; below threshold passes.
+	 * B1: the independent side is NOT a recomputed copy of the row-sum. Passing
+	 * no independent_totals (the old tautology shape) yields a mismatch → fail,
+	 * never a silent pass.
 	 */
-	public function test_resolution_coverage_thresholds(): void {
+	public function test_reconciliation_does_not_silently_pass_without_independent(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'views'   => 1000,
+					'revenue' => 100.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods' => array( $this->period() ),
+				'rows'    => $rows,
+			)
+		);
+
+		$recon = $this->check( $built, 'totals_reconciliation' );
+		$this->assertSame( 'fail', $recon['status'] );
+	}
+
+	/**
+	 * B1: content/unresolved reconciliation reports a stale stored post_id as a
+	 * warning (post was trashed since import, correctly routed to unresolved).
+	 */
+	public function test_content_unresolved_reconciliation_flags_stale_post_id(): void {
+		$rows = array(
+			// A healthy resolved post.
+			$this->row(
+				array(
+					'post_id'        => 10,
+					'stored_post_id' => 10,
+				)
+			),
+			// An unresolved row that stored a post_id at import (now stale/trashed).
+			$this->row(
+				array(
+					'slug'           => '/trashed/',
+					'post_id'        => 0,
+					'stored_post_id' => 77,
+					'is_content'     => false,
+					'route_family'   => 'other',
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
+			)
+		);
+
+		$cur = $this->check( $built, 'content_unresolved_reconciliation' );
+		$this->assertSame( 'warning', $cur['status'] );
+		$this->assertSame( 1, $cur['totals']['stale_post_id_rows'] );
+		$this->assertSame( 1, $cur['totals']['resolved_pages'] );
+		$this->assertSame( 1, $cur['totals']['unresolved_pages'] );
+		$this->assertTrue( $cur['totals']['partition_complete'] );
+	}
+
+	/**
+	 * M4: resolution_coverage counts DEDUPED pages, not raw rows. A post with
+	 * three URL variants counts once.
+	 */
+	public function test_resolution_coverage_dedupes_pages(): void {
+		// One resolved post (post 1) via three variant rows + two distinct
+		// unresolved routes.
+		$rows = array(
+			$this->row(
+				array(
+					'slug'           => '/a/',
+					'post_id'        => 1,
+					'stored_post_id' => 1,
+				)
+			),
+			$this->row(
+				array(
+					'slug'           => '/a/?x',
+					'post_id'        => 1,
+					'stored_post_id' => 1,
+				)
+			),
+			$this->row(
+				array(
+					'slug'           => '/a/?y',
+					'post_id'        => 1,
+					'stored_post_id' => 1,
+				)
+			),
+			$this->row(
+				array(
+					'slug'           => '/home/',
+					'post_id'        => 0,
+					'stored_post_id' => 0,
+					'is_content'     => false,
+					'route_family'   => 'home',
+				)
+			),
+			$this->row(
+				array(
+					'slug'           => '/page/2/',
+					'post_id'        => 0,
+					'stored_post_id' => 0,
+					'is_content'     => false,
+					'route_family'   => 'pagination',
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
+			)
+		);
+
+		$cov = $this->check( $built, 'resolution_coverage' );
+		// 1 distinct resolved page (not 3), 2 distinct unresolved.
+		$this->assertSame( 1, $cov['totals']['resolved_pages'] );
+		$this->assertSame( 2, $cov['totals']['unresolved_pages'] );
+		$this->assertSame( 3, $cov['totals']['total_pages'] );
+	}
+
+	/**
+	 * M4: resolution_coverage warns when >50% of distinct pages are unresolved.
+	 */
+	public function test_resolution_coverage_warns_on_high_ratio(): void {
 		$rows = array();
-		// 2 resolved, 3 unresolved of 5 total = 60% unresolved → warning.
-		$rows[] = $this->row( array( 'is_content' => true ) );
+		// 2 distinct resolved, 3 distinct unresolved of 5 = 60% → warning.
 		$rows[] = $this->row(
 			array(
-				'slug'       => '/a/',
-				'is_content' => true,
+				'slug'           => '/r1/',
+				'post_id'        => 1,
+				'stored_post_id' => 1,
 			)
 		);
 		$rows[] = $this->row(
 			array(
-				'slug'         => '/home/',
-				'is_content'   => false,
-				'route_family' => 'home',
+				'slug'           => '/r2/',
+				'post_id'        => 2,
+				'stored_post_id' => 2,
 			)
 		);
 		$rows[] = $this->row(
 			array(
-				'slug'         => '/page/2/',
-				'is_content'   => false,
-				'route_family' => 'pagination',
+				'slug'           => '/home/',
+				'post_id'        => 0,
+				'stored_post_id' => 0,
+				'is_content'     => false,
+				'route_family'   => 'home',
 			)
 		);
 		$rows[] = $this->row(
 			array(
-				'slug'         => '/old.html',
-				'is_content'   => false,
-				'route_family' => 'legacy-html',
+				'slug'           => '/page/2/',
+				'post_id'        => 0,
+				'stored_post_id' => 0,
+				'is_content'     => false,
+				'route_family'   => 'pagination',
+			)
+		);
+		$rows[] = $this->row(
+			array(
+				'slug'           => '/old.html',
+				'post_id'        => 0,
+				'stored_post_id' => 0,
+				'is_content'     => false,
+				'route_family'   => 'legacy-html',
 			)
 		);
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => 8000,
-					'revenue' => 107.0,
-				),
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
 		$cov = $this->check( $built, 'resolution_coverage' );
 		$this->assertSame( 'warning', $cov['status'] );
-		$this->assertSame( 3, $cov['totals']['unresolved_rows'] );
-
-		// Now mostly resolved → pass.
-		$rows2 = array();
-		for ( $i = 0; $i < 8; $i++ ) {
-			$rows2[] = $this->row(
-				array(
-					'slug'       => '/r' . $i . '/',
-					'is_content' => true,
-				)
-			);
-		}
-		$rows2[] = $this->row(
-			array(
-				'slug'         => '/home/',
-				'is_content'   => false,
-				'route_family' => 'home',
-			)
-		);
-
-		$ts_views = 0;
-		$ts_rev   = 0.0;
-		foreach ( $rows2 as $r ) {
-			$ts_views += $r['views'];
-			$ts_rev   += $r['revenue'];
-		}
-
-		$built2 = extrachill_analytics_revenue_build_diagnostics(
-			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows2,
-				'timeseries_totals' => array(
-					'views'   => $ts_views,
-					'revenue' => $ts_rev,
-				),
-			)
-		);
-
-		$cov2 = $this->check( $built2, 'resolution_coverage' );
-		$this->assertSame( 'pass', $cov2['status'] );
+		$this->assertSame( 3, $cov['totals']['unresolved_pages'] );
 	}
 
 	/**
-	 * High uncategorized ratio → format_coverage warns.
+	 * M4: format_coverage dedupes by post id and warns on high uncategorized.
 	 */
-	public function test_format_coverage_warns_on_high_uncategorized(): void {
-		$rows = array();
-		// 2 classified, 3 uncategorized of 5 resolved = 60% → warning (>30%).
-		$rows[] = $this->row( array( 'format' => 'song-meaning' ) );
+	public function test_format_coverage_dedupes_and_warns_on_uncategorized(): void {
+		// 2 distinct classified posts + 3 distinct uncategorized of 5 resolved.
+		$rows   = array();
 		$rows[] = $this->row(
 			array(
-				'slug'   => '/b/',
-				'format' => 'news',
+				'slug'           => '/a/',
+				'post_id'        => 1,
+				'stored_post_id' => 1,
+				'format'         => 'song-meaning',
 			)
 		);
 		$rows[] = $this->row(
 			array(
-				'slug'   => '/c/',
-				'format' => 'uncategorized',
+				'slug'           => '/b/',
+				'post_id'        => 2,
+				'stored_post_id' => 2,
+				'format'         => 'news',
 			)
 		);
 		$rows[] = $this->row(
 			array(
-				'slug'   => '/d/',
-				'format' => 'uncategorized',
+				'slug'           => '/c/',
+				'post_id'        => 3,
+				'stored_post_id' => 3,
+				'format'         => 'uncategorized',
 			)
 		);
 		$rows[] = $this->row(
 			array(
-				'slug'   => '/e/',
-				'format' => 'uncategorized',
+				'slug'           => '/d/',
+				'post_id'        => 4,
+				'stored_post_id' => 4,
+				'format'         => 'uncategorized',
+			)
+		);
+		$rows[] = $this->row(
+			array(
+				'slug'           => '/e/',
+				'post_id'        => 5,
+				'stored_post_id' => 5,
+				'format'         => 'uncategorized',
+			)
+		);
+		// Variant of post 3 — must NOT double-count.
+		$rows[] = $this->row(
+			array(
+				'slug'           => '/c/?x',
+				'post_id'        => 3,
+				'stored_post_id' => 3,
+				'format'         => 'uncategorized',
 			)
 		);
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => 5000,
-					'revenue' => 500.0,
-				),
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
 		$fmt = $this->check( $built, 'format_coverage' );
 		$this->assertSame( 'warning', $fmt['status'] );
-		$this->assertSame( 3, $fmt['totals']['uncategorized_rows'] );
+		// 5 distinct resolved pages (the post-3 variant collapsed), 3 uncategorized.
+		$this->assertSame( 5, $fmt['totals']['resolved_pages'] );
+		$this->assertSame( 3, $fmt['totals']['uncategorized_pages'] );
 	}
 
 	/**
@@ -488,21 +647,20 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 			),
 			$this->row(
 				array(
-					'slug'    => '/ok/',
-					'views'   => 1000,
-					'revenue' => 100.0,
+					'slug'           => '/ok/',
+					'post_id'        => 2,
+					'stored_post_id' => 2,
+					'views'          => 1000,
+					'revenue'        => 100.0,
 				)
 			),
 		);
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => 1000,
-					'revenue' => 112.5,
-				),
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -517,34 +675,34 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	 */
 	public function test_views_zero_revenue_warns_above_threshold(): void {
 		$rows = array();
-		// 3 of 10 rows have views but $0 revenue = 30% → warning.
 		for ( $i = 0; $i < 7; $i++ ) {
 			$rows[] = $this->row(
 				array(
-					'slug'    => '/r' . $i . '/',
-					'views'   => 1000,
-					'revenue' => 10.0,
+					'slug'           => '/r' . $i . '/',
+					'post_id'        => $i + 1,
+					'stored_post_id' => $i + 1,
+					'views'          => 1000,
+					'revenue'        => 10.0,
 				)
 			);
 		}
 		for ( $i = 0; $i < 3; $i++ ) {
 			$rows[] = $this->row(
 				array(
-					'slug'    => '/z' . $i . '/',
-					'views'   => 500,
-					'revenue' => 0.0,
+					'slug'           => '/z' . $i . '/',
+					'post_id'        => 100 + $i,
+					'stored_post_id' => 100 + $i,
+					'views'          => 500,
+					'revenue'        => 0.0,
 				)
 			);
 		}
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => 8500,
-					'revenue' => 70.0,
-				),
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -560,57 +718,49 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 		$rows = array(
 			$this->row(
 				array(
-					'slug'    => '/bad/',
-					'revenue' => -5.0,
+					'slug'           => '/bad/',
+					'post_id'        => 2,
+					'stored_post_id' => 2,
+					'revenue'        => -5.0,
 				)
 			),
-			$this->row(
-				array(
-					'slug'    => '/ok/',
-					'revenue' => 10.0,
-				)
-			),
+			$this->row( array( 'slug' => '/ok/' ) ),
 		);
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => 2000,
-					'revenue' => 5.0,
-				),
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
 		$neg = $this->check( $built, 'negative_impossible_values' );
 		$this->assertSame( 'fail', $neg['status'] );
 		$this->assertSame( 1, $neg['totals']['rows'] );
-		// A fail here drives the overall status to fail.
 		$this->assertSame( 'fail', $built['overall_status'] );
 	}
 
 	/**
-	 * Negative views → also fail.
+	 * M7: out-of-range rate values (viewability/fill_rate > 100) are impossible → fail.
 	 */
-	public function test_negative_views_fail(): void {
+	public function test_out_of_range_rates_are_impossible(): void {
 		$rows = array(
 			$this->row(
 				array(
-					'slug'  => '/bad/',
-					'views' => -100,
+					'slug'           => '/bad-view/',
+					'post_id'        => 2,
+					'stored_post_id' => 2,
+					'viewability'    => 150.0,
 				)
 			),
 		);
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => -100,
-					'revenue' => 100.0,
-				),
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -619,38 +769,92 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
-	 * Source anomalies (zero-view revenue, variance) do NOT fail on their own.
+	 * M7: impossibly high RPM (> 1000) is flagged.
 	 */
-	public function test_source_anomalies_are_warnings_not_failures(): void {
-		// 1000 views, $100 revenue → derived RPM 100. Source says 50 → 100% variance.
+	public function test_impossibly_high_rpm_is_flagged(): void {
 		$rows = array(
 			$this->row(
 				array(
-					'slug'       => '/v/',
-					'views'      => 0,
-					'revenue'    => 5.0,
-					'source_rpm' => 0.0,
-				)
-			),
-			$this->row(
-				array(
-					'slug'        => '/ok/',
-					'views'       => 1000,
-					'revenue'     => 100.0,
-					'source_rpm'  => 50.0,
-					'derived_rpm' => 100.0,
+					'slug'           => '/bad-rpm/',
+					'post_id'        => 2,
+					'stored_post_id' => 2,
+					'source_rpm'     => 5000.0,
 				)
 			),
 		);
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => 1000,
-					'revenue' => 105.0,
-				),
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
+			)
+		);
+
+		$neg = $this->check( $built, 'negative_impossible_values' );
+		$this->assertSame( 'fail', $neg['status'] );
+	}
+
+	/**
+	 * Negative impressions/pageview and impossible derived RPM are flagged.
+	 */
+	public function test_additional_impossible_metrics_are_flagged(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'impressions_per_pageview' => -1.0,
+					'derived_rpm'              => 1500.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
+			)
+		);
+
+		$check = $this->check( $built, 'negative_impossible_values' );
+		$this->assertSame( 'fail', $check['status'] );
+		$this->assertStringContainsString( 'derived rpm', implode( ' ', $check['totals']['samples'][0]['issues'] ) );
+		$this->assertStringContainsString( 'impressions_per_pageview', implode( ' ', $check['totals']['samples'][0]['issues'] ) );
+	}
+
+	/**
+	 * Source anomalies (zero-view revenue, variance) do NOT fail on their own.
+	 */
+	public function test_source_anomalies_are_warnings_not_failures(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'slug'           => '/z/',
+					'post_id'        => 2,
+					'stored_post_id' => 2,
+					'views'          => 0,
+					'revenue'        => 5.0,
+					'source_rpm'     => 0.0,
+				)
+			),
+			$this->row(
+				array(
+					'slug'           => '/ok/',
+					'post_id'        => 3,
+					'stored_post_id' => 3,
+					'views'          => 1000,
+					'revenue'        => 100.0,
+					'source_rpm'     => 50.0,
+					'derived_rpm'    => 100.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -667,39 +871,38 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	public function test_rpm_variance_flags_high_disagreement(): void {
 		$rows = array();
 		// 6 views-positive rows; 2 disagree by >20% → 33% → warning (>10%).
-		// Agreeing: views 1000, revenue 100 → derived 100, source 100.
 		for ( $i = 0; $i < 4; $i++ ) {
 			$rows[] = $this->row(
 				array(
-					'slug'        => '/ok' . $i . '/',
-					'views'       => 1000,
-					'revenue'     => 100.0,
-					'source_rpm'  => 100.0,
-					'derived_rpm' => 100.0,
+					'slug'           => '/ok' . $i . '/',
+					'post_id'        => $i + 1,
+					'stored_post_id' => $i + 1,
+					'views'          => 1000,
+					'revenue'        => 100.0,
+					'source_rpm'     => 100.0,
+					'derived_rpm'    => 100.0,
 				)
 			);
 		}
-		// Disagreeing: derived 100, source 50 → 100% variance.
 		for ( $i = 0; $i < 2; $i++ ) {
 			$rows[] = $this->row(
 				array(
-					'slug'        => '/v' . $i . '/',
-					'views'       => 1000,
-					'revenue'     => 100.0,
-					'source_rpm'  => 50.0,
-					'derived_rpm' => 100.0,
+					'slug'           => '/v' . $i . '/',
+					'post_id'        => 50 + $i,
+					'stored_post_id' => 50 + $i,
+					'views'          => 1000,
+					'revenue'        => 100.0,
+					'source_rpm'     => 50.0,
+					'derived_rpm'    => 100.0,
 				)
 			);
 		}
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => 6000,
-					'revenue' => 600.0,
-				),
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -715,17 +918,20 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	public function test_provenance_coverage_warns_on_missing_batch(): void {
 		$rows = array(
 			$this->row( array( 'import_batch' => '' ) ),
-			$this->row( array( 'slug' => '/ok/' ) ),
+			$this->row(
+				array(
+					'slug'           => '/ok/',
+					'post_id'        => 2,
+					'stored_post_id' => 2,
+				)
+			),
 		);
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => 2000,
-					'revenue' => 200.0,
-				),
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -735,7 +941,31 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
-	 * A clean store → all pass, overall pass.
+	 * M5: an empty scoped query never passes — reconciliation warns when there
+	 * are zero rows (and zero independent rows) in scope.
+	 */
+	public function test_empty_scoped_query_does_not_pass(): void {
+		// Whole-store has periods, but the scoped query matched zero rows.
+		$built = extrachill_analytics_revenue_build_diagnostics(
+			array(
+				'periods'            => array( $this->period() ),
+				'rows'               => array(),
+				'independent_totals' => array(
+					'rows'    => 0,
+					'views'   => 0,
+					'revenue' => 0.0,
+				),
+			)
+		);
+
+		$recon = $this->check( $built, 'totals_reconciliation' );
+		$this->assertSame( 'warning', $recon['status'] );
+		// Overall is warning (not pass) because the empty scope cannot reconcile.
+		$this->assertSame( 'warning', $built['overall_status'] );
+	}
+
+	/**
+	 * A clean store → all pass, overall pass (12 checks now).
 	 */
 	public function test_clean_store_overall_pass(): void {
 		$periods = array();
@@ -744,6 +974,7 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 				array(
 					'period_label' => $label,
 					'period_start' => $label . '-01',
+					'period_end'   => gmdate( 'Y-m-t', strtotime( $label . '-01' ) ),
 				)
 			);
 		}
@@ -752,30 +983,29 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 		for ( $i = 0; $i < 10; $i++ ) {
 			$rows[] = $this->row(
 				array(
-					'slug'        => '/r' . $i . '/',
-					'views'       => 1000,
-					'revenue'     => 100.0,
-					'source_rpm'  => 100.0,
-					'derived_rpm' => 100.0,
-					'format'      => 'song-meaning',
+					'slug'           => '/r' . $i . '/',
+					'post_id'        => $i + 1,
+					'stored_post_id' => $i + 1,
+					'views'          => 1000,
+					'revenue'        => 100.0,
+					'source_rpm'     => 100.0,
+					'derived_rpm'    => 100.0,
+					'format'         => 'song-meaning',
 				)
 			);
 		}
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => $periods,
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => 10000,
-					'revenue' => 1000.0,
-				),
+				'periods'            => $periods,
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
 		$this->assertSame( 'pass', $built['overall_status'] );
-		$this->assertSame( 11, $built['summary']['total'] );
-		$this->assertSame( 11, $built['summary']['pass'] );
+		$this->assertSame( 12, $built['summary']['total'] );
+		$this->assertSame( 12, $built['summary']['pass'] );
 		$this->assertSame( 0, $built['summary']['warning'] );
 		$this->assertSame( 0, $built['summary']['fail'] );
 	}
@@ -784,24 +1014,22 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	 * Overall status precedence: fail beats warning beats pass.
 	 */
 	public function test_overall_status_fail_beats_warning(): void {
-		// A negative value (fail) alongside a clean period.
 		$rows = array(
 			$this->row(
 				array(
-					'slug'    => '/bad/',
-					'revenue' => -1.0,
+					'slug'           => '/bad/',
+					'post_id'        => 2,
+					'stored_post_id' => 2,
+					'revenue'        => -1.0,
 				)
 			),
 		);
 
 		$built = extrachill_analytics_revenue_build_diagnostics(
 			array(
-				'periods'           => array( $this->period() ),
-				'rows'              => $rows,
-				'timeseries_totals' => array(
-					'views'   => 1000,
-					'revenue' => -1.0,
-				),
+				'periods'            => array( $this->period() ),
+				'rows'               => $rows,
+				'independent_totals' => $this->reconciling_totals( $rows ),
 			)
 		);
 
@@ -810,19 +1038,23 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
-	 * Source-string contract: the callback reuses the shared store resolver and
-	 * classifiers, publish-gates content, and delegates to the pure builder.
+	 * B2/B1/M2: source-string contract — the callback enforces blog
+	 * authorization, switch_to_blog around resolution, queries the independent
+	 * scope aggregate, and freshness uses the period boundary.
 	 */
-	public function test_callback_reuses_shared_substrate_and_delegates(): void {
+	public function test_callback_enforces_auth_switch_independent_and_boundary(): void {
 		$source = $this->ability_source();
 
-		$this->assertStringContainsString( "'publish' === get_post_status( \$post_id )", $source );
-		$this->assertStringContainsString( 'extrachill_analytics_revenue_resolve_post_id', $source );
-		$this->assertStringContainsString( 'extrachill_analytics_revenue_classify_route_family', $source );
-		$this->assertStringContainsString( 'extrachill_analytics_classify_format', $source );
-		$this->assertStringContainsString( 'extrachill_analytics_revenue_get_rows', $source );
-		$this->assertStringContainsString( 'extrachill_analytics_revenue_list_batches', $source );
-		$this->assertStringContainsString( 'extrachill_analytics_revenue_build_diagnostics', $source );
+		// Authorization helper.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_authorize_blog_read', $source );
+		$this->assertStringContainsString( 'manage_network_options', $source );
+		// switch_to_blog around resolution.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_run_in_blog', $source );
+		// Independent SQL aggregate for reconciliation.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_get_scope_totals', $source );
+		$this->assertStringContainsString( "'independent_totals'", $source );
+		// Freshness uses period_end boundary (not imported_at).
+		$this->assertStringContainsString( "'latest_period_end'", $source );
 		// No new table creation inside this ability.
 		$this->assertStringNotContainsString( 'CREATE TABLE', $source );
 	}

--- a/tests/GetContentRevenuePagesTest.php
+++ b/tests/GetContentRevenuePagesTest.php
@@ -205,13 +205,13 @@ final class GetContentRevenuePagesTest extends TestCase {
 	}
 
 	/**
-	 * URL-variant rows of one post collapse by page_key; views/revenue sum,
-	 * rates are views-weighted averages.
+	 * M3: URL-variant rows of one post collapse by page_key; views/revenue sum,
+	 * rate metrics are simple-averaged (no invented denominators). derived_rpm is
+	 * recomputed from the summed revenue/views and remains the correct aggregate.
 	 */
-	public function test_variant_rows_collapse_and_weighted_rates(): void {
+	public function test_variant_rows_collapse_and_source_average_rates(): void {
 		$records = array(
-			// Two variants of p1: 1000 views @ RPM 100, 3000 views @ RPM 40.
-			// Weighted source_rpm = (100*1000 + 40*3000) / 4000 = 55.
+			// Two variants of p1: 1000 views @ source_rpm 100, 3000 views @ source_rpm 40.
 			$this->content(
 				array(
 					'page_key'   => 'p1',
@@ -234,15 +234,123 @@ final class GetContentRevenuePagesTest extends TestCase {
 
 		$this->assertCount( 1, $built['pages'] );
 		$page = $built['pages'][0];
-		// Summed volume.
+		// Volume summed.
 		$this->assertSame( 4000, $page['views'] );
 		$this->assertEquals( 220.0, $page['revenue'] );
 		// Derived RPM recomputed from the SUM: 220 / 4 = 55.
 		$this->assertEquals( 55.0, $page['derived_rpm'] );
-		// Source RPM is the views-weighted average, NOT the derived value.
-		$this->assertEquals( 55.0, $page['source_rpm'] );
+		// Source RPM is simple-averaged across the two variants: (100 + 40) / 2 = 70.
+		// (NOT views-weighted, because the true denominator is not stored.).
+		$this->assertEquals( 70.0, $page['source_rpm'] );
 		// One page counted once.
 		$this->assertSame( 1, $built['sample']['resolved_pages'] );
+	}
+
+	/**
+	 * M1: totals (views/revenue/zero_views) cover the FULL cohort BEFORE the
+	 * limit, not just the truncated top-N returned.
+	 */
+	public function test_totals_reflect_full_cohort_before_limit(): void {
+		$records = array();
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$records[] = $this->content(
+				array(
+					'page_key' => 'p' . $i,
+					'views'    => 1000,
+					'revenue'  => 10.0 * $i,
+				)
+			);
+		}
+
+		$built = extrachill_analytics_revenue_build_pages(
+			$records,
+			array(
+				'cohort'  => 'resolved',
+				'sort_by' => 'revenue',
+				'order'   => 'desc',
+				'limit'   => 2,
+			)
+		);
+
+		// Only 2 pages returned.
+		$this->assertCount( 2, $built['pages'] );
+		$this->assertSame( 2, $built['totals']['pages_returned'] );
+		// But totals cover all 5 pages (full cohort before the limit).
+		$this->assertSame( 5, $built['totals']['pages_before_limit'] );
+		$this->assertSame( 5, $built['totals']['cohort_pages'] );
+		$this->assertSame( 5000, $built['totals']['views'] );
+		// Revenue 10+20+30+40+50 = 150.
+		$this->assertEquals( 150.0, $built['totals']['revenue'] );
+	}
+
+	/**
+	 * The implicit scope selects one freshest period/batch pair.
+	 */
+	public function test_default_scope_selects_one_freshest_batch(): void {
+		$batches = array(
+			(object) array(
+				'period_label' => '2026-06',
+				'period_end'   => '2026-06-30',
+				'import_batch' => 'newest-june',
+			),
+			(object) array(
+				'period_label' => '2026-06',
+				'period_end'   => '2026-06-30',
+				'import_batch' => 'older-june',
+			),
+			(object) array(
+				'period_label' => 'all-time',
+				'period_end'   => null,
+				'import_batch' => 'lifetime',
+			),
+		);
+
+		$scope = extrachill_analytics_revenue_select_default_scope( $batches );
+
+		$this->assertSame( '2026-06', $scope['effective_period'] );
+		$this->assertSame( 'newest-june', $scope['effective_batch'] );
+		$this->assertTrue( $scope['defaulted'] );
+	}
+
+	/**
+	 * Cohort totals exclude pages from the other cohort before min_views.
+	 */
+	public function test_cohort_pages_counts_only_selected_cohort(): void {
+		$built = extrachill_analytics_revenue_build_pages(
+			array(
+				$this->content( array( 'page_key' => 'p1' ) ),
+				$this->unresolved( array( 'page_key' => 'u1' ) ),
+			),
+			array( 'cohort' => 'resolved' )
+		);
+
+		$this->assertSame( 1, $built['totals']['cohort_pages'] );
+	}
+
+	/**
+	 * M6/B2/B4: source-string contract — the callback populates path, enforces
+	 * blog authorization, switch_to_blog around resolution, applies the default
+	 * window contract, and exposes selected periods/batches.
+	 */
+	public function test_callback_populates_path_and_enforces_auth_and_scope(): void {
+		$source = $this->ability_source();
+
+		// path is derived from the permalink.
+		$this->assertStringContainsString( 'wp_make_link_relative', $source );
+		// Network/blog authorization.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_authorize_blog_read', $source );
+		$this->assertStringContainsString( 'manage_network_options', $source );
+		// switch_to_blog around resolution.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_maybe_switch_to_blog', $source );
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_maybe_restore_blog', $source );
+		// Default window contract (freshest dated period).
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_resolve_default_period', $source );
+		// Selected periods/batches exposed.
+		$this->assertStringContainsString( "'selected_periods'", $source );
+		$this->assertStringContainsString( "'selected_batches'", $source );
+		// Reuses shared substrate (no new SQL/table).
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_get_rows', $source );
+		$this->assertStringNotContainsString( 'CREATE TABLE', $source );
 	}
 
 	/**
@@ -568,6 +676,7 @@ final class GetContentRevenuePagesTest extends TestCase {
 		$this->assertSame( 42, $page['post_id'] );
 		$this->assertSame( 'Grateful Dead Ripple Meaning', $page['title'] );
 		$this->assertSame( 'https://extrachill.com/ripple-meaning/', $page['url'] );
+		$this->assertSame( '/song/', $page['path'] );
 		$this->assertSame( 'song-meaning', $page['format'] );
 		$this->assertSame( array( 'song-meanings' ), $page['categories'] );
 		$this->assertSame( '2022-03-15 10:00:00', $page['published_date'] );

--- a/tests/GetContentRevenuePagesTest.php
+++ b/tests/GetContentRevenuePagesTest.php
@@ -12,6 +12,7 @@
 use PHPUnit\Framework\TestCase;
 
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue-pages.php';
+require_once dirname( __DIR__ ) . '/inc/core/content-format-classifier.php';
 
 /**
  * Verify page-level analysis contracts.
@@ -310,6 +311,39 @@ final class GetContentRevenuePagesTest extends TestCase {
 		$this->assertSame( '2026-06', $scope['effective_period'] );
 		$this->assertSame( 'newest-june', $scope['effective_batch'] );
 		$this->assertTrue( $scope['defaulted'] );
+	}
+
+	/**
+	 * A relative path inherits the authorized target blog's hostname, and the
+	 * run-in-blog wrapper restores the original site afterwards.
+	 */
+	public function test_relative_path_uses_target_blog_hostname_and_restores_context(): void {
+		$GLOBALS['extrachill_analytics_test_blog_id']       = 1;
+		$GLOBALS['extrachill_analytics_test_blog_stack']    = array();
+		$GLOBALS['extrachill_analytics_test_home_urls']     = array(
+			1 => 'https://extrachill.com',
+			7 => 'https://events.extrachill.com',
+		);
+		$GLOBALS['extrachill_analytics_test_resolved_urls'] = array();
+		$GLOBALS['extrachill_analytics_test_url_post_ids']  = array(
+			'https://events.extrachill.com/target-show/' => 77,
+		);
+
+		$post_id = extrachill_analytics_revenue_run_in_blog(
+			7,
+			static function () {
+				return extrachill_analytics_revenue_resolve_post_id(
+					'/target-show/',
+					extrachill_analytics_revenue_resolution_hostname()
+				);
+			}
+		);
+
+		$this->assertSame( 77, $post_id );
+		$this->assertSame( array( 'https://events.extrachill.com/target-show/' ), $GLOBALS['extrachill_analytics_test_resolved_urls'] );
+		$this->assertSame( 1, get_current_blog_id() );
+		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_blog_stack'] );
+		$this->assertSame( 'override.example.com', extrachill_analytics_revenue_resolution_hostname( 'override.example.com' ) );
 	}
 
 	/**

--- a/tests/GetContentRevenuePagesTest.php
+++ b/tests/GetContentRevenuePagesTest.php
@@ -1,0 +1,636 @@
+<?php
+/**
+ * Behavioral + contract tests for the content-revenue page-level lens (#141).
+ *
+ * The pure core (aggregation, metric derivation, thresholding, stable sorting,
+ * benchmark) is unit-tested directly; the WordPress-dependent resolution gate
+ * is locked down via a source-string contract on the ability callback.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue-pages.php';
+
+/**
+ * Verify page-level analysis contracts.
+ */
+final class GetContentRevenuePagesTest extends TestCase {
+
+	/**
+	 * Helper: a minimal resolved-content record.
+	 *
+	 * @param array $over Overrides.
+	 * @return array
+	 */
+	private function content( array $over = array() ) {
+		return array_merge(
+			array(
+				'page_key'                 => 'p1',
+				'is_content'               => true,
+				'post_id'                  => 1,
+				'format'                   => 'song-meaning',
+				'categories'               => array( 'song-meanings' ),
+				'route_family'             => '',
+				'views'                    => 1000,
+				'revenue'                  => 100.0,
+				'source_rpm'               => 100.0,
+				'cpm'                      => 5.0,
+				'viewability'              => 80.0,
+				'fill_rate'                => 90.0,
+				'impressions_per_pageview' => 2.0,
+				'url'                      => '/song/',
+				'title'                    => 'A Song',
+				'path'                     => '/song/',
+				'published_date'           => '2024-01-01 00:00:00',
+			),
+			$over
+		);
+	}
+
+	/**
+	 * Helper: a minimal unresolved-route record.
+	 *
+	 * @param array $over Overrides.
+	 * @return array
+	 */
+	private function unresolved( array $over = array() ) {
+		return array_merge(
+			array(
+				'page_key'                 => 'u' . md5( '/' ),
+				'is_content'               => false,
+				'post_id'                  => 0,
+				'format'                   => '',
+				'categories'               => array(),
+				'route_family'             => 'home',
+				'views'                    => 5000,
+				'revenue'                  => 5.0,
+				'source_rpm'               => 1.0,
+				'cpm'                      => 0.0,
+				'viewability'              => 0.0,
+				'fill_rate'                => 0.0,
+				'impressions_per_pageview' => 0.0,
+				'url'                      => '/',
+				'title'                    => '',
+				'path'                     => '',
+				'published_date'           => '',
+			),
+			$over
+		);
+	}
+
+	/**
+	 * Derived RPM = revenue / (views/1000), distinct from source_rpm.
+	 */
+	public function test_derived_rpm_distinct_from_source_rpm(): void {
+		$built = extrachill_analytics_revenue_build_pages(
+			array(
+				// 1000 views, $100 revenue → derived RPM = 100. Source says 95.
+				$this->content( array( 'source_rpm' => 95.0 ) ),
+			),
+			array(
+				'cohort'  => 'resolved',
+				'sort_by' => 'derived_rpm',
+			)
+		);
+
+		$page = $built['pages'][0];
+		$this->assertEquals( 100.0, $page['derived_rpm'] );
+		$this->assertEquals( 95.0, $page['source_rpm'] );
+		$this->assertNotEquals( $page['derived_rpm'], $page['source_rpm'] );
+	}
+
+	/**
+	 * Zero-view revenue: no division error, revenue preserved, flagged.
+	 */
+	public function test_zero_view_revenue_handled_without_division_error(): void {
+		$built = extrachill_analytics_revenue_build_pages(
+			array(
+				$this->content(
+					array(
+						'views'      => 0,
+						'revenue'    => 12.50,
+						'source_rpm' => 0.0,
+					)
+				),
+				$this->content(
+					array(
+						'page_key' => 'p2',
+						'views'    => 500,
+						'revenue'  => 25.0,
+					)
+				),
+			),
+			array( 'cohort' => 'resolved' )
+		);
+
+		$by_key = array();
+		foreach ( $built['pages'] as $p ) {
+			$by_key[ $p['page_key'] ] = $p;
+		}
+
+		// The zero-view page is present, flagged, revenue preserved.
+		$this->assertArrayHasKey( 'p1', $by_key );
+		$this->assertTrue( $by_key['p1']['zero_views'] );
+		$this->assertEquals( 12.5, $by_key['p1']['revenue'] );
+		// derived_rpm is 0.0 — never INF, never NAN, never a thrown error.
+		$this->assertSame( 0.0, $by_key['p1']['derived_rpm'] );
+
+		// The views-positive page is NOT flagged.
+		$this->assertFalse( $by_key['p2']['zero_views'] );
+		$this->assertEquals( 50.0, $by_key['p2']['derived_rpm'] );
+
+		// Totals disclose the zero-view cohort.
+		$this->assertSame( 1, $built['totals']['zero_views_pages'] );
+	}
+
+	/**
+	 * Cohort filter: resolved excludes unresolved routes and vice-versa.
+	 */
+	public function test_cohort_filtering(): void {
+		$records = array(
+			$this->content( array( 'page_key' => 'p1' ) ),
+			$this->unresolved( array( 'page_key' => 'u' . md5( '/' ) ) ),
+		);
+
+		$resolved = extrachill_analytics_revenue_build_pages( $records, array( 'cohort' => 'resolved' ) );
+		$this->assertCount( 1, $resolved['pages'] );
+		$this->assertSame( 'resolved', $resolved['pages'][0]['cohort'] );
+
+		$unresolved = extrachill_analytics_revenue_build_pages( $records, array( 'cohort' => 'unresolved' ) );
+		$this->assertCount( 1, $unresolved['pages'] );
+		$this->assertSame( 'unresolved', $unresolved['pages'][0]['cohort'] );
+
+		$all = extrachill_analytics_revenue_build_pages( $records, array( 'cohort' => 'all' ) );
+		$this->assertCount( 2, $all['pages'] );
+	}
+
+	/**
+	 * Minimum-views threshold excludes sub-floor pages, applied after aggregation.
+	 */
+	public function test_min_views_threshold(): void {
+		$records = array(
+			$this->content(
+				array(
+					'page_key' => 'p1',
+					'views'    => 100,
+				)
+			),
+			$this->content(
+				array(
+					'page_key' => 'p2',
+					'views'    => 500,
+				)
+			),
+			$this->content(
+				array(
+					'page_key' => 'p3',
+					'views'    => 5000,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_pages(
+			$records,
+			array(
+				'cohort'    => 'resolved',
+				'min_views' => 500,
+			)
+		);
+
+		$keys = array_column( $built['pages'], 'page_key' );
+		$this->assertSame( array( 'p2', 'p3' ), $keys );
+		$this->assertSame( 2, $built['sample']['after_min_views'] );
+	}
+
+	/**
+	 * URL-variant rows of one post collapse by page_key; views/revenue sum,
+	 * rates are views-weighted averages.
+	 */
+	public function test_variant_rows_collapse_and_weighted_rates(): void {
+		$records = array(
+			// Two variants of p1: 1000 views @ RPM 100, 3000 views @ RPM 40.
+			// Weighted source_rpm = (100*1000 + 40*3000) / 4000 = 55.
+			$this->content(
+				array(
+					'page_key'   => 'p1',
+					'views'      => 1000,
+					'revenue'    => 100.0,
+					'source_rpm' => 100.0,
+				)
+			),
+			$this->content(
+				array(
+					'page_key'   => 'p1',
+					'views'      => 3000,
+					'revenue'    => 120.0,
+					'source_rpm' => 40.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_pages( $records, array( 'cohort' => 'resolved' ) );
+
+		$this->assertCount( 1, $built['pages'] );
+		$page = $built['pages'][0];
+		// Summed volume.
+		$this->assertSame( 4000, $page['views'] );
+		$this->assertEquals( 220.0, $page['revenue'] );
+		// Derived RPM recomputed from the SUM: 220 / 4 = 55.
+		$this->assertEquals( 55.0, $page['derived_rpm'] );
+		// Source RPM is the views-weighted average, NOT the derived value.
+		$this->assertEquals( 55.0, $page['source_rpm'] );
+		// One page counted once.
+		$this->assertSame( 1, $built['sample']['resolved_pages'] );
+	}
+
+	/**
+	 * Stable sorting: by derived_rpm desc, with a deterministic page_key tiebreaker.
+	 */
+	public function test_sort_by_derived_rpm_desc_stable(): void {
+		$records = array(
+			$this->content(
+				array(
+					'page_key' => 'p3',
+					'views'    => 1000,
+					'revenue'  => 30.0,
+				)
+			), // RPM 30.
+			$this->content(
+				array(
+					'page_key' => 'p1',
+					'views'    => 1000,
+					'revenue'  => 10.0,
+				)
+			), // RPM 10.
+			$this->content(
+				array(
+					'page_key' => 'p2',
+					'views'    => 1000,
+					'revenue'  => 30.0,
+				)
+			), // RPM 30 (tie with p3).
+		);
+
+		$built = extrachill_analytics_revenue_build_pages(
+			$records,
+			array(
+				'cohort'  => 'resolved',
+				'sort_by' => 'derived_rpm',
+				'order'   => 'desc',
+			)
+		);
+
+		$keys = array_column( $built['pages'], 'page_key' );
+		// p2 and p3 tie on RPM 30; tiebreaker is page_key asc → p2 before p3.
+		// Then p1 (RPM 10).
+		$this->assertSame( array( 'p2', 'p3', 'p1' ), $keys );
+	}
+
+	/**
+	 * Ascending order reverses the primary direction; tiebreaker stays ascending.
+	 */
+	public function test_sort_ascending_keeps_tiebreaker_ascending(): void {
+		$records = array(
+			$this->content(
+				array(
+					'page_key' => 'p3',
+					'views'    => 1000,
+					'revenue'  => 30.0,
+				)
+			),
+			$this->content(
+				array(
+					'page_key' => 'p1',
+					'views'    => 1000,
+					'revenue'  => 10.0,
+				)
+			),
+			$this->content(
+				array(
+					'page_key' => 'p2',
+					'views'    => 1000,
+					'revenue'  => 30.0,
+				)
+			),
+		);
+
+		$built = extrachill_analytics_revenue_build_pages(
+			$records,
+			array(
+				'cohort'  => 'resolved',
+				'sort_by' => 'derived_rpm',
+				'order'   => 'asc',
+			)
+		);
+
+		$keys = array_column( $built['pages'], 'page_key' );
+		// Ascending: p1 (10) first, then p2/p3 (30, tie → page_key asc).
+		$this->assertSame( array( 'p1', 'p2', 'p3' ), $keys );
+	}
+
+	/**
+	 * Sort by each supported key surfaces the right page on top.
+	 */
+	public function test_sort_by_each_key(): void {
+		$records = array(
+			$this->content(
+				array(
+					'page_key'                 => 'p1',
+					'views'                    => 1000,
+					'revenue'                  => 10.0,
+					'source_rpm'               => 10.0,
+					'cpm'                      => 1.0,
+					'viewability'              => 50.0,
+					'fill_rate'                => 50.0,
+					'impressions_per_pageview' => 1.0,
+				)
+			),
+			// p2: higher on every metric including derived RPM (40/(2000/1000)=20 vs p1's 10).
+			$this->content(
+				array(
+					'page_key'                 => 'p2',
+					'views'                    => 2000,
+					'revenue'                  => 40.0,
+					'source_rpm'               => 20.0,
+					'cpm'                      => 2.0,
+					'viewability'              => 60.0,
+					'fill_rate'                => 60.0,
+					'impressions_per_pageview' => 2.0,
+				)
+			),
+		);
+
+		$expect_top = array(
+			'views'                    => 'p2',
+			'revenue'                  => 'p2',
+			'derived_rpm'              => 'p2',
+			'source_rpm'               => 'p2',
+			'cpm'                      => 'p2',
+			'viewability'              => 'p2',
+			'fill_rate'                => 'p2',
+			'impressions_per_pageview' => 'p2',
+			'dollars_per_page'         => 'p2',
+		);
+
+		foreach ( $expect_top as $sort_by => $expected_key ) {
+			$built = extrachill_analytics_revenue_build_pages(
+				$records,
+				array(
+					'cohort'  => 'resolved',
+					'sort_by' => $sort_by,
+					'order'   => 'desc',
+				)
+			);
+			$this->assertSame( $expected_key, $built['pages'][0]['page_key'], "sort_by={$sort_by} did not surface {$expected_key}" );
+		}
+	}
+
+	/**
+	 * Limit truncates and flags; pages_before_limit preserves the full count.
+	 */
+	public function test_limit_truncates_and_flags(): void {
+		$records = array();
+		for ( $i = 1; $i <= 10; $i++ ) {
+			$records[] = $this->content(
+				array(
+					'page_key' => 'p' . $i,
+					'views'    => 1000 * $i,
+					'revenue'  => (float) $i,
+				)
+			);
+		}
+
+		$built = extrachill_analytics_revenue_build_pages(
+			$records,
+			array(
+				'cohort'  => 'resolved',
+				'sort_by' => 'views',
+				'order'   => 'desc',
+				'limit'   => 3,
+			)
+		);
+
+		$this->assertCount( 3, $built['pages'] );
+		$this->assertSame( 10, $built['totals']['pages_before_limit'] );
+		$this->assertSame( 3, $built['totals']['pages_returned'] );
+		$this->assertTrue( $built['sample']['truncated'] );
+		// Descending by views: p10, p9, p8.
+		$this->assertSame( 'p10', $built['pages'][0]['page_key'] );
+	}
+
+	/**
+	 * Benchmark opportunity requires >= 5 views-positive pages; below that it is suppressed.
+	 */
+	public function test_benchmark_suppressed_below_sample_floor(): void {
+		$records = array();
+		for ( $i = 1; $i <= 4; $i++ ) {
+			$records[] = $this->content(
+				array(
+					'page_key' => 'p' . $i,
+					'views'    => 1000,
+					'revenue'  => 50.0,
+				)
+			);
+		}
+
+		$built = extrachill_analytics_revenue_build_pages( $records, array( 'cohort' => 'resolved' ) );
+
+		$this->assertFalse( $built['sample']['benchmark_computed'] );
+		$this->assertFalse( $built['sample']['sufficient_for_benchmark'] );
+		foreach ( $built['pages'] as $p ) {
+			$this->assertFalse( $p['benchmark_opportunity'] );
+			$this->assertNull( $p['benchmark_score'] );
+		}
+	}
+
+	/**
+	 * Benchmark qualifies high-RPM-at-volume pages; tiny-volume pages never qualify.
+	 */
+	public function test_benchmark_qualifies_high_rpm_at_volume(): void {
+		// 6 pages. RPMs: p1=10, p2=20, p3=30, p4=40, p5=50, p6=300.
+		// Median RPM = (30+40)/2 = 35. 1.5x = 52.5 → only p6 (300) qualifies on RPM.
+		// Views: p1..p6 = 1000..6000. Median views = (3000+4000)/2 = 3500.
+		// p6 has 6000 views >= 3500 → qualifies.
+		$records = array();
+		for ( $i = 1; $i <= 6; $i++ ) {
+			$records[] = $this->content(
+				array(
+					'page_key' => 'p' . $i,
+					'views'    => 1000 * $i,
+					'revenue'  => 10.0 * $i, // RPM = (10i)/(i) = 10... wait: derived_rpm = revenue/(views/1000).
+				)
+			);
+		}
+		// Recompute: revenue 10i, views 1000i → derived_rpm = 10i / i = 10 for ALL.
+		// That won't test qualification. Let me set explicit RPMs via revenue.
+		$records = array();
+		$rpms    = array(
+			1 => 10.0,
+			2 => 20.0,
+			3 => 30.0,
+			4 => 40.0,
+			5 => 50.0,
+			6 => 300.0,
+		);
+		for ( $i = 1; $i <= 6; $i++ ) {
+			$rpm       = $rpms[ $i ];
+			$views     = 1000 * $i;
+			$rev       = $rpm * ( $views / 1000 );
+			$records[] = $this->content(
+				array(
+					'page_key' => 'p' . $i,
+					'views'    => $views,
+					'revenue'  => $rev,
+				)
+			);
+		}
+
+		$built = extrachill_analytics_revenue_build_pages( $records, array( 'cohort' => 'resolved' ) );
+
+		$this->assertTrue( $built['sample']['benchmark_computed'] );
+
+		$by_key = array();
+		foreach ( $built['pages'] as $p ) {
+			$by_key[ $p['page_key'] ] = $p;
+		}
+
+		// Only p6 qualifies (RPM 300 >= 52.5, views 6000 >= 3500).
+		$this->assertTrue( $by_key['p6']['benchmark_opportunity'] );
+		$this->assertFalse( $by_key['p1']['benchmark_opportunity'] );
+		$this->assertFalse( $by_key['p5']['benchmark_opportunity'] );
+
+		// Scores are populated for views-positive pages.
+		$this->assertNotNull( $by_key['p6']['benchmark_score'] );
+		// score = 300 / 35 ≈ 8.57.
+		$this->assertEqualsWithDelta( 8.5714, $by_key['p6']['benchmark_score'], 0.01 );
+	}
+
+	/**
+	 * A high-RPM page on tiny volume never qualifies as a benchmark.
+	 */
+	public function test_high_rpm_tiny_volume_never_qualifies(): void {
+		// 5 pages with healthy volume + one tiny-volume high-RPM outlier.
+		$records = array();
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$records[] = $this->content(
+				array(
+					'page_key' => 'p' . $i,
+					'views'    => 5000,
+					'revenue'  => 50.0, // RPM 10.
+				)
+			);
+		}
+		// Tiny volume, huge RPM.
+		$records[] = $this->content(
+			array(
+				'page_key' => 'p6',
+				'views'    => 5,
+				'revenue'  => 5.0, // RPM 1000.
+			)
+		);
+
+		$built = extrachill_analytics_revenue_build_pages( $records, array( 'cohort' => 'resolved' ) );
+
+		$by_key = array();
+		foreach ( $built['pages'] as $p ) {
+			$by_key[ $p['page_key'] ] = $p;
+		}
+
+		// p6 has huge RPM (1000) and a high score, but its views (5) are well
+		// below the median (5000), so it does NOT qualify.
+		$this->assertFalse( $by_key['p6']['benchmark_opportunity'] );
+	}
+
+	/**
+	 * Post metadata is carried through to resolved pages.
+	 */
+	public function test_resolved_post_metadata_carried(): void {
+		$built = extrachill_analytics_revenue_build_pages(
+			array(
+				$this->content(
+					array(
+						'page_key'       => 'p42',
+						'post_id'        => 42,
+						'title'          => 'Grateful Dead Ripple Meaning',
+						'url'            => 'https://extrachill.com/ripple-meaning/',
+						'format'         => 'song-meaning',
+						'categories'     => array( 'song-meanings' ),
+						'published_date' => '2022-03-15 10:00:00',
+					)
+				),
+			),
+			array( 'cohort' => 'resolved' )
+		);
+
+		$page = $built['pages'][0];
+		$this->assertSame( 42, $page['post_id'] );
+		$this->assertSame( 'Grateful Dead Ripple Meaning', $page['title'] );
+		$this->assertSame( 'https://extrachill.com/ripple-meaning/', $page['url'] );
+		$this->assertSame( 'song-meaning', $page['format'] );
+		$this->assertSame( array( 'song-meanings' ), $page['categories'] );
+		$this->assertSame( '2022-03-15 10:00:00', $page['published_date'] );
+		// Resolved pages carry no route_family.
+		$this->assertSame( '', $page['route_family'] );
+	}
+
+	/**
+	 * Unresolved pages carry route_family, not post metadata.
+	 */
+	public function test_unresolved_pages_carry_route_family(): void {
+		$built = extrachill_analytics_revenue_build_pages(
+			array(
+				$this->unresolved(
+					array(
+						'page_key'     => 'u' . md5( '/old.html' ),
+						'route_family' => 'legacy-html',
+						'url'          => '/old.html',
+					)
+				),
+			),
+			array( 'cohort' => 'unresolved' )
+		);
+
+		$page = $built['pages'][0];
+		$this->assertSame( 'legacy-html', $page['route_family'] );
+		$this->assertSame( '', $page['format'] );
+		$this->assertSame( 0, $page['post_id'] );
+	}
+
+	/**
+	 * Source-string contract: the callback publish-gates content, reuses the
+	 * shared resolver and classifiers, and delegates to the pure builder.
+	 */
+	public function test_callback_publish_gates_and_delegates(): void {
+		$source = $this->ability_source();
+
+		// Publish-status gate (same contract as the rollup).
+		$this->assertStringContainsString( "'publish' === get_post_status( \$post_id )", $source );
+		// Reuses the shared resolver — no parallel slug->post logic.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_resolve_post_id', $source );
+		// Reuses the shared route-family classifier.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_classify_route_family', $source );
+		// Reuses the shared content-format classifier.
+		$this->assertStringContainsString( 'extrachill_analytics_classify_format', $source );
+		// Reuses the shared store reader — no new SQL/table.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_get_rows', $source );
+		// Delegates the pure half to the builder.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_build_pages', $source );
+		// No new table creation inside this ability.
+		$this->assertStringNotContainsString( 'CREATE TABLE', $source );
+	}
+
+	/**
+	 * Read the production ability source.
+	 *
+	 * @return string
+	 */
+	private function ability_source() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local source file.
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue-pages.php' );
+		$this->assertNotFalse( $source );
+
+		return $source;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -141,6 +141,81 @@ if ( ! function_exists( 'update_site_option' ) ) {
 		return true;
 	}
 }
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	/**
+	 * Return the current blog fixture ID.
+	 *
+	 * @return int Blog ID.
+	 */
+	function get_current_blog_id() {
+		return isset( $GLOBALS['extrachill_analytics_test_blog_id'] ) ? (int) $GLOBALS['extrachill_analytics_test_blog_id'] : 1;
+	}
+}
+if ( ! function_exists( 'switch_to_blog' ) ) {
+	/**
+	 * Switch the current blog fixture ID.
+	 *
+	 * @param int $blog_id Target blog ID.
+	 * @return bool Always true.
+	 */
+	function switch_to_blog( $blog_id ) {
+		$GLOBALS['extrachill_analytics_test_blog_stack'][] = get_current_blog_id();
+		$GLOBALS['extrachill_analytics_test_blog_id']      = (int) $blog_id;
+		return true;
+	}
+}
+if ( ! function_exists( 'restore_current_blog' ) ) {
+	/**
+	 * Restore the prior blog fixture ID.
+	 *
+	 * @return bool True when a prior blog was restored.
+	 */
+	function restore_current_blog() {
+		if ( empty( $GLOBALS['extrachill_analytics_test_blog_stack'] ) ) {
+			return false;
+		}
+		$GLOBALS['extrachill_analytics_test_blog_id'] = array_pop( $GLOBALS['extrachill_analytics_test_blog_stack'] );
+		return true;
+	}
+}
+if ( ! function_exists( 'home_url' ) ) {
+	/**
+	 * Return the configured home URL for the current blog fixture.
+	 *
+	 * @param string $path Optional path.
+	 * @return string Home URL.
+	 */
+	function home_url( $path = '' ) {
+		$blog_id = get_current_blog_id();
+		$homes   = isset( $GLOBALS['extrachill_analytics_test_home_urls'] ) ? $GLOBALS['extrachill_analytics_test_home_urls'] : array();
+		$home    = isset( $homes[ $blog_id ] ) ? $homes[ $blog_id ] : 'https://extrachill.com';
+		return rtrim( $home, '/' ) . '/' . ltrim( $path, '/' );
+	}
+}
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	/**
+	 * Stub for wp_parse_url().
+	 *
+	 * @param string $url URL to parse.
+	 * @return array|false Parsed URL components.
+	 */
+	function wp_parse_url( $url ) {
+		return parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+	}
+}
+if ( ! function_exists( 'url_to_postid' ) ) {
+	/**
+	 * Capture resolver URLs and return configured fixture IDs.
+	 *
+	 * @param string $url URL to resolve.
+	 * @return int Configured post ID, or zero.
+	 */
+	function url_to_postid( $url ) {
+		$GLOBALS['extrachill_analytics_test_resolved_urls'][] = $url;
+		$posts = isset( $GLOBALS['extrachill_analytics_test_url_post_ids'] ) ? $GLOBALS['extrachill_analytics_test_url_post_ids'] : array();
+		return isset( $posts[ $url ] ) ? (int) $posts[ $url ] : 0;
+	}
+}
 
 require_once dirname( __DIR__ ) . '/inc/core/php-error-log.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-php-error-summary.php';


### PR DESCRIPTION
## Summary

Adds two narrowly scoped sibling abilities alongside `extrachill/get-content-revenue` so page-level Mediavine analysis and store integrity checks no longer require direct SQL. The existing rollup/timeseries contracts are preserved untouched.

Fixes #141

## Architecture decision: siblings, not a new group_by axis

The rollup ability's output contract (rollups/totals/unresolved) cannot cleanly represent either a flat, machine-sortable page list with per-page rate metrics, or an array of independent integrity checks each carrying status/evidence/totals. The issue explicitly permits narrowly scoped siblings where the existing contract cannot represent the new lens, so this PR adds:

- `extrachill/get-content-revenue-pages`
- `extrachill/get-content-revenue-diagnostics`

Both reuse the **same** substrate — no new tables, clients, or parallel aggregation:
- `extrachill_analytics_revenue_get_rows()` / `extrachill_analytics_revenue_list_batches()` — the shared store readers
- `extrachill_analytics_revenue_resolve_post_id()` — slug→post resolution
- `extrachill_analytics_revenue_classify_route_family()` — unresolved-route classifier
- `extrachill_analytics_classify_format()` — content-format classifier

The same `p<id>` / `u<hash>` page-key convention and the same `publish`-status gate as the rollup keep resolved published content and unresolved routes honestly separated.

## `extrachill/get-content-revenue-pages` — page-level lens

Every resolved published post (or unresolved route) as its own ranked row:

- **Full delivery stack**: views, revenue, **derived RPM** (`revenue/(views/1000)`, recomputed here), **source RPM** (Mediavine-reported `rpm` column), CPM, viewability, fill rate, impressions/pageview. Derived and source RPM are kept distinct and both are sort keys — they can disagree.
- **Post metadata** when resolved: post ID, title, URL, path, categories, content format, publication date.
- **Cohort filter**: `resolved` (default) / `unresolved` / `all`.
- **Minimum-views threshold** (applied after aggregation so a page's full volume counts toward the floor).
- **Stable sorting** by views, revenue, derived_rpm, source_rpm, cpm, viewability, fill_rate, impressions_per_pageview, dollars_per_page, or benchmark_opportunity — with a deterministic `page_key` tiebreaker so output is machine-stable across runs.
- **Zero-view revenue handling**: `derived_rpm = 0.0` (never a division error, never infinity), the page is flagged `zero_views => true`, and revenue is preserved and visible — never hidden.
- **Benchmark opportunity** (optional, defensible): a page qualifies only when it shows genuinely strong RPM **at meaningful volume** — `derived_rpm >= 1.5× cohort median RPM` **AND** `views >= cohort median views` (medians over views-positive pages). Requires ≥5 views-positive pages or the flag is suppressed. High RPM on tiny volume never qualifies.

## `extrachill/get-content-revenue-diagnostics` — integrity lens

Structured checks, each returning a stable `status` (`pass`/`warning`/`fail`), `evidence` (human+machine readable facts), and `totals`:

| Check | fail on | warning on |
|-------|---------|------------|
| latest_period_freshness | empty store | only all-time bucket / stale (>45d) |
| missing_periods | — | gaps in the YYYY-MM sequence |
| duplicate_period_batches | — | one period_label across multiple batches |
| totals_reconciliation | row-sum ≠ timeseries | — |
| resolution_coverage | — | >50% unresolved |
| format_coverage | — | >30% uncategorized resolved |
| zero_view_revenue | — | revenue>0 with views=0 |
| views_zero_revenue | — | >20% viewed-but-zero-revenue |
| negative_impossible_values | negative views/revenue/rpm/cpm | — |
| stored_vs_derived_rpm_variance | — | >10% of rows disagree by >20% |
| provenance_coverage | — | rows missing batch/period |

**Status contract (load-bearing):** source quirks (zero-view revenue, duplicate batches, RPM variance, unresolved routes) are **warnings** — disclosure, never corruption claims without evidence. `fail` is reserved for genuine integrity violations: negative/impossible values, or a read model that does not reconcile. Overall status is `fail` if any check fails, else `warning` if any warns, else `pass`.

## Compatibility

- Existing rollup (`format`/`category`/`both`) and `timeseries` (arc) contracts are unchanged.
- No new tables, no schema migration, no DB version bump, no CHANGELOG edit, no version bump (homeboy owns both).
- CLI consumers (extrachill-cli#93) map args and format output only — all SQL, resolution, sorting, thresholds, calculations, and caveats live in the ability callbacks + their pure helpers.

## Tests

20 new unit/contract tests (full suite: 136 tests, 366 assertions, all green):

- **Pages**: cohort filtering, min-views threshold, sorting by each key with stable tiebreaker (asc/desc), limit/truncation, zero-view revenue (no division error, revenue preserved), derived vs source RPM distinctness, URL-variant collapse + views-weighted rates, benchmark suppression below sample floor, benchmark qualification at volume, tiny-volume-never-qualifies, post-metadata carry-through, unresolved route_family, callback source-string contract.
- **Diagnostics**: empty-store fail, all-time-only warning, recent/stale freshness, contiguous vs gapped periods, duplicate batches, reconciliation pass/fail, resolution/format coverage thresholds, zero-view revenue, views-zero-revenue, negative-values fail, source-anomalies-are-warnings-not-failures, RPM variance, provenance, clean-store overall pass, fail-beats-warning precedence, callback source-string contract.

Pure helpers (`build_pages`, `build_diagnostics`, sort/median/weighted-average, and every `diag_*` check) carry no WordPress/DB dependencies, so the analytical contracts are exercised directly. The WordPress-dependent halves (resolution, publish gate, post metadata) are locked down via source-string contracts — the same strategy the existing `GetContentRevenueRollupTest` uses.

## Verification

- `vendor/bin/phpunit` — **136 tests, 366 assertions, OK**.
- `vendor/bin/phpcs --standard=WordPress` on all 6 changed files — **clean**.
- `homeboy review extrachill-analytics test` — **could not run**: the machine is hot (load avg ~135 across 8 CPUs) with no Homeboy Lab runner available, so Homeboy refuses to start `review` from a non-interactive shell. Reported honestly; PHPUnit + PHPCS (the substantive gates) pass.