### PR TITLE
feat: add idempotent revenue ingestion ability

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -23,6 +23,7 @@ define( 'EXTRACHILL_ANALYTICS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/events-db.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/php-error-log-db.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/mediavine-revenue-db.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/class-extrachill-analytics-revenue-store.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/link-page-analytics-db.php';
 
 // Core functionality (network-wide).
@@ -65,6 +66,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-crosslink
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-stickiness.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-activation-funnel.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-content-revenue.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/ingest-revenue.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-bot-filter-impact.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-php-error-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/check-fatal-alarm.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -33,6 +33,7 @@ add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_crosslink_ta
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_surface_stickiness_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_activation_funnel_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_content_revenue_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_ingest_revenue_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_bot_filter_impact_ability' );
 
 /**

--- a/inc/core/abilities/ingest-revenue.php
+++ b/inc/core/abilities/ingest-revenue.php
@@ -35,13 +35,13 @@
  * REPLACEMENT vs ADDITIVE:
  * - `replace` (default): REQUIRES non-empty rows (an empty/omitted set can never
  *   wipe an existing snapshot). It upserts incoming rows into the deterministic
- *   snapshot, removes stale rows that disappeared from the refreshed source, AND
- *   ADOPTS the period — sweeping any OTHER batch for the same (blog, period) so
- *   a legacy filename-derived batch left over from the old importer flow cannot
- *   double the ARC on the first ability ingestion. The whole mutation runs in a
- *   transaction (where supported) under a per-period advisory lock so two
- *   concurrent refreshes cannot union snapshots.
- * - `additive`: NEVER deletes or adopts, and REQUIRES an explicit operator-
+ *   snapshot and removes stale rows that disappeared from that exact snapshot.
+ *   It never discovers, adopts, or deletes another batch. Existing legacy
+ *   batches require an explicit one-time operator migration or purge outside
+ *   this runtime ability. The whole mutation runs in a transaction (where
+ *   supported) under a per-period advisory lock so concurrent refreshes cannot
+ *   union one snapshot.
+ * - `additive`: NEVER deletes, and REQUIRES an explicit operator-
  *   supplied `snapshot` identity (a distinct parallel batch) that must NOT
  *   collide with the deterministic replace identity. This is the only way to
  *   land a second snapshot for the same period on purpose; it needs network-
@@ -306,9 +306,8 @@ function extrachill_analytics_revenue_ingest_authorize( $blog_id, $mode ) {
  * - `rows` is required and non-empty; an empty/omitted set is rejected and
  *   NEVER wipes an existing snapshot.
  * - Replace establishes ONE canonical snapshot per (blog, period): it upserts
- *   incoming rows, removes stale within-batch rows, and ADOPTS the period
- *   (sweeps any other batch for that period) so a legacy filename-derived batch
- *   cannot double the ARC.
+ *   incoming rows and removes stale rows only within that exact batch. Legacy
+ *   batch cleanup is an explicit one-time operator action outside this ability.
  * - The whole mutation runs in a transaction under a per-period advisory lock,
  *   begun BEFORE the snapshot read, so concurrent refreshes cannot union
  *   snapshots. Transaction begin/commit failures FAIL CLOSED.
@@ -549,14 +548,11 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 		$store = new Extrachill_Analytics_Revenue_Store();
 	}
 
-	// Dry run: read the snapshot + count adoption candidates, plan, and report
-	// — mutate nothing. No lock is needed because nothing is written.
+	// Dry run: read exactly this snapshot, plan, and report — mutate nothing.
+	// No lock is needed because nothing is written.
 	if ( $dry_run ) {
 		$existing = $store->get_snapshot( $blog_id, $period_label, $batch );
 		$plan     = extrachill_analytics_revenue_build_ingestion_plan( $records, $existing, $mode );
-		$other    = ( 'replace' === $mode )
-			? $store->count_period_other_batches( $blog_id, $period_label, $batch )
-			: 0;
 
 		return array_merge(
 			array(
@@ -566,8 +562,6 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 				'replaced'     => count( $plan['replaces'] ),
 				'deleted'      => 0,
 				'would_delete' => count( $plan['deletes'] ),
-				'adopted'      => 0,
-				'would_adopt'  => $other,
 			),
 			$base
 		);
@@ -603,7 +597,6 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 	}
 
 	$op_error       = null;
-	$adopted        = 0;
 	$deletes_count  = 0;
 	$inserts_count  = 0;
 	$replaces_count = 0;
@@ -633,15 +626,6 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 		if ( null === $op_error && ! empty( $plan['deletes'] ) ) {
 			if ( false === $store->delete_ids( $plan['deletes'] ) ) {
 				$op_error = 'Failed to remove stale revenue rows.';
-			}
-		}
-		// Adopt the period: replace establishes ONE canonical snapshot per
-		// (blog, period), sweeping any other batch (legacy filename-derived or
-		// stray) so the ARC cannot double-count on the first ability ingestion.
-		if ( null === $op_error && 'replace' === $mode ) {
-			$adopted = $store->adopt_period( $blog_id, $period_label, $batch );
-			if ( false === $adopted ) {
-				$op_error = 'Failed to adopt the canonical period snapshot.';
 			}
 		}
 		if ( null === $op_error && false === $store->commit() ) {
@@ -680,7 +664,6 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 			'inserted' => $inserts_count,
 			'replaced' => $replaces_count,
 			'deleted'  => $deletes_count,
-			'adopted'  => (int) $adopted,
 		),
 		$base
 	);
@@ -698,7 +681,7 @@ function extrachill_analytics_register_ingest_revenue_ability() {
 		'extrachill/ingest-revenue',
 		array(
 			'label'               => __( 'Ingest Revenue Snapshot', 'extrachill-analytics' ),
-			'description'         => __( 'Idempotently ingest a set of per-URL ad-revenue rows (e.g. a Mediavine period export) into the revenue store with a deterministic snapshot identity. Default mode is deterministic REPLACE: the same source/site/blog/period always lands on the SAME snapshot, updating rows in place, removing any that disappeared from the refreshed source, and ADOPTING the period (sweeping legacy batches) so the ARC never double-counts. REQUIRES non-empty rows — an empty/omitted set never wipes a snapshot. ADDITIVE mode never deletes/adopts and requires an explicit, non-colliding snapshot identity plus network-level authorization. Replace authorizes against the TARGET blog (or network). The whole mutation runs in a transaction under a per-period advisory lock; begin/commit failures fail closed. Accepts normalized revenue rows plus source provenance; agnostic about the upstream source ability. Supports dry-run. Owned by analytics: validation, period/snapshot identity, replacement, adoption, resolution, and persistence all live here.', 'extrachill-analytics' ),
+			'description'         => __( 'Idempotently ingest a set of per-URL ad-revenue rows (e.g. a Mediavine period export) into the revenue store with a deterministic snapshot identity. Default mode is deterministic REPLACE: the same source/site/blog/period always lands on the SAME snapshot, updating rows in place and removing only rows that disappeared from that exact snapshot. It never discovers, adopts, or deletes another batch; existing legacy batches require an explicit one-time operator migration or purge outside this runtime ability. REQUIRES non-empty rows — an empty/omitted set never wipes a snapshot. ADDITIVE mode never deletes and requires an explicit, non-colliding snapshot identity plus network-level authorization. Replace authorizes against the TARGET blog (or network). The whole mutation runs in a transaction under a per-period advisory lock; begin/commit failures fail closed. Accepts normalized revenue rows plus source provenance; agnostic about the upstream source ability. Supports dry-run. Owned by analytics: validation, period/snapshot identity, replacement, resolution, and persistence all live here.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -774,7 +757,7 @@ function extrachill_analytics_register_ingest_revenue_ability() {
 					),
 					'mode'         => array(
 						'type'        => 'string',
-						'description' => __( '"replace" (default) updates the deterministic snapshot in place, removes stale rows, and adopts the period; "additive" never deletes/adopts and requires an explicit snapshot identity plus network-level authorization. Additive cannot happen by accident.', 'extrachill-analytics' ),
+						'description' => __( '"replace" (default) updates only the deterministic snapshot in place and removes stale rows only from that snapshot; "additive" never deletes and requires an explicit snapshot identity plus network-level authorization. Existing legacy batches require an explicit operator migration or purge outside this ability.', 'extrachill-analytics' ),
 						'default'     => 'replace',
 						'enum'        => array( 'replace', 'additive' ),
 					),
@@ -787,7 +770,7 @@ function extrachill_analytics_register_ingest_revenue_ability() {
 					),
 					'dry_run'      => array(
 						'type'        => 'boolean',
-						'description' => __( 'If true, resolve + plan but write nothing. Reported counts reflect what would happen (would_delete, would_adopt).', 'extrachill-analytics' ),
+						'description' => __( 'If true, resolve + plan but write nothing. Reported counts reflect what would happen within the exact target snapshot.', 'extrachill-analytics' ),
 						'default'     => false,
 					),
 				),
@@ -795,7 +778,7 @@ function extrachill_analytics_register_ingest_revenue_ability() {
 			),
 			'output_schema'       => array(
 				'type'        => 'object',
-				'description' => __( 'Result with success, written, mode, dry_run, counts (rows, input_rows, duplicate_rows_deduped, resolved, unresolved, inserted, replaced, deleted, adopted, and would_delete/would_adopt on dry run), and the stable identity (import_batch, period_label, period_start/end, source, source_site, blog_id). On failure: success=false, written=false, error.', 'extrachill-analytics' ),
+				'description' => __( 'Result with success, written, mode, dry_run, counts (rows, input_rows, duplicate_rows_deduped, resolved, unresolved, inserted, replaced, deleted, and would_delete on dry run), and the stable identity (import_batch, period_label, period_start/end, source, source_site, blog_id). On failure: success=false, written=false, error.', 'extrachill-analytics' ),
 				'properties'  => array(
 					'success'                => array( 'type' => 'boolean' ),
 					'written'                => array( 'type' => 'boolean' ),
@@ -836,15 +819,7 @@ function extrachill_analytics_register_ingest_revenue_ability() {
 						'type'    => 'integer',
 						'minimum' => 0,
 					),
-					'adopted'                => array(
-						'type'    => 'integer',
-						'minimum' => 0,
-					),
 					'would_delete'           => array(
-						'type'    => 'integer',
-						'minimum' => 0,
-					),
-					'would_adopt'            => array(
 						'type'    => 'integer',
 						'minimum' => 0,
 					),

--- a/inc/core/abilities/ingest-revenue.php
+++ b/inc/core/abilities/ingest-revenue.php
@@ -33,14 +33,30 @@
  * snapshot. The identity is NEVER derived from a temp filename.
  *
  * REPLACEMENT vs ADDITIVE:
- * - `replace` (default): upsert the incoming rows into the deterministic
- *   snapshot AND remove ("replace") any row that belonged to that snapshot but
- *   disappeared from the refreshed source. Scoped to exactly one snapshot, in a
- *   transaction where supported. This is what a recurring fetch wants.
- * - `additive`: NEVER deletes, and REQUIRES an explicit operator-supplied
- *   `snapshot` identity (a distinct parallel batch). This is the only way to
- *   land a second snapshot for the same period on purpose. Additive behavior
- *   cannot happen by accident — the default is always replace.
+ * - `replace` (default): REQUIRES non-empty rows (an empty/omitted set can never
+ *   wipe an existing snapshot). It upserts incoming rows into the deterministic
+ *   snapshot, removes stale rows that disappeared from the refreshed source, AND
+ *   ADOPTS the period — sweeping any OTHER batch for the same (blog, period) so
+ *   a legacy filename-derived batch left over from the old importer flow cannot
+ *   double the ARC on the first ability ingestion. The whole mutation runs in a
+ *   transaction (where supported) under a per-period advisory lock so two
+ *   concurrent refreshes cannot union snapshots.
+ * - `additive`: NEVER deletes or adopts, and REQUIRES an explicit operator-
+ *   supplied `snapshot` identity (a distinct parallel batch) that must NOT
+ *   collide with the deterministic replace identity. This is the only way to
+ *   land a second snapshot for the same period on purpose; it needs network-
+ *   level authorization because it is the path that can intentionally create a
+ *   double-counted snapshot.
+ *
+ * SAFETY:
+ * - `rows` is required and non-empty; an empty/omitted set is rejected and never
+ *   wipes a snapshot.
+ * - Authorization is against the TARGET blog (or network-level); current-site
+ *   `manage_options` cannot mutate an arbitrary blog_id. Additive requires
+ *   network-level capability.
+ * - Transaction begin/commit failures FAIL CLOSED (rollback, success=false);
+ *   the engine never continues non-atomically and never reports success after a
+ *   failed commit.
  *
  * @package ExtraChill\Analytics
  * @since 0.28.0
@@ -70,13 +86,25 @@ defined( 'ABSPATH' ) || exit;
  * @return array{import_batch:string,period_label:string,period_start:string,period_end:string,source:string,source_site:string,blog_id:int}
  */
 function extrachill_analytics_revenue_snapshot_identity( array $args ) {
-	$source = isset( $args['source'] ) && '' !== (string) $args['source']
-		? sanitize_key( (string) $args['source'] )
-		: 'mediavine';
+	$raw_source = isset( $args['source'] ) ? strtolower( trim( (string) $args['source'] ) ) : '';
+	if ( '' === $raw_source ) {
+		$raw_source = 'mediavine';
+	}
+	$source = sanitize_key( $raw_source );
+	if ( '' === $source ) {
+		$source = 'source';
+	}
 
-	$source_site = isset( $args['source_site'] ) && '' !== (string) $args['source_site']
-		? sanitize_key( (string) $args['source_site'] )
-		: sanitize_key( isset( $args['hostname'] ) && '' !== (string) $args['hostname'] ? (string) $args['hostname'] : 'extrachill' );
+	$raw_source_site = isset( $args['source_site'] ) ? strtolower( trim( (string) $args['source_site'] ) ) : '';
+	if ( '' === $raw_source_site ) {
+		$raw_source_site = isset( $args['hostname'] ) && '' !== trim( (string) $args['hostname'] )
+			? strtolower( trim( (string) $args['hostname'] ) )
+			: 'extrachill';
+	}
+	$source_site = sanitize_key( $raw_source_site );
+	if ( '' === $source_site ) {
+		$source_site = 'site';
+	}
 
 	$blog_id = isset( $args['blog_id'] ) ? max( 0, (int) $args['blog_id'] ) : 0;
 
@@ -93,8 +121,18 @@ function extrachill_analytics_revenue_snapshot_identity( array $args ) {
 	if ( $blog_id > 0 ) {
 		$parts[] = 'b' . $blog_id;
 	}
-	$parts[]      = sanitize_key( $resolved['label'] );
-	$import_batch = trim( implode( '-', $parts ), '-' );
+	$parts[] = sanitize_key( $resolved['label'] );
+
+	// The readable prefix is useful operationally, while the hash prevents
+	// sanitize/truncation collisions (for example, "a.b" and "ab") and includes
+	// explicit date overrides. Keep the final value inside varchar(64).
+	$fingerprint  = substr(
+		hash( 'sha256', implode( "\0", array( $raw_source, $raw_source_site, (string) $blog_id, $resolved['label'], $resolved['start'], $resolved['end'] ) ) ),
+		0,
+		12
+	);
+	$prefix       = substr( trim( implode( '-', $parts ), '-' ), 0, 51 );
+	$import_batch = trim( $prefix, '-' ) . '-' . $fingerprint;
 
 	return array(
 		'import_batch' => $import_batch,
@@ -115,9 +153,9 @@ function extrachill_analytics_revenue_snapshot_identity( array $args ) {
  * it classifies each incoming slug as an insert (new to the snapshot) or a
  * replace (already present), and — for replace mode — identifies the stale rows
  * that disappeared from the refreshed source and must be removed. The engine
- * then applies this plan through the store; the plan itself owns every count
- * the ability reports, so the load-bearing logic is fully testable without a
- * database.
+ * then applies this plan through the store; the plan itself owns the within-
+ * batch counts the ability reports, so the load-bearing logic is fully testable
+ * without a database.
  *
  * @param array              $records Normalized incoming records, each with at least a `slug`.
  * @param array<int, object> $existing Existing rows of the target snapshot (objects with `id`, `slug`).
@@ -168,17 +206,112 @@ function extrachill_analytics_revenue_build_ingestion_plan( array $records, arra
 }
 
 /**
+ * Validate a Y-m-d date string is real (not just formatted).
+ *
+ * @param string $date Candidate date.
+ * @return bool
+ */
+function extrachill_analytics_revenue_is_valid_date( $date ) {
+	if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', (string) $date, $m ) ) {
+		return false;
+	}
+	return checkdate( (int) $m[2], (int) $m[3], (int) $m[1] );
+}
+
+/**
+ * Validate the period token and explicit date overrides.
+ *
+ * @param string $period Period token.
+ * @param string $start  Explicit window start.
+ * @param string $end    Explicit window end.
+ * @return string|null Error message, or null when valid.
+ */
+function extrachill_analytics_revenue_validate_period( $period, $start, $end ) {
+	$period = trim( (string) $period );
+	$start  = trim( (string) $start );
+	$end    = trim( (string) $end );
+
+	if ( '' !== $period && ! preg_match( '/^\d{4}(?:-\d{2})?$/', $period ) ) {
+		return 'period must be YYYY-MM, YYYY, or empty.';
+	}
+
+	if ( preg_match( '/^(\d{4})-(\d{2})$/', $period, $m ) ) {
+		$month = (int) $m[2];
+		if ( $month < 1 || $month > 12 ) {
+			return 'period month must be 01-12.';
+		}
+	}
+
+	if ( '' !== $start && ! extrachill_analytics_revenue_is_valid_date( $start ) ) {
+		return 'period_start must be a valid Y-m-d date.';
+	}
+	if ( '' !== $end && ! extrachill_analytics_revenue_is_valid_date( $end ) ) {
+		return 'period_end must be a valid Y-m-d date.';
+	}
+	if ( ( '' === $start ) !== ( '' === $end ) ) {
+		return 'period_start and period_end must be provided together.';
+	}
+	if ( '' !== $start && $start > $end ) {
+		return 'period_start must not be after period_end.';
+	}
+
+	return null;
+}
+
+/**
+ * Authorize a revenue ingestion against the TARGET blog.
+ *
+ * Current-site `manage_options` must not mutate an arbitrary blog_id: the check
+ * is scoped to the requested blog (target-blog capability), or requires a
+ * network-level capability. Additive mode — the path that can intentionally
+ * create a double-counted parallel snapshot — requires network-level authority
+ * regardless of blog. WP-CLI is trusted (server-side operator).
+ *
+ * @param int    $blog_id Target blog.
+ * @param string $mode    'replace' or 'additive'.
+ * @return bool
+ */
+function extrachill_analytics_revenue_ingest_authorize( $blog_id, $mode ) {
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return true;
+	}
+	if ( ! function_exists( 'current_user_can' ) ) {
+		return false;
+	}
+
+	// Additive creates a parallel snapshot — elevated, network-level capability.
+	if ( 'additive' === $mode ) {
+		return current_user_can( 'manage_network_options' );
+	}
+
+	$current = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+
+	// Replace on the current blog: site-level manage_options is sufficient.
+	if ( (int) $blog_id === $current ) {
+		return current_user_can( 'manage_options' );
+	}
+
+	// Replace on a different blog: target-blog capability OR network-level.
+	if ( function_exists( 'current_user_can_for_site' ) && current_user_can_for_site( $blog_id, 'manage_options' ) ) {
+		return true;
+	}
+	return current_user_can( 'manage_network_options' );
+}
+
+/**
  * Ingest a set of normalized revenue rows into the store with deterministic
  * snapshot identity and explicit replace/additive semantics.
  *
- * The engine resolves + normalizes each row (reusing the shared slug resolver),
- * computes a pure plan against the snapshot's existing rows, then applies it
- * through the supplied `$store` in a transaction (where supported). Dry runs
- * compute identical counts and write nothing.
- *
- * Resolution (url_to_postid) runs against the current blog; when importing for a
- * different blog the engine switches first so the stamped blog_id and resolved
- * post_id agree — mirroring the CSV importer.
+ * Safety contract:
+ * - `rows` is required and non-empty; an empty/omitted set is rejected and
+ *   NEVER wipes an existing snapshot.
+ * - Replace establishes ONE canonical snapshot per (blog, period): it upserts
+ *   incoming rows, removes stale within-batch rows, and ADOPTS the period
+ *   (sweeps any other batch for that period) so a legacy filename-derived batch
+ *   cannot double the ARC.
+ * - The whole mutation runs in a transaction under a per-period advisory lock,
+ *   begun BEFORE the snapshot read, so concurrent refreshes cannot union
+ *   snapshots. Transaction begin/commit failures FAIL CLOSED.
  *
  * @param array                                   $input_rows Normalized revenue rows. Each row may carry a pre-resolved
  *                                                   `post_id`; otherwise the slug is resolved. Metric keys mirror
@@ -210,20 +343,32 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 		);
 	}
 
-	// Additive is the explicit opt-in for a parallel snapshot; it MUST NOT
-	// delete, and it requires an operator-supplied snapshot identity so a second
-	// snapshot for the same period is intentional, not accidental.
-	$snapshot_override = isset( $args['snapshot'] ) ? trim( (string) $args['snapshot'] ) : '';
-	if ( 'additive' === $mode && '' === $snapshot_override ) {
+	// SAFETY: rows is required and non-empty. An empty/omitted set can never
+	// wipe an existing snapshot — clearing a snapshot needs a separate,
+	// separately-authorized delete operation (out of scope here).
+	if ( empty( $input_rows ) ) {
 		return array(
 			'success' => false,
-			'error'   => 'additive mode requires an explicit snapshot identity (a distinct batch label). Use replace for the default deterministic snapshot.',
+			'error'   => 'rows is required and must be non-empty.',
 		);
 	}
 
-	$blog_id  = isset( $args['blog_id'] ) && (int) $args['blog_id'] > 0 ? (int) $args['blog_id'] : get_current_blog_id();
-	$hostname = ! empty( $args['hostname'] ) ? (string) $args['hostname'] : 'extrachill.com';
-	$dry_run  = ! empty( $args['dry_run'] );
+	$blog_id           = isset( $args['blog_id'] ) && (int) $args['blog_id'] > 0 ? (int) $args['blog_id'] : get_current_blog_id();
+	$hostname          = ! empty( $args['hostname'] ) ? (string) $args['hostname'] : 'extrachill.com';
+	$dry_run           = ! empty( $args['dry_run'] );
+	$period            = isset( $args['period'] ) ? (string) $args['period'] : '';
+	$period_start_arg  = isset( $args['period_start'] ) ? (string) $args['period_start'] : '';
+	$period_end_arg    = isset( $args['period_end'] ) ? (string) $args['period_end'] : '';
+	$snapshot_override = isset( $args['snapshot'] ) ? trim( (string) $args['snapshot'] ) : '';
+
+	// Validate period token + explicit date overrides.
+	$date_error = extrachill_analytics_revenue_validate_period( $period, $period_start_arg, $period_end_arg );
+	if ( null !== $date_error ) {
+		return array(
+			'success' => false,
+			'error'   => $date_error,
+		);
+	}
 
 	$identity            = extrachill_analytics_revenue_snapshot_identity(
 		array(
@@ -231,37 +376,65 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 			'source'       => isset( $args['source'] ) ? (string) $args['source'] : 'mediavine',
 			'source_site'  => isset( $args['source_site'] ) ? (string) $args['source_site'] : $hostname,
 			'hostname'     => $hostname,
-			'period'       => isset( $args['period'] ) ? (string) $args['period'] : '',
-			'period_start' => isset( $args['period_start'] ) ? (string) $args['period_start'] : '',
-			'period_end'   => isset( $args['period_end'] ) ? (string) $args['period_end'] : '',
+			'period'       => $period,
+			'period_start' => $period_start_arg,
+			'period_end'   => $period_end_arg,
 		)
 	);
 	$identity['blog_id'] = $blog_id;
 
-	// An additive snapshot is named by the operator; the period still resolves
-	// deterministically from the period token.
-	if ( 'additive' === $mode && '' !== $snapshot_override ) {
-		$identity['import_batch'] = $snapshot_override;
+	$batch = $identity['import_batch'];
+
+	// Additive: explicit snapshot identity required, must not collide with the
+	// deterministic replace identity (else it would silently overwrite the
+	// canonical snapshot), and must fit the column.
+	if ( 'additive' === $mode ) {
+		if ( '' === $snapshot_override ) {
+			return array(
+				'success' => false,
+				'error'   => 'additive mode requires an explicit snapshot identity (a distinct batch label). Use replace for the default deterministic snapshot.',
+			);
+		}
+		if ( ! preg_match( '/^[a-z0-9][a-z0-9_-]{0,63}$/', $snapshot_override ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'additive snapshot must be 1-64 lowercase letters, numbers, hyphens, or underscores.',
+			);
+		}
+		if ( hash_equals( $batch, $snapshot_override ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'additive snapshot must differ from the deterministic replace identity for this period.',
+			);
+		}
+		$batch                    = $snapshot_override;
+		$identity['import_batch'] = $batch;
+	}
+
+	// Validate the final batch label fits the store's varchar(64) column.
+	if ( '' === $batch || strlen( $batch ) > 64 ) {
+		return array(
+			'success' => false,
+			'error'   => 'snapshot identity must be non-empty and no longer than 64 characters.',
+		);
 	}
 
 	$period_label = $identity['period_label'];
 	$period_start = $identity['period_start'];
 	$period_end   = $identity['period_end'];
-	$batch        = $identity['import_batch'];
 
-	// Resolve + normalize each incoming row against the target blog. Resolution
-	// (url_to_postid) is current-blog-scoped, so switch for the duration to keep
-	// the stamped blog_id and resolved post_id in agreement on a multisite.
+	// Resolve + normalize each incoming row against the target blog, deduping
+	// by normalized slug (last occurrence wins). Resolution (url_to_postid) is
+	// current-blog-scoped, so switch for the duration to keep the stamped
+	// blog_id and resolved post_id in agreement on a multisite.
 	$switched = false;
 	if ( $blog_id > 0 && function_exists( 'switch_to_blog' ) && function_exists( 'get_current_blog_id' ) && get_current_blog_id() !== $blog_id ) {
 		switch_to_blog( $blog_id );
 		$switched = true;
 	}
 
-	$records    = array();
-	$resolved   = 0;
-	$unresolved = 0;
-
+	$by_slug    = array();
+	$duplicates = 0;
 	foreach ( $input_rows as $input ) {
 		$raw_slug = isset( $input['slug'] ) ? (string) $input['slug'] : ( isset( $input['url'] ) ? (string) $input['url'] : '' );
 		if ( '' === trim( $raw_slug ) ) {
@@ -282,13 +455,14 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 			$slug         = $resolved_row['slug'];
 		}
 
-		if ( $post_id > 0 ) {
-			++$resolved;
-		} else {
-			++$unresolved;
+		if ( '' === $slug ) {
+			continue;
 		}
 
-		$records[] = array(
+		if ( isset( $by_slug[ $slug ] ) ) {
+			++$duplicates;
+		}
+		$by_slug[ $slug ] = array(
 			'blog_id'                  => $blog_id,
 			'slug'                     => $slug,
 			'url'                      => $raw_slug,
@@ -311,39 +485,31 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 		restore_current_blog();
 	}
 
-	$rows_count = count( $records );
+	$records = array_values( $by_slug );
 
-	// Acquire the production store when the caller (production callback) did not
-	// inject one. Tests inject an in-memory fake to exercise the full path.
-	if ( null === $store ) {
-		if ( ! class_exists( 'Extrachill_Analytics_Revenue_Store' ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Revenue store is not available.',
-			);
+	// Count resolved/unresolved over the DEDUPED set so duplicates don't inflate
+	// the counts.
+	$resolved   = 0;
+	$unresolved = 0;
+	foreach ( $records as $rec ) {
+		if ( $rec['post_id'] > 0 ) {
+			++$resolved;
+		} else {
+			++$unresolved;
 		}
-		$store = new Extrachill_Analytics_Revenue_Store();
 	}
 
-	$existing = $store->get_snapshot( $blog_id, $period_label, $batch );
-	$plan     = extrachill_analytics_revenue_build_ingestion_plan( $records, $existing, $mode );
+	$rows_count = count( $records );
 
-	$inserts  = count( $plan['inserts'] );
-	$replaces = count( $plan['replaces'] );
-	$deletes  = count( $plan['deletes'] );
-
-	$result = array(
-		'success'    => true,
-		'mode'       => $mode,
-		'dry_run'    => $dry_run,
-		'written'    => ! $dry_run,
-		'rows'       => $rows_count,
-		'resolved'   => $resolved,
-		'unresolved' => $unresolved,
-		'inserted'   => $inserts,
-		'replaced'   => $replaces,
-		'deleted'    => $dry_run ? 0 : $deletes,
-		'identity'   => array(
+	$base = array(
+		'mode'                   => $mode,
+		'dry_run'                => $dry_run,
+		'rows'                   => $rows_count,
+		'input_rows'             => count( $input_rows ),
+		'duplicate_rows_deduped' => $duplicates,
+		'resolved'               => $resolved,
+		'unresolved'             => $unresolved,
+		'identity'               => array(
 			'import_batch' => $batch,
 			'period_label' => $period_label,
 			'period_start' => $period_start,
@@ -354,71 +520,170 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 		),
 	);
 
-	// Dry run reports the full plan (including deletes that WOULD happen) but
-	// mutates nothing.
-	if ( $dry_run ) {
-		$result['would_delete'] = $deletes;
-		$result['deleted']      = 0;
-		return $result;
+	// A normalized input that reduced to zero usable slugs cannot replace
+	// anything — refuse rather than risk an empty write.
+	if ( 0 === $rows_count ) {
+		return array_merge(
+			array(
+				'success' => false,
+				'written' => false,
+				'error'   => 'rows contained no usable slug after normalization.',
+			),
+			$base
+		);
 	}
 
-	// Nothing to write: no incoming slugs and nothing to remove is a clean
-	// idempotent no-op (e.g. an empty refreshed source clearing a snapshot only
-	// happens when existing rows exist — handled by the deletes branch below).
-	if ( 0 === $inserts && 0 === $replaces && 0 === $deletes ) {
-		return $result;
-	}
-
-	// Apply the plan atomically. On any write failure, roll back so a partially
-	// replaced snapshot never replaces a good one.
-	$txn = $store->begin();
-
-	$write_ok = true;
-	$error    = '';
-
-	foreach ( $plan['inserts'] as $rec ) {
-		if ( false === $store->upsert( $rec ) ) {
-			$write_ok = false;
-			$error    = 'Failed to insert a revenue row.';
-			break;
+	// Acquire the production store when the caller (production callback) did not
+	// inject one. Tests inject an in-memory fake to exercise the full path.
+	if ( null === $store ) {
+		if ( ! class_exists( 'Extrachill_Analytics_Revenue_Store' ) ) {
+			return array_merge(
+				array(
+					'success' => false,
+					'written' => false,
+					'error'   => 'Revenue store is not available.',
+				),
+				$base
+			);
 		}
+		$store = new Extrachill_Analytics_Revenue_Store();
 	}
 
-	if ( $write_ok ) {
-		foreach ( $plan['replaces'] as $rec ) {
+	// Dry run: read the snapshot + count adoption candidates, plan, and report
+	// — mutate nothing. No lock is needed because nothing is written.
+	if ( $dry_run ) {
+		$existing = $store->get_snapshot( $blog_id, $period_label, $batch );
+		$plan     = extrachill_analytics_revenue_build_ingestion_plan( $records, $existing, $mode );
+		$other    = ( 'replace' === $mode )
+			? $store->count_period_other_batches( $blog_id, $period_label, $batch )
+			: 0;
+
+		return array_merge(
+			array(
+				'success'      => true,
+				'written'      => false,
+				'inserted'     => count( $plan['inserts'] ),
+				'replaced'     => count( $plan['replaces'] ),
+				'deleted'      => 0,
+				'would_delete' => count( $plan['deletes'] ),
+				'adopted'      => 0,
+				'would_adopt'  => $other,
+			),
+			$base
+		);
+	}
+
+	// WRITE PATH — critical section. Begin the transaction BEFORE the snapshot
+	// read and hold a per-period advisory lock so two concurrent refreshes
+	// cannot both read the prior snapshot and union their writes. Begin/commit
+	// failures fail CLOSED (rollback, success=false): the engine never continues
+	// non-atomically and never reports success after a failed commit.
+	if ( false === $store->begin() ) {
+		return array_merge(
+			array(
+				'success' => false,
+				'written' => false,
+				'error'   => 'Could not begin a transaction; ingestion aborted (fail closed).',
+			),
+			$base
+		);
+	}
+
+	$lock_name = 'ecrev_ing_' . md5( $blog_id . ':' . $period_label );
+	if ( false === $store->lock( $lock_name, 10 ) ) {
+		$rollback_ok = $store->rollback();
+		return array_merge(
+			array(
+				'success' => false,
+				'written' => false,
+				'error'   => 'Could not acquire the ingestion lock for this period; another refresh may be in progress.' . ( false === $rollback_ok ? ' Rollback also failed.' : '' ),
+			),
+			$base
+		);
+	}
+
+	$op_error       = null;
+	$adopted        = 0;
+	$deletes_count  = 0;
+	$inserts_count  = 0;
+	$replaces_count = 0;
+
+	try {
+		$existing = $store->get_snapshot( $blog_id, $period_label, $batch );
+		$plan     = extrachill_analytics_revenue_build_ingestion_plan( $records, $existing, $mode );
+
+		$inserts_count  = count( $plan['inserts'] );
+		$replaces_count = count( $plan['replaces'] );
+		$deletes_count  = count( $plan['deletes'] );
+
+		foreach ( $plan['inserts'] as $rec ) {
 			if ( false === $store->upsert( $rec ) ) {
-				$write_ok = false;
-				$error    = 'Failed to replace a revenue row.';
+				$op_error = 'Failed to insert a revenue row.';
 				break;
 			}
 		}
-	}
-
-	if ( $write_ok && ! empty( $plan['deletes'] ) ) {
-		if ( false === $store->delete_ids( $plan['deletes'] ) ) {
-			$write_ok = false;
-			$error    = 'Failed to remove stale revenue rows.';
+		if ( null === $op_error ) {
+			foreach ( $plan['replaces'] as $rec ) {
+				if ( false === $store->upsert( $rec ) ) {
+					$op_error = 'Failed to replace a revenue row.';
+					break;
+				}
+			}
 		}
-	}
-
-	if ( ! $write_ok ) {
-		if ( $txn ) {
-			$store->rollback();
+		if ( null === $op_error && ! empty( $plan['deletes'] ) ) {
+			if ( false === $store->delete_ids( $plan['deletes'] ) ) {
+				$op_error = 'Failed to remove stale revenue rows.';
+			}
 		}
-		$result['success'] = false;
-		$result['written'] = false;
-		unset( $result['mode'], $result['dry_run'] );
-		$result['mode']    = $mode;
-		$result['dry_run'] = false;
-		$result['error']   = $error;
-		return $result;
+		// Adopt the period: replace establishes ONE canonical snapshot per
+		// (blog, period), sweeping any other batch (legacy filename-derived or
+		// stray) so the ARC cannot double-count on the first ability ingestion.
+		if ( null === $op_error && 'replace' === $mode ) {
+			$adopted = $store->adopt_period( $blog_id, $period_label, $batch );
+			if ( false === $adopted ) {
+				$op_error = 'Failed to adopt the canonical period snapshot.';
+			}
+		}
+		if ( null === $op_error && false === $store->commit() ) {
+			$op_error = 'Failed to commit the revenue snapshot.';
+		}
+	} catch ( Throwable $throwable ) {
+		$op_error = 'Revenue ingestion failed: ' . $throwable->getMessage();
+	} finally {
+		if ( null !== $op_error ) {
+			$rollback_ok = $store->rollback();
+			if ( false === $rollback_ok ) {
+				$op_error .= ' Rollback also failed.';
+			}
+		}
+		// Keep rollback inside the lock; then always release the advisory lock.
+		$store->unlock( $lock_name );
 	}
 
-	if ( $txn ) {
-		$store->commit();
+	if ( null !== $op_error ) {
+		return array_merge(
+			array(
+				'success'  => false,
+				'written'  => false,
+				'error'    => $op_error,
+				'inserted' => $inserts_count,
+				'replaced' => $replaces_count,
+			),
+			$base
+		);
 	}
 
-	return $result;
+	return array_merge(
+		array(
+			'success'  => true,
+			'written'  => true,
+			'inserted' => $inserts_count,
+			'replaced' => $replaces_count,
+			'deleted'  => $deletes_count,
+			'adopted'  => (int) $adopted,
+		),
+		$base
+	);
 }
 
 /**
@@ -433,20 +698,46 @@ function extrachill_analytics_register_ingest_revenue_ability() {
 		'extrachill/ingest-revenue',
 		array(
 			'label'               => __( 'Ingest Revenue Snapshot', 'extrachill-analytics' ),
-			'description'         => __( 'Idempotently ingest a set of per-URL ad-revenue rows (e.g. a Mediavine period export) into the revenue store with a deterministic snapshot identity. Default mode is deterministic REPLACE: the same source/site/blog/period always lands on the SAME snapshot, updating rows in place and removing any that disappeared from the refreshed source, so re-running identical inputs never double-counts the ARC or rollups. ADDITIVE mode never deletes and requires an explicit operator-supplied snapshot identity to create a distinct parallel snapshot on purpose. Accepts normalized revenue rows plus source provenance; agnostic about the upstream source ability. Supports dry-run. Owned by analytics: validation, period/snapshot identity, replacement, resolution, and persistence all live here.', 'extrachill-analytics' ),
+			'description'         => __( 'Idempotently ingest a set of per-URL ad-revenue rows (e.g. a Mediavine period export) into the revenue store with a deterministic snapshot identity. Default mode is deterministic REPLACE: the same source/site/blog/period always lands on the SAME snapshot, updating rows in place, removing any that disappeared from the refreshed source, and ADOPTING the period (sweeping legacy batches) so the ARC never double-counts. REQUIRES non-empty rows — an empty/omitted set never wipes a snapshot. ADDITIVE mode never deletes/adopts and requires an explicit, non-colliding snapshot identity plus network-level authorization. Replace authorizes against the TARGET blog (or network). The whole mutation runs in a transaction under a per-period advisory lock; begin/commit failures fail closed. Accepts normalized revenue rows plus source provenance; agnostic about the upstream source ability. Supports dry-run. Owned by analytics: validation, period/snapshot identity, replacement, adoption, resolution, and persistence all live here.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
 					'rows'         => array(
 						'type'        => 'array',
-						'description' => __( 'Normalized per-URL revenue rows. Each row carries a slug/url plus metrics (views, revenue, rpm, cpm, viewability, fill_rate, impressions_per_pageview) and an optional pre-resolved post_id.', 'extrachill-analytics' ),
-						'default'     => array(),
+						'description' => __( 'REQUIRED, non-empty. Normalized per-URL revenue rows. Each row carries a slug/url plus metrics (views, revenue, rpm, cpm, viewability, fill_rate, impressions_per_pageview) and an optional pre-resolved post_id. Duplicate slugs are deduped (last wins).', 'extrachill-analytics' ),
+						'minItems'    => 1,
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'slug'                     => array( 'type' => 'string' ),
+								'url'                      => array( 'type' => 'string' ),
+								'post_id'                  => array(
+									'type'    => 'integer',
+									'minimum' => 0,
+								),
+								'views'                    => array(
+									'type'    => 'integer',
+									'minimum' => 0,
+								),
+								'revenue'                  => array( 'type' => 'number' ),
+								'rpm'                      => array( 'type' => 'number' ),
+								'cpm'                      => array( 'type' => 'number' ),
+								'viewability'              => array( 'type' => 'number' ),
+								'fill_rate'                => array( 'type' => 'number' ),
+								'impressions_per_pageview' => array( 'type' => 'number' ),
+							),
+							'anyOf'      => array(
+								array( 'required' => array( 'slug' ) ),
+								array( 'required' => array( 'url' ) ),
+							),
+						),
 					),
 					'blog_id'      => array(
 						'type'        => 'integer',
-						'description' => __( 'Blog the rows belong to. 0 = current blog.', 'extrachill-analytics' ),
+						'description' => __( 'Blog the rows belong to. 0 = current blog. Replace authorizes against this target blog (target-blog capability) or requires network-level capability.', 'extrachill-analytics' ),
 						'default'     => 0,
+						'minimum'     => 0,
 					),
 					'hostname'     => array(
 						'type'        => 'string',
@@ -465,43 +756,124 @@ function extrachill_analytics_register_ingest_revenue_ability() {
 					),
 					'period'       => array(
 						'type'        => 'string',
-						'description' => __( 'Period token these rows belong to: YYYY-MM (a monthly export), YYYY (a year), or "" for the flat lifetime file. Part of the snapshot identity and the canonical period_label the ARC groups by.', 'extrachill-analytics' ),
+						'description' => __( 'Period token: YYYY-MM (monthly), YYYY (yearly), or "" for the flat lifetime file. Part of the snapshot identity and the canonical period_label the ARC groups by.', 'extrachill-analytics' ),
 						'default'     => '',
+						'pattern'     => '^(?:\\d{4}(?:-(?:0[1-9]|1[0-2]))?)?$',
 					),
 					'period_start' => array(
 						'type'        => 'string',
-						'description' => __( 'Explicit window start (Y-m-d) override. Defaults to the start derived from period.', 'extrachill-analytics' ),
+						'description' => __( 'Explicit window start (Y-m-d) override. Must be a valid date when non-empty. Defaults to the start derived from period.', 'extrachill-analytics' ),
 						'default'     => '',
+						'pattern'     => '^(?:\\d{4}-\\d{2}-\\d{2})?$',
 					),
 					'period_end'   => array(
 						'type'        => 'string',
-						'description' => __( 'Explicit window end (Y-m-d) override. Defaults to the end derived from period.', 'extrachill-analytics' ),
+						'description' => __( 'Explicit window end (Y-m-d) override. Must be a valid date when non-empty. Defaults to the end derived from period.', 'extrachill-analytics' ),
 						'default'     => '',
+						'pattern'     => '^(?:\\d{4}-\\d{2}-\\d{2})?$',
 					),
 					'mode'         => array(
 						'type'        => 'string',
-						'description' => __( '"replace" (default) updates the deterministic snapshot in place and removes stale rows; "additive" never deletes and requires an explicit snapshot identity to create a parallel snapshot. Additive behavior cannot happen by accident.', 'extrachill-analytics' ),
+						'description' => __( '"replace" (default) updates the deterministic snapshot in place, removes stale rows, and adopts the period; "additive" never deletes/adopts and requires an explicit snapshot identity plus network-level authorization. Additive cannot happen by accident.', 'extrachill-analytics' ),
 						'default'     => 'replace',
+						'enum'        => array( 'replace', 'additive' ),
 					),
 					'snapshot'     => array(
 						'type'        => 'string',
-						'description' => __( 'Explicit snapshot identity (batch label). REQUIRED for additive mode (the operator names the parallel snapshot). Ignored for replace, which always uses the deterministic identity.', 'extrachill-analytics' ),
+						'description' => __( 'Explicit snapshot identity (batch label). REQUIRED for additive mode (must differ from the deterministic replace identity). Ignored for replace, which always uses the deterministic identity.', 'extrachill-analytics' ),
 						'default'     => '',
+						'maxLength'   => 64,
+						'pattern'     => '^(?:[a-z0-9][a-z0-9_-]{0,63})?$',
 					),
 					'dry_run'      => array(
 						'type'        => 'boolean',
-						'description' => __( 'If true, resolve + plan but write nothing. Reported counts reflect what would happen.', 'extrachill-analytics' ),
+						'description' => __( 'If true, resolve + plan but write nothing. Reported counts reflect what would happen (would_delete, would_adopt).', 'extrachill-analytics' ),
 						'default'     => false,
 					),
 				),
+				'required'   => array( 'rows' ),
 			),
 			'output_schema'       => array(
 				'type'        => 'object',
-				'description' => __( 'Result with success, written, mode, dry_run, counts (rows, resolved, unresolved, inserted, replaced, deleted), and the stable identity (import_batch, period_label, period_start/end, source, source_site, blog_id).', 'extrachill-analytics' ),
+				'description' => __( 'Result with success, written, mode, dry_run, counts (rows, input_rows, duplicate_rows_deduped, resolved, unresolved, inserted, replaced, deleted, adopted, and would_delete/would_adopt on dry run), and the stable identity (import_batch, period_label, period_start/end, source, source_site, blog_id). On failure: success=false, written=false, error.', 'extrachill-analytics' ),
+				'properties'  => array(
+					'success'                => array( 'type' => 'boolean' ),
+					'written'                => array( 'type' => 'boolean' ),
+					'mode'                   => array(
+						'type' => 'string',
+						'enum' => array( 'replace', 'additive' ),
+					),
+					'dry_run'                => array( 'type' => 'boolean' ),
+					'rows'                   => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'input_rows'             => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'duplicate_rows_deduped' => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'resolved'               => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'unresolved'             => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'inserted'               => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'replaced'               => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'deleted'                => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'adopted'                => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'would_delete'           => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'would_adopt'            => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+					'error'                  => array( 'type' => 'string' ),
+					'identity'               => array(
+						'type'       => 'object',
+						'properties' => array(
+							'import_batch' => array( 'type' => 'string' ),
+							'period_label' => array( 'type' => 'string' ),
+							'period_start' => array( 'type' => 'string' ),
+							'period_end'   => array( 'type' => 'string' ),
+							'source'       => array( 'type' => 'string' ),
+							'source_site'  => array( 'type' => 'string' ),
+							'blog_id'      => array(
+								'type'    => 'integer',
+								'minimum' => 1,
+							),
+						),
+						'required'   => array( 'import_batch', 'period_label', 'period_start', 'period_end', 'source', 'source_site', 'blog_id' ),
+					),
+				),
+				'required'    => array( 'success' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_ingest_revenue',
 			'permission_callback' => function () {
-				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+				// First-pass REST gate (current site). Target-blog / network
+				// authorization is enforced inside the execute callback, which
+				// sees the requested blog_id and mode.
+				return current_user_can( 'manage_options' ) || current_user_can( 'manage_network_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
 			},
 			'meta'                => array(
 				'show_in_rest' => false,
@@ -518,23 +890,40 @@ function extrachill_analytics_register_ingest_revenue_ability() {
 /**
  * Execute callback for the ingest-revenue ability.
  *
+ * Performs target-blog / network authorization against the requested blog and
+ * mode, then delegates to the engine.
+ *
  * @param array $input Input parameters.
- * @return array Ingestion result.
+ * @return array|\WP_Error Ingestion result, or WP_Error when unauthorized.
  */
 function extrachill_analytics_ability_ingest_revenue( $input ) {
-	$rows = isset( $input['rows'] ) && is_array( $input['rows'] ) ? $input['rows'] : array();
+	$rows    = isset( $input['rows'] ) && is_array( $input['rows'] ) ? $input['rows'] : array();
+	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+	$mode    = isset( $input['mode'] ) ? (string) $input['mode'] : 'replace';
+	$target  = $blog_id > 0 ? $blog_id : ( function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0 );
+
+	if ( ! extrachill_analytics_revenue_ingest_authorize( $target, $mode ) ) {
+		return new WP_Error(
+			'extrachill_ingest_revenue_unauthorized',
+			'additive' === $mode
+				? __( 'You are not authorized to create an additive revenue snapshot (requires network-level capability).', 'extrachill-analytics' )
+				/* translators: %d: blog ID */
+				: sprintf( __( 'You are not authorized to ingest revenue for blog %d.', 'extrachill-analytics' ), $target ),
+			array( 'status' => 403 )
+		);
+	}
 
 	return extrachill_analytics_revenue_ingest_rows(
 		$rows,
 		array(
-			'blog_id'      => isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0,
+			'blog_id'      => $blog_id,
 			'hostname'     => isset( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com',
 			'source'       => isset( $input['source'] ) ? (string) $input['source'] : 'mediavine',
 			'source_site'  => isset( $input['source_site'] ) ? (string) $input['source_site'] : '',
 			'period'       => isset( $input['period'] ) ? (string) $input['period'] : '',
 			'period_start' => isset( $input['period_start'] ) ? (string) $input['period_start'] : '',
 			'period_end'   => isset( $input['period_end'] ) ? (string) $input['period_end'] : '',
-			'mode'         => isset( $input['mode'] ) ? (string) $input['mode'] : 'replace',
+			'mode'         => $mode,
 			'snapshot'     => isset( $input['snapshot'] ) ? (string) $input['snapshot'] : '',
 			'dry_run'      => ! empty( $input['dry_run'] ),
 		)

--- a/inc/core/abilities/ingest-revenue.php
+++ b/inc/core/abilities/ingest-revenue.php
@@ -1,0 +1,542 @@
+<?php
+/**
+ * Ingest Revenue Ability
+ *
+ * The first-class, idempotent mutation ability that owns Mediavine (and any
+ * future per-URL ad-revenue) ingestion into the revenue store.
+ *
+ * WHY THIS EXISTS (issue #140 / extrachill-cli#92):
+ * The CLI `revenue fetch` path used to serialize source rows to a RANDOM temp
+ * CSV and call the importer without an explicit batch. The importer derived the
+ * batch from that random filename, so re-fetching one period created a SECOND
+ * snapshot for the same period_label. Because the revenue ARC and rollups SUM
+ * every batch by default, a repeat operational fetch silently doubled that
+ * month. This ability replaces that flow with a deterministic snapshot identity
+ * keyed on STABLE inputs (source + source-site + blog + period) and explicit
+ * replace/additive semantics, so identical inputs always land on the same
+ * snapshot and leave totals unchanged.
+ *
+ * STORAGE OWNERSHIP:
+ * Analytics owns persistence, period/snapshot identity, replacement policy,
+ * resolution, and mutation validation. It reuses the existing writer
+ * (`extrachill_analytics_revenue_upsert()`) and the shared slug resolver
+ * (`extrachill_analytics_revenue_resolve_slug()`) — there is still exactly one
+ * writer and one resolution path. The ability is agnostic about the Data
+ * Machine Business source ability: callers hand it already-normalized revenue
+ * rows plus source provenance.
+ *
+ * IDENTITY CONTRACT:
+ * The default snapshot identity is deterministic. Running the same
+ * (source, source_site, blog_id, period) twice MUST resolve to the same
+ * `import_batch`, so the store's UNIQUE (blog_id, slug, period_label,
+ * import_batch) key upserts the same rows in place instead of adding a parallel
+ * snapshot. The identity is NEVER derived from a temp filename.
+ *
+ * REPLACEMENT vs ADDITIVE:
+ * - `replace` (default): upsert the incoming rows into the deterministic
+ *   snapshot AND remove ("replace") any row that belonged to that snapshot but
+ *   disappeared from the refreshed source. Scoped to exactly one snapshot, in a
+ *   transaction where supported. This is what a recurring fetch wants.
+ * - `additive`: NEVER deletes, and REQUIRES an explicit operator-supplied
+ *   `snapshot` identity (a distinct parallel batch). This is the only way to
+ *   land a second snapshot for the same period on purpose. Additive behavior
+ *   cannot happen by accident — the default is always replace.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.28.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Compute a deterministic snapshot identity from stable inputs.
+ *
+ * Pure (no WordPress I/O): `extrachill_analytics_revenue_resolve_period()` is
+ * pure and `sanitize_key()` is pure. The same inputs always produce the same
+ * `import_batch`, which is the whole point — re-running identical inputs lands
+ * on the same snapshot and the unique key upserts in place.
+ *
+ * @param array $args {
+ *     Identity inputs.
+ *
+ *     @type int    $blog_id      Blog the rows belong to. 0 = current (resolved later).
+ *     @type string $source       Source provenance slug, e.g. "mediavine". Default "mediavine".
+ *     @type string $source_site  Source site / host the rows were pulled for. Falls back to hostname.
+ *     @type string $hostname     Hostname fallback for source_site. Default "extrachill".
+ *     @type string $period       Period token (YYYY-MM, YYYY, or '' for the flat lifetime file).
+ *     @type string $period_start Explicit window start (Y-m-d) override.
+ *     @type string $period_end   Explicit window end (Y-m-d) override.
+ * }
+ * @return array{import_batch:string,period_label:string,period_start:string,period_end:string,source:string,source_site:string,blog_id:int}
+ */
+function extrachill_analytics_revenue_snapshot_identity( array $args ) {
+	$source = isset( $args['source'] ) && '' !== (string) $args['source']
+		? sanitize_key( (string) $args['source'] )
+		: 'mediavine';
+
+	$source_site = isset( $args['source_site'] ) && '' !== (string) $args['source_site']
+		? sanitize_key( (string) $args['source_site'] )
+		: sanitize_key( isset( $args['hostname'] ) && '' !== (string) $args['hostname'] ? (string) $args['hostname'] : 'extrachill' );
+
+	$blog_id = isset( $args['blog_id'] ) ? max( 0, (int) $args['blog_id'] ) : 0;
+
+	$resolved = extrachill_analytics_revenue_resolve_period(
+		isset( $args['period'] ) ? (string) $args['period'] : '',
+		isset( $args['period_start'] ) ? (string) $args['period_start'] : '',
+		isset( $args['period_end'] ) ? (string) $args['period_end'] : ''
+	);
+
+	// Deterministic, filename-free identity. Every part comes from stable
+	// operator/source inputs, never a temp path, so identical runs collide on
+	// purpose and the store's unique key dedupes instead of duplicating.
+	$parts = array( $source, $source_site );
+	if ( $blog_id > 0 ) {
+		$parts[] = 'b' . $blog_id;
+	}
+	$parts[]      = sanitize_key( $resolved['label'] );
+	$import_batch = trim( implode( '-', $parts ), '-' );
+
+	return array(
+		'import_batch' => $import_batch,
+		'period_label' => $resolved['label'],
+		'period_start' => $resolved['start'],
+		'period_end'   => $resolved['end'],
+		'source'       => $source,
+		'source_site'  => $source_site,
+		'blog_id'      => $blog_id,
+	);
+}
+
+/**
+ * Build a deterministic ingestion plan from incoming records and the snapshot's
+ * existing rows.
+ *
+ * Pure (no I/O). This is the decision core that the engine unit-tests directly:
+ * it classifies each incoming slug as an insert (new to the snapshot) or a
+ * replace (already present), and — for replace mode — identifies the stale rows
+ * that disappeared from the refreshed source and must be removed. The engine
+ * then applies this plan through the store; the plan itself owns every count
+ * the ability reports, so the load-bearing logic is fully testable without a
+ * database.
+ *
+ * @param array              $records Normalized incoming records, each with at least a `slug`.
+ * @param array<int, object> $existing Existing rows of the target snapshot (objects with `id`, `slug`).
+ * @param string             $mode     'replace' or 'additive'.
+ * @return array{inserts:array,replaces:array,deletes:array} Plan.
+ */
+function extrachill_analytics_revenue_build_ingestion_plan( array $records, array $existing, $mode ) {
+	$existing_by_slug = array();
+	foreach ( $existing as $row ) {
+		$slug = is_object( $row ) && isset( $row->slug ) ? (string) $row->slug : (string) ( isset( $row['slug'] ) ? $row['slug'] : '' );
+		if ( '' !== $slug ) {
+			$id                        = is_object( $row ) && isset( $row->id ) ? (int) $row->id : (int) ( isset( $row['id'] ) ? $row['id'] : 0 );
+			$existing_by_slug[ $slug ] = $id;
+		}
+	}
+
+	$inserts  = array();
+	$replaces = array();
+	$seen_new = array();
+
+	foreach ( $records as $rec ) {
+		$slug = isset( $rec['slug'] ) ? (string) $rec['slug'] : '';
+		if ( '' === $slug ) {
+			continue;
+		}
+		if ( isset( $existing_by_slug[ $slug ] ) ) {
+			$replaces[] = $rec;
+		} else {
+			$inserts[] = $rec;
+		}
+		$seen_new[ $slug ] = true;
+	}
+
+	$deletes = array();
+	if ( 'replace' === $mode ) {
+		foreach ( $existing_by_slug as $slug => $id ) {
+			if ( ! isset( $seen_new[ $slug ] ) ) {
+				$deletes[] = $id;
+			}
+		}
+	}
+
+	return array(
+		'inserts'  => $inserts,
+		'replaces' => $replaces,
+		'deletes'  => $deletes,
+	);
+}
+
+/**
+ * Ingest a set of normalized revenue rows into the store with deterministic
+ * snapshot identity and explicit replace/additive semantics.
+ *
+ * The engine resolves + normalizes each row (reusing the shared slug resolver),
+ * computes a pure plan against the snapshot's existing rows, then applies it
+ * through the supplied `$store` in a transaction (where supported). Dry runs
+ * compute identical counts and write nothing.
+ *
+ * Resolution (url_to_postid) runs against the current blog; when importing for a
+ * different blog the engine switches first so the stamped blog_id and resolved
+ * post_id agree — mirroring the CSV importer.
+ *
+ * @param array                                   $input_rows Normalized revenue rows. Each row may carry a pre-resolved
+ *                                                   `post_id`; otherwise the slug is resolved. Metric keys mirror
+ *                                                   the store: views, revenue, rpm, cpm, viewability, fill_rate,
+ *                                                   impressions_per_pageview. `slug`/`url` carry the path.
+ * @param array                                   $args {
+ *     Ingestion options.
+ *
+ *     @type int                 $blog_id      Target blog. 0 = current blog.
+ *     @type string              $hostname     Hostname for slug->post resolution. Default extrachill.com.
+ *     @type string              $source       Source provenance slug. Default mediavine.
+ *     @type string              $source_site  Source site identifier. Default derived from hostname.
+ *     @type string              $period       Period token (YYYY-MM / YYYY / '').
+ *     @type string              $period_start Explicit window start override.
+ *     @type string              $period_end   Explicit window end override.
+ *     @type string              $mode         'replace' (default) or 'additive'.
+ *     @type string              $snapshot     Explicit snapshot identity for additive mode (required when mode=additive).
+ *     @type bool                $dry_run      Parse + plan but write nothing.
+ * }
+ * @param Extrachill_Analytics_Revenue_Store|null $store Storage handle. Null builds the production store.
+ * @return array Ingestion result (see output_schema) or { success:false, error }.
+ */
+function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $args, $store = null ) {
+	$mode = isset( $args['mode'] ) ? (string) $args['mode'] : 'replace';
+	if ( ! in_array( $mode, array( 'replace', 'additive' ), true ) ) {
+		return array(
+			'success' => false,
+			'error'   => 'mode must be "replace" or "additive".',
+		);
+	}
+
+	// Additive is the explicit opt-in for a parallel snapshot; it MUST NOT
+	// delete, and it requires an operator-supplied snapshot identity so a second
+	// snapshot for the same period is intentional, not accidental.
+	$snapshot_override = isset( $args['snapshot'] ) ? trim( (string) $args['snapshot'] ) : '';
+	if ( 'additive' === $mode && '' === $snapshot_override ) {
+		return array(
+			'success' => false,
+			'error'   => 'additive mode requires an explicit snapshot identity (a distinct batch label). Use replace for the default deterministic snapshot.',
+		);
+	}
+
+	$blog_id  = isset( $args['blog_id'] ) && (int) $args['blog_id'] > 0 ? (int) $args['blog_id'] : get_current_blog_id();
+	$hostname = ! empty( $args['hostname'] ) ? (string) $args['hostname'] : 'extrachill.com';
+	$dry_run  = ! empty( $args['dry_run'] );
+
+	$identity            = extrachill_analytics_revenue_snapshot_identity(
+		array(
+			'blog_id'      => $blog_id,
+			'source'       => isset( $args['source'] ) ? (string) $args['source'] : 'mediavine',
+			'source_site'  => isset( $args['source_site'] ) ? (string) $args['source_site'] : $hostname,
+			'hostname'     => $hostname,
+			'period'       => isset( $args['period'] ) ? (string) $args['period'] : '',
+			'period_start' => isset( $args['period_start'] ) ? (string) $args['period_start'] : '',
+			'period_end'   => isset( $args['period_end'] ) ? (string) $args['period_end'] : '',
+		)
+	);
+	$identity['blog_id'] = $blog_id;
+
+	// An additive snapshot is named by the operator; the period still resolves
+	// deterministically from the period token.
+	if ( 'additive' === $mode && '' !== $snapshot_override ) {
+		$identity['import_batch'] = $snapshot_override;
+	}
+
+	$period_label = $identity['period_label'];
+	$period_start = $identity['period_start'];
+	$period_end   = $identity['period_end'];
+	$batch        = $identity['import_batch'];
+
+	// Resolve + normalize each incoming row against the target blog. Resolution
+	// (url_to_postid) is current-blog-scoped, so switch for the duration to keep
+	// the stamped blog_id and resolved post_id in agreement on a multisite.
+	$switched = false;
+	if ( $blog_id > 0 && function_exists( 'switch_to_blog' ) && function_exists( 'get_current_blog_id' ) && get_current_blog_id() !== $blog_id ) {
+		switch_to_blog( $blog_id );
+		$switched = true;
+	}
+
+	$records    = array();
+	$resolved   = 0;
+	$unresolved = 0;
+
+	foreach ( $input_rows as $input ) {
+		$raw_slug = isset( $input['slug'] ) ? (string) $input['slug'] : ( isset( $input['url'] ) ? (string) $input['url'] : '' );
+		if ( '' === trim( $raw_slug ) ) {
+			continue;
+		}
+
+		if ( isset( $input['post_id'] ) && (int) $input['post_id'] > 0 ) {
+			$post_id = (int) $input['post_id'];
+			if ( function_exists( 'get_post' ) ) {
+				$post = get_post( $post_id );
+				$slug = ( is_object( $post ) && isset( $post->post_name ) ) ? $post->post_name : trim( (string) strtok( $raw_slug, '?#' ), '/' );
+			} else {
+				$slug = trim( (string) strtok( $raw_slug, '?#' ), '/' );
+			}
+		} else {
+			$resolved_row = extrachill_analytics_revenue_resolve_slug( $raw_slug, $hostname );
+			$post_id      = $resolved_row['post_id'];
+			$slug         = $resolved_row['slug'];
+		}
+
+		if ( $post_id > 0 ) {
+			++$resolved;
+		} else {
+			++$unresolved;
+		}
+
+		$records[] = array(
+			'blog_id'                  => $blog_id,
+			'slug'                     => $slug,
+			'url'                      => $raw_slug,
+			'post_id'                  => $post_id,
+			'views'                    => isset( $input['views'] ) ? (int) $input['views'] : 0,
+			'revenue'                  => isset( $input['revenue'] ) ? (float) $input['revenue'] : 0.0,
+			'rpm'                      => isset( $input['rpm'] ) ? (float) $input['rpm'] : 0.0,
+			'cpm'                      => isset( $input['cpm'] ) ? (float) $input['cpm'] : 0.0,
+			'viewability'              => isset( $input['viewability'] ) ? (float) $input['viewability'] : 0.0,
+			'fill_rate'                => isset( $input['fill_rate'] ) ? (float) $input['fill_rate'] : 0.0,
+			'impressions_per_pageview' => isset( $input['impressions_per_pageview'] ) ? (float) $input['impressions_per_pageview'] : 0.0,
+			'period_label'             => $period_label,
+			'period_start'             => $period_start,
+			'period_end'               => $period_end,
+			'import_batch'             => $batch,
+		);
+	}
+
+	if ( $switched && function_exists( 'restore_current_blog' ) ) {
+		restore_current_blog();
+	}
+
+	$rows_count = count( $records );
+
+	// Acquire the production store when the caller (production callback) did not
+	// inject one. Tests inject an in-memory fake to exercise the full path.
+	if ( null === $store ) {
+		if ( ! class_exists( 'Extrachill_Analytics_Revenue_Store' ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Revenue store is not available.',
+			);
+		}
+		$store = new Extrachill_Analytics_Revenue_Store();
+	}
+
+	$existing = $store->get_snapshot( $blog_id, $period_label, $batch );
+	$plan     = extrachill_analytics_revenue_build_ingestion_plan( $records, $existing, $mode );
+
+	$inserts  = count( $plan['inserts'] );
+	$replaces = count( $plan['replaces'] );
+	$deletes  = count( $plan['deletes'] );
+
+	$result = array(
+		'success'    => true,
+		'mode'       => $mode,
+		'dry_run'    => $dry_run,
+		'written'    => ! $dry_run,
+		'rows'       => $rows_count,
+		'resolved'   => $resolved,
+		'unresolved' => $unresolved,
+		'inserted'   => $inserts,
+		'replaced'   => $replaces,
+		'deleted'    => $dry_run ? 0 : $deletes,
+		'identity'   => array(
+			'import_batch' => $batch,
+			'period_label' => $period_label,
+			'period_start' => $period_start,
+			'period_end'   => $period_end,
+			'source'       => $identity['source'],
+			'source_site'  => $identity['source_site'],
+			'blog_id'      => $blog_id,
+		),
+	);
+
+	// Dry run reports the full plan (including deletes that WOULD happen) but
+	// mutates nothing.
+	if ( $dry_run ) {
+		$result['would_delete'] = $deletes;
+		$result['deleted']      = 0;
+		return $result;
+	}
+
+	// Nothing to write: no incoming slugs and nothing to remove is a clean
+	// idempotent no-op (e.g. an empty refreshed source clearing a snapshot only
+	// happens when existing rows exist — handled by the deletes branch below).
+	if ( 0 === $inserts && 0 === $replaces && 0 === $deletes ) {
+		return $result;
+	}
+
+	// Apply the plan atomically. On any write failure, roll back so a partially
+	// replaced snapshot never replaces a good one.
+	$txn = $store->begin();
+
+	$write_ok = true;
+	$error    = '';
+
+	foreach ( $plan['inserts'] as $rec ) {
+		if ( false === $store->upsert( $rec ) ) {
+			$write_ok = false;
+			$error    = 'Failed to insert a revenue row.';
+			break;
+		}
+	}
+
+	if ( $write_ok ) {
+		foreach ( $plan['replaces'] as $rec ) {
+			if ( false === $store->upsert( $rec ) ) {
+				$write_ok = false;
+				$error    = 'Failed to replace a revenue row.';
+				break;
+			}
+		}
+	}
+
+	if ( $write_ok && ! empty( $plan['deletes'] ) ) {
+		if ( false === $store->delete_ids( $plan['deletes'] ) ) {
+			$write_ok = false;
+			$error    = 'Failed to remove stale revenue rows.';
+		}
+	}
+
+	if ( ! $write_ok ) {
+		if ( $txn ) {
+			$store->rollback();
+		}
+		$result['success'] = false;
+		$result['written'] = false;
+		unset( $result['mode'], $result['dry_run'] );
+		$result['mode']    = $mode;
+		$result['dry_run'] = false;
+		$result['error']   = $error;
+		return $result;
+	}
+
+	if ( $txn ) {
+		$store->commit();
+	}
+
+	return $result;
+}
+
+/**
+ * Register the ingest-revenue ability.
+ */
+function extrachill_analytics_register_ingest_revenue_ability() {
+	if ( ! function_exists( 'wp_register_ability' ) ) {
+		return;
+	}
+
+	wp_register_ability(
+		'extrachill/ingest-revenue',
+		array(
+			'label'               => __( 'Ingest Revenue Snapshot', 'extrachill-analytics' ),
+			'description'         => __( 'Idempotently ingest a set of per-URL ad-revenue rows (e.g. a Mediavine period export) into the revenue store with a deterministic snapshot identity. Default mode is deterministic REPLACE: the same source/site/blog/period always lands on the SAME snapshot, updating rows in place and removing any that disappeared from the refreshed source, so re-running identical inputs never double-counts the ARC or rollups. ADDITIVE mode never deletes and requires an explicit operator-supplied snapshot identity to create a distinct parallel snapshot on purpose. Accepts normalized revenue rows plus source provenance; agnostic about the upstream source ability. Supports dry-run. Owned by analytics: validation, period/snapshot identity, replacement, resolution, and persistence all live here.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'rows'         => array(
+						'type'        => 'array',
+						'description' => __( 'Normalized per-URL revenue rows. Each row carries a slug/url plus metrics (views, revenue, rpm, cpm, viewability, fill_rate, impressions_per_pageview) and an optional pre-resolved post_id.', 'extrachill-analytics' ),
+						'default'     => array(),
+					),
+					'blog_id'      => array(
+						'type'        => 'integer',
+						'description' => __( 'Blog the rows belong to. 0 = current blog.', 'extrachill-analytics' ),
+						'default'     => 0,
+					),
+					'hostname'     => array(
+						'type'        => 'string',
+						'description' => __( 'Hostname for slug->post resolution (default extrachill.com).', 'extrachill-analytics' ),
+						'default'     => 'extrachill.com',
+					),
+					'source'       => array(
+						'type'        => 'string',
+						'description' => __( 'Source provenance slug, e.g. "mediavine". Part of the deterministic snapshot identity. Default mediavine.', 'extrachill-analytics' ),
+						'default'     => 'mediavine',
+					),
+					'source_site'  => array(
+						'type'        => 'string',
+						'description' => __( 'Source site / host the rows were pulled for. Part of the snapshot identity so the same period for different sites never collides. Defaults to the hostname.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'period'       => array(
+						'type'        => 'string',
+						'description' => __( 'Period token these rows belong to: YYYY-MM (a monthly export), YYYY (a year), or "" for the flat lifetime file. Part of the snapshot identity and the canonical period_label the ARC groups by.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'period_start' => array(
+						'type'        => 'string',
+						'description' => __( 'Explicit window start (Y-m-d) override. Defaults to the start derived from period.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'period_end'   => array(
+						'type'        => 'string',
+						'description' => __( 'Explicit window end (Y-m-d) override. Defaults to the end derived from period.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'mode'         => array(
+						'type'        => 'string',
+						'description' => __( '"replace" (default) updates the deterministic snapshot in place and removes stale rows; "additive" never deletes and requires an explicit snapshot identity to create a parallel snapshot. Additive behavior cannot happen by accident.', 'extrachill-analytics' ),
+						'default'     => 'replace',
+					),
+					'snapshot'     => array(
+						'type'        => 'string',
+						'description' => __( 'Explicit snapshot identity (batch label). REQUIRED for additive mode (the operator names the parallel snapshot). Ignored for replace, which always uses the deterministic identity.', 'extrachill-analytics' ),
+						'default'     => '',
+					),
+					'dry_run'      => array(
+						'type'        => 'boolean',
+						'description' => __( 'If true, resolve + plan but write nothing. Reported counts reflect what would happen.', 'extrachill-analytics' ),
+						'default'     => false,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'Result with success, written, mode, dry_run, counts (rows, resolved, unresolved, inserted, replaced, deleted), and the stable identity (import_batch, period_label, period_start/end, source, source_site, blog_id).', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_ingest_revenue',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => true,
+					'destructive' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for the ingest-revenue ability.
+ *
+ * @param array $input Input parameters.
+ * @return array Ingestion result.
+ */
+function extrachill_analytics_ability_ingest_revenue( $input ) {
+	$rows = isset( $input['rows'] ) && is_array( $input['rows'] ) ? $input['rows'] : array();
+
+	return extrachill_analytics_revenue_ingest_rows(
+		$rows,
+		array(
+			'blog_id'      => isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0,
+			'hostname'     => isset( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com',
+			'source'       => isset( $input['source'] ) ? (string) $input['source'] : 'mediavine',
+			'source_site'  => isset( $input['source_site'] ) ? (string) $input['source_site'] : '',
+			'period'       => isset( $input['period'] ) ? (string) $input['period'] : '',
+			'period_start' => isset( $input['period_start'] ) ? (string) $input['period_start'] : '',
+			'period_end'   => isset( $input['period_end'] ) ? (string) $input['period_end'] : '',
+			'mode'         => isset( $input['mode'] ) ? (string) $input['mode'] : 'replace',
+			'snapshot'     => isset( $input['snapshot'] ) ? (string) $input['snapshot'] : '',
+			'dry_run'      => ! empty( $input['dry_run'] ),
+		)
+	);
+}

--- a/inc/core/mediavine-csv-import.php
+++ b/inc/core/mediavine-csv-import.php
@@ -78,6 +78,46 @@ function extrachill_analytics_revenue_parse_number( $value ) {
 }
 
 /**
+ * Resolve a raw CSV/row slug to a post ID and a normalized slug key.
+ *
+ * Shared by the CSV importer and the ingestion ability so slug->post resolution
+ * and slug normalization stay in exactly one place. A resolved row keys its
+ * slug on the post's actual `post_name` (stable across URL variants); an
+ * unresolved row keys on the path's last segment. This normalized slug is the
+ * dedupe key the store's UNIQUE (blog_id, slug, period_label, import_batch)
+ * index relies on, so identical inputs must always normalize identically.
+ *
+ * Resolution (url_to_postid) always runs against the CURRENT blog — callers
+ * that import for a different blog must switch_to_blog() first so the stamped
+ * blog_id and the resolved post_id agree.
+ *
+ * @param string $raw_slug  Raw identifier from the CSV / source row (slug, path, or URL).
+ * @param string $hostname  Hostname pages map to.
+ * @return array{post_id:int,slug:string} Resolved post ID (0 when unresolved) and normalized slug.
+ */
+function extrachill_analytics_revenue_resolve_slug( $raw_slug, $hostname ) {
+	$raw_slug = trim( (string) $raw_slug );
+
+	$post_id = extrachill_analytics_revenue_resolve_post_id( $raw_slug, $hostname );
+
+	if ( $post_id > 0 && function_exists( 'get_post' ) ) {
+		$post = get_post( $post_id );
+		if ( is_object( $post ) && isset( $post->post_name ) ) {
+			$slug = $post->post_name;
+		} else {
+			$slug = trim( (string) strtok( $raw_slug, '?#' ), '/' );
+		}
+	} else {
+		$slug = trim( (string) strtok( $raw_slug, '?#' ), '/' );
+	}
+
+	return array(
+		'post_id' => $post_id,
+		'slug'    => $slug,
+	);
+}
+
+/**
  * Import a Mediavine Pages CSV into the revenue store.
  *
  * Time-awareness: the flat Mediavine pages export has NO date column — it is one
@@ -212,21 +252,14 @@ function extrachill_analytics_revenue_import_csv( $file, array $args = array() )
 
 		++$rows;
 
-		$post_id = extrachill_analytics_revenue_resolve_post_id( $raw_slug, $hostname );
+		$resolved_row = extrachill_analytics_revenue_resolve_slug( $raw_slug, $hostname );
+		$post_id      = $resolved_row['post_id'];
+		$slug         = $resolved_row['slug'];
+
 		if ( $post_id > 0 ) {
 			++$resolved;
 		} else {
 			++$unresolved;
-		}
-
-		// Normalize the slug to a stable key: prefer the post's slug when
-		// resolved, else the path's last segment.
-		if ( $post_id > 0 ) {
-			$post = get_post( $post_id );
-			$slug = $post instanceof WP_Post ? $post->post_name : $raw_slug;
-		} else {
-			$path = strtok( $raw_slug, '?#' );
-			$slug = trim( (string) $path, '/' );
 		}
 
 		$record = array(

--- a/inc/database/class-extrachill-analytics-revenue-store.php
+++ b/inc/database/class-extrachill-analytics-revenue-store.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Revenue snapshot store.
+ *
+ * A thin, cohesive wrapper over the existing revenue persistence helpers
+ * (`extrachill_analytics_revenue_get_rows()`, `extrachill_analytics_revenue_upsert()`,
+ * `extrachill_analytics_revenue_delete_ids()`, and the transaction helpers). It
+ * exists for one reason: the ingestion ability's replacement/transaction logic
+ * is load-bearing and must be unit-testable, and this repository has no
+ * WordPress-DB test scaffold. The store exposes the small set of operations the
+ * engine needs behind a duck-typed interface, so the pure decision logic can be
+ * exercised against an in-memory fake in tests while production binds to this
+ * real `$wpdb`-backed implementation.
+ *
+ * This is NOT a parallel writer: `upsert()` delegates straight to the single
+ * existing writer (`extrachill_analytics_revenue_upsert()`), and `get_snapshot()`
+ * delegates to the existing reader. There is exactly one persistence
+ * implementation; this class only groups the calls the engine makes.
+ *
+ * @package ExtraChill\Analytics
+ * @since 0.28.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Thin $wpdb-backed revenue store implementing the operations the ingestion
+ * engine depends on.
+ */
+final class Extrachill_Analytics_Revenue_Store {
+
+	/**
+	 * Return the existing rows of exactly one snapshot.
+	 *
+	 * Each row is an object including at least `id` and `slug`. Scoped to one
+	 * (blog_id, period_label, import_batch) so the caller can compute a
+	 * deterministic replace plan that never escapes the snapshot.
+	 *
+	 * @param int    $blog_id      Blog ID.
+	 * @param string $period_label Canonical period label.
+	 * @param string $import_batch Snapshot identity / batch label.
+	 * @return array<int, object> Existing snapshot rows.
+	 */
+	public function get_snapshot( $blog_id, $period_label, $import_batch ) {
+		return extrachill_analytics_revenue_get_rows(
+			array(
+				'blog_id'      => $blog_id,
+				'period_label' => $period_label,
+				'import_batch' => $import_batch,
+			)
+		);
+	}
+
+	/**
+	 * Insert or replace one snapshot row.
+	 *
+	 * Delegates to the single existing writer so there is one persistence path.
+	 *
+	 * @param array $row Record shaped per extrachill_analytics_revenue_upsert().
+	 * @return int|false Inserted/replaced row ID, or false on failure.
+	 */
+	public function upsert( array $row ) {
+		return extrachill_analytics_revenue_upsert( $row );
+	}
+
+	/**
+	 * Delete snapshot rows by primary-key ID.
+	 *
+	 * @param array<int> $ids Row IDs to delete.
+	 * @return int|false Rows deleted, or false on error.
+	 */
+	public function delete_ids( array $ids ) {
+		return extrachill_analytics_revenue_delete_ids( $ids );
+	}
+
+	/**
+	 * Begin a transaction (no-op on engines without transactions).
+	 *
+	 * @return bool
+	 */
+	public function begin() {
+		return extrachill_analytics_revenue_transaction_begin();
+	}
+
+	/**
+	 * Commit the active transaction.
+	 *
+	 * @return bool
+	 */
+	public function commit() {
+		return extrachill_analytics_revenue_transaction_commit();
+	}
+
+	/**
+	 * Roll back the active transaction.
+	 *
+	 * @return bool
+	 */
+	public function rollback() {
+		return extrachill_analytics_revenue_transaction_rollback();
+	}
+}

--- a/inc/database/class-extrachill-analytics-revenue-store.php
+++ b/inc/database/class-extrachill-analytics-revenue-store.php
@@ -74,6 +74,54 @@ final class Extrachill_Analytics_Revenue_Store {
 	}
 
 	/**
+	 * Count rows for a period that belong to a DIFFERENT batch (adoption preview).
+	 *
+	 * @param int    $blog_id      Blog ID.
+	 * @param string $period_label Canonical period label.
+	 * @param string $import_batch Canonical batch to exclude.
+	 * @return int
+	 */
+	public function count_period_other_batches( $blog_id, $period_label, $import_batch ) {
+		return extrachill_analytics_revenue_count_period_other_batches( $blog_id, $period_label, $import_batch );
+	}
+
+	/**
+	 * Adopt a period: delete every row whose batch is not the canonical one.
+	 *
+	 * Replace mode establishes one canonical snapshot per (blog, period) so the
+	 * ARC cannot double-count a legacy batch. Additive never calls this.
+	 *
+	 * @param int    $blog_id      Blog ID.
+	 * @param string $period_label Canonical period label.
+	 * @param string $import_batch Canonical batch to keep.
+	 * @return int|false Rows deleted, or false on error.
+	 */
+	public function adopt_period( $blog_id, $period_label, $import_batch ) {
+		return extrachill_analytics_revenue_delete_period_except_batch( $blog_id, $period_label, $import_batch );
+	}
+
+	/**
+	 * Acquire a named advisory lock serializing ingestion for one period.
+	 *
+	 * @param string $name    Lock name.
+	 * @param int    $timeout Seconds to wait.
+	 * @return bool
+	 */
+	public function lock( $name, $timeout = 10 ) {
+		return extrachill_analytics_revenue_lock_acquire( $name, $timeout );
+	}
+
+	/**
+	 * Release a previously acquired advisory lock.
+	 *
+	 * @param string $name Lock name.
+	 * @return bool
+	 */
+	public function unlock( $name ) {
+		return extrachill_analytics_revenue_lock_release( $name );
+	}
+
+	/**
 	 * Begin a transaction (no-op on engines without transactions).
 	 *
 	 * @return bool

--- a/inc/database/class-extrachill-analytics-revenue-store.php
+++ b/inc/database/class-extrachill-analytics-revenue-store.php
@@ -74,33 +74,6 @@ final class Extrachill_Analytics_Revenue_Store {
 	}
 
 	/**
-	 * Count rows for a period that belong to a DIFFERENT batch (adoption preview).
-	 *
-	 * @param int    $blog_id      Blog ID.
-	 * @param string $period_label Canonical period label.
-	 * @param string $import_batch Canonical batch to exclude.
-	 * @return int
-	 */
-	public function count_period_other_batches( $blog_id, $period_label, $import_batch ) {
-		return extrachill_analytics_revenue_count_period_other_batches( $blog_id, $period_label, $import_batch );
-	}
-
-	/**
-	 * Adopt a period: delete every row whose batch is not the canonical one.
-	 *
-	 * Replace mode establishes one canonical snapshot per (blog, period) so the
-	 * ARC cannot double-count a legacy batch. Additive never calls this.
-	 *
-	 * @param int    $blog_id      Blog ID.
-	 * @param string $period_label Canonical period label.
-	 * @param string $import_batch Canonical batch to keep.
-	 * @return int|false Rows deleted, or false on error.
-	 */
-	public function adopt_period( $blog_id, $period_label, $import_batch ) {
-		return extrachill_analytics_revenue_delete_period_except_batch( $blog_id, $period_label, $import_batch );
-	}
-
-	/**
 	 * Acquire a named advisory lock serializing ingestion for one period.
 	 *
 	 * @param string $name    Lock name.

--- a/inc/database/mediavine-revenue-db.php
+++ b/inc/database/mediavine-revenue-db.php
@@ -339,6 +339,83 @@ function extrachill_analytics_revenue_get_timeseries( array $args = array() ) {
 }
 
 /**
+ * Delete revenue snapshot rows by their primary-key IDs.
+ *
+ * Scoped deletion used by the ingestion ability's deterministic-replace path to
+ * remove rows that belonged to a snapshot but disappeared from a refreshed
+ * source. Callers MUST pass IDs they obtained from a snapshot query scoped to
+ * exactly one (blog_id, period_label, import_batch) so the delete can never
+ * escape that snapshot. There is intentionally no "delete by slug" helper here:
+ * the caller always holds the concrete row IDs it intends to remove.
+ *
+ * @param array<int> $ids Row IDs to delete.
+ * @return int|false Number of rows deleted, or false on error.
+ */
+function extrachill_analytics_revenue_delete_ids( array $ids ) {
+	$ids = array_values(
+		array_filter(
+			array_map( 'intval', $ids ),
+			static function ( $id ) {
+				return $id > 0;
+			}
+		)
+	);
+
+	if ( empty( $ids ) ) {
+		return 0;
+	}
+
+	global $wpdb;
+
+	$table        = extrachill_analytics_revenue_table();
+	$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+	$sql          = "DELETE FROM {$table} WHERE id IN ({$placeholders})";
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$result = $wpdb->query( $wpdb->prepare( $sql, $ids ) );
+
+	return false === $result ? false : (int) $result;
+}
+
+/**
+ * Begin a transaction around a revenue snapshot mutation.
+ *
+ * A no-op safety net on storage engines without transactions (e.g. MyISAM); on
+ * InnoDB it makes the ingestion ability's replace path (upserts + stale-row
+ * deletes) atomic so a mid-snapshot failure rolls back to the prior snapshot
+ * instead of leaving a half-replaced one.
+ *
+ * @return bool True on success (or when unsupported), false on error.
+ */
+function extrachill_analytics_revenue_transaction_begin() {
+	global $wpdb;
+	$result = $wpdb->query( 'START TRANSACTION' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+	return false !== $result;
+}
+
+/**
+ * Commit the active revenue mutation transaction.
+ *
+ * @return bool True on success, false on error.
+ */
+function extrachill_analytics_revenue_transaction_commit() {
+	global $wpdb;
+	$result = $wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+	return false !== $result;
+}
+
+/**
+ * Roll back the active revenue mutation transaction.
+ *
+ * @return bool True on success, false on error.
+ */
+function extrachill_analytics_revenue_transaction_rollback() {
+	global $wpdb;
+	$result = $wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+	return false !== $result;
+}
+
+/**
  * Resolve an operator-supplied period token into a canonical label + date range.
  *
  * The flat Mediavine pages export has NO date column, so the operator passes the

--- a/inc/database/mediavine-revenue-db.php
+++ b/inc/database/mediavine-revenue-db.php
@@ -416,6 +416,90 @@ function extrachill_analytics_revenue_transaction_rollback() {
 }
 
 /**
+ * Count snapshot rows for a period that belong to a DIFFERENT batch.
+ *
+ * Used by the ingestion ability's replace path to detect legacy / stray
+ * snapshots for the same canonical period — the ARC groups by period_label and
+ * SUMs every batch, so a second batch for one period silently doubles totals.
+ * Counting them (without deleting) lets dry runs and result reporting disclose
+ * how many rows adoption WOULD sweep.
+ *
+ * @param int    $blog_id      Blog ID.
+ * @param string $period_label Canonical period label.
+ * @param string $import_batch The canonical batch to EXCLUDE.
+ * @return int Number of rows in other batches for this blog/period.
+ */
+function extrachill_analytics_revenue_count_period_other_batches( $blog_id, $period_label, $import_batch ) {
+	global $wpdb;
+
+	$table = extrachill_analytics_revenue_table();
+	$sql   = "SELECT COUNT(*) FROM {$table} WHERE blog_id = %d AND period_label = %s AND import_batch <> %s";
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	return (int) $wpdb->get_var( $wpdb->prepare( $sql, $blog_id, $period_label, $import_batch ) );
+}
+
+/**
+ * Delete every snapshot row for a period EXCEPT the canonical batch (adoption).
+ *
+ * Replace mode establishes ONE canonical snapshot per (blog, period) so the ARC
+ * cannot double-count a legacy filename-derived batch left over from the old
+ * importer flow. This is scoped to (blog_id, period_label) and excludes the
+ * canonical batch, so it can never touch another period and never deletes the
+ * rows just written. Additive mode never calls this — a parallel snapshot is
+ * intentional and must survive.
+ *
+ * @param int    $blog_id      Blog ID.
+ * @param string $period_label Canonical period label.
+ * @param string $import_batch The canonical batch to KEEP.
+ * @return int|false Rows deleted, or false on error.
+ */
+function extrachill_analytics_revenue_delete_period_except_batch( $blog_id, $period_label, $import_batch ) {
+	global $wpdb;
+
+	$table = extrachill_analytics_revenue_table();
+	$sql   = "DELETE FROM {$table} WHERE blog_id = %d AND period_label = %s AND import_batch <> %s";
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$result = $wpdb->query( $wpdb->prepare( $sql, $blog_id, $period_label, $import_batch ) );
+
+	return false === $result ? false : (int) $result;
+}
+
+/**
+ * Acquire a named advisory lock to serialize ingestion for one period.
+ *
+ * Concurrent refreshes of the same (blog, period) can otherwise union snapshots:
+ * each reads the prior snapshot, then both upsert/delete, re-adding rows the
+ * other removed. MySQL/MariaDB session-scoped advisory locks (GET_LOCK) are
+ * independent of transactions but bound to the connection, so acquiring one
+ * here — held until release after commit — serializes the whole critical
+ * section per period. Returns false if the lock could not be obtained within
+ * the timeout so the caller fails closed instead of racing.
+ *
+ * @param string $name    Lock name.
+ * @param int    $timeout Seconds to wait (0 = non-blocking).
+ * @return bool True if the lock was acquired.
+ */
+function extrachill_analytics_revenue_lock_acquire( $name, $timeout = 10 ) {
+	global $wpdb;
+	$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $name, $timeout ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+	return '1' === $result;
+}
+
+/**
+ * Release a previously acquired advisory lock.
+ *
+ * @param string $name Lock name.
+ * @return bool True if released.
+ */
+function extrachill_analytics_revenue_lock_release( $name ) {
+	global $wpdb;
+	$result = $wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+	return '1' === $result;
+}
+
+/**
  * Resolve an operator-supplied period token into a canonical label + date range.
  *
  * The flat Mediavine pages export has NO date column, so the operator passes the

--- a/inc/database/mediavine-revenue-db.php
+++ b/inc/database/mediavine-revenue-db.php
@@ -416,57 +416,6 @@ function extrachill_analytics_revenue_transaction_rollback() {
 }
 
 /**
- * Count snapshot rows for a period that belong to a DIFFERENT batch.
- *
- * Used by the ingestion ability's replace path to detect legacy / stray
- * snapshots for the same canonical period — the ARC groups by period_label and
- * SUMs every batch, so a second batch for one period silently doubles totals.
- * Counting them (without deleting) lets dry runs and result reporting disclose
- * how many rows adoption WOULD sweep.
- *
- * @param int    $blog_id      Blog ID.
- * @param string $period_label Canonical period label.
- * @param string $import_batch The canonical batch to EXCLUDE.
- * @return int Number of rows in other batches for this blog/period.
- */
-function extrachill_analytics_revenue_count_period_other_batches( $blog_id, $period_label, $import_batch ) {
-	global $wpdb;
-
-	$table = extrachill_analytics_revenue_table();
-	$sql   = "SELECT COUNT(*) FROM {$table} WHERE blog_id = %d AND period_label = %s AND import_batch <> %s";
-
-	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	return (int) $wpdb->get_var( $wpdb->prepare( $sql, $blog_id, $period_label, $import_batch ) );
-}
-
-/**
- * Delete every snapshot row for a period EXCEPT the canonical batch (adoption).
- *
- * Replace mode establishes ONE canonical snapshot per (blog, period) so the ARC
- * cannot double-count a legacy filename-derived batch left over from the old
- * importer flow. This is scoped to (blog_id, period_label) and excludes the
- * canonical batch, so it can never touch another period and never deletes the
- * rows just written. Additive mode never calls this — a parallel snapshot is
- * intentional and must survive.
- *
- * @param int    $blog_id      Blog ID.
- * @param string $period_label Canonical period label.
- * @param string $import_batch The canonical batch to KEEP.
- * @return int|false Rows deleted, or false on error.
- */
-function extrachill_analytics_revenue_delete_period_except_batch( $blog_id, $period_label, $import_batch ) {
-	global $wpdb;
-
-	$table = extrachill_analytics_revenue_table();
-	$sql   = "DELETE FROM {$table} WHERE blog_id = %d AND period_label = %s AND import_batch <> %s";
-
-	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$result = $wpdb->query( $wpdb->prepare( $sql, $blog_id, $period_label, $import_batch ) );
-
-	return false === $result ? false : (int) $result;
-}
-
-/**
  * Acquire a named advisory lock to serialize ingestion for one period.
  *
  * Concurrent refreshes of the same (blog, period) can otherwise union snapshots:

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -1,0 +1,663 @@
+<?php
+/**
+ * Behavioral + contract tests for the revenue ingestion ability (issue #140).
+ *
+ * The pure decision core (deterministic identity + ingestion plan) is unit-
+ * tested directly. The full engine path — resolution, replace/additive
+ * semantics, stale-row removal, idempotency, isolation, dry-run, rollback — is
+ * exercised against an in-memory fake store that mirrors the production store's
+ * contract, because this repository has no WordPress-DB test scaffold. The
+ * ability registration (annotations / schemas / permission) is locked down via
+ * a source-string contract. WordPress function stubs live in bootstrap.php.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/content-format-classifier.php';
+require_once dirname( __DIR__ ) . '/inc/database/mediavine-revenue-db.php';
+require_once dirname( __DIR__ ) . '/inc/core/mediavine-csv-import.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities/ingest-revenue.php';
+require_once dirname( __DIR__ ) . '/inc/database/class-extrachill-analytics-revenue-store.php';
+require_once __DIR__ . '/class-fake-revenue-store.php';
+
+/**
+ * Verify deterministic identity, replace/additive semantics, idempotency,
+ * isolation, dry-run, validation, resolution, rollback, and the output contract.
+ */
+final class IngestRevenueTest extends TestCase {
+
+	/**
+	 * Fake store under test.
+	 *
+	 * @var Fake_Revenue_Store
+	 */
+	private $store;
+
+	/**
+	 * Set up a fresh store and clear per-test resolution maps.
+	 */
+	protected function setUp(): void {
+		$this->store = new Fake_Revenue_Store();
+		unset( $GLOBALS['extrachill_ingest_url_map'], $GLOBALS['extrachill_ingest_post_map'] );
+	}
+
+	/**
+	 * Identical identity inputs yield identical, filename-free batches.
+	 */
+	public function test_identity_is_deterministic_and_filename_free(): void {
+		$base = array(
+			'source'      => 'mediavine',
+			'source_site' => 'extrachill.com',
+			'blog_id'     => 1,
+			'period'      => '2026-05',
+		);
+
+		$a = extrachill_analytics_revenue_snapshot_identity( $base );
+		$b = extrachill_analytics_revenue_snapshot_identity( $base );
+
+		$this->assertSame( $a['import_batch'], $b['import_batch'], 'identical inputs must yield identical batch' );
+		$this->assertSame( 'mediavine-extrachillcom-b1-2026-05', $a['import_batch'] );
+		$this->assertSame( '2026-05', $a['period_label'] );
+		$this->assertSame( '2026-05-01', $a['period_start'] );
+		$this->assertSame( '2026-05-31', $a['period_end'] );
+		$this->assertStringNotContainsString( 'tmp', $a['import_batch'] );
+	}
+
+	/**
+	 * Identity isolates across source, site, blog, and period.
+	 */
+	public function test_identity_isolates_by_source_site_blog_and_period(): void {
+		$base  = array(
+			'source'      => 'mediavine',
+			'source_site' => 'extrachill.com',
+			'blog_id'     => 1,
+			'period'      => '2026-05',
+		);
+		$batch = extrachill_analytics_revenue_snapshot_identity( $base )['import_batch'];
+
+		$other_period = extrachill_analytics_revenue_snapshot_identity( array_merge( $base, array( 'period' => '2026-06' ) ) )['import_batch'];
+		$other_blog   = extrachill_analytics_revenue_snapshot_identity( array_merge( $base, array( 'blog_id' => 7 ) ) )['import_batch'];
+		$other_site   = extrachill_analytics_revenue_snapshot_identity( array_merge( $base, array( 'source_site' => 'wire.extrachill.com' ) ) )['import_batch'];
+		$other_source = extrachill_analytics_revenue_snapshot_identity( array_merge( $base, array( 'source' => 'adthrive' ) ) )['import_batch'];
+
+		$this->assertNotSame( $batch, $other_period );
+		$this->assertNotSame( $batch, $other_blog );
+		$this->assertNotSame( $batch, $other_site );
+		$this->assertNotSame( $batch, $other_source );
+	}
+
+	/**
+	 * The plan classifies incoming slugs as inserts/replaces and stale deletes.
+	 */
+	public function test_plan_classifies_inserts_replaces_deletes(): void {
+		$records  = $this->records( array( 'a', 'b', 'd' ) );
+		$existing = array(
+			$this->existing_row( 10, 'a' ),
+			$this->existing_row( 11, 'b' ),
+			$this->existing_row( 12, 'c' ),
+		);
+
+		$plan = extrachill_analytics_revenue_build_ingestion_plan( $records, $existing, 'replace' );
+
+		$this->assertSame( array( 'd' ), $this->slugs( $plan['inserts'] ) );
+		$this->assertSame( array( 'a', 'b' ), $this->slugs( $plan['replaces'] ) );
+		$this->assertSame( array( 12 ), $plan['deletes'] );
+	}
+
+	/**
+	 * Additive plans never delete stale rows.
+	 */
+	public function test_plan_additive_never_deletes(): void {
+		$records  = $this->records( array( 'a', 'b' ) );
+		$existing = array(
+			$this->existing_row( 10, 'a' ),
+			$this->existing_row( 11, 'c' ),
+		);
+
+		$plan = extrachill_analytics_revenue_build_ingestion_plan( $records, $existing, 'additive' );
+
+		$this->assertSame( array(), $plan['deletes'], 'additive mode must never plan deletes' );
+		$this->assertSame( array( 'b' ), $this->slugs( $plan['inserts'] ) );
+		$this->assertSame( array( 'a' ), $this->slugs( $plan['replaces'] ) );
+	}
+
+	/**
+	 * A repeat run (existing == incoming) plans all replaces, zero deletes.
+	 */
+	public function test_plan_repeat_run_is_all_replaces_zero_deletes(): void {
+		$records  = $this->records( array( 'a', 'b', 'c' ) );
+		$existing = array(
+			$this->existing_row( 1, 'a' ),
+			$this->existing_row( 2, 'b' ),
+			$this->existing_row( 3, 'c' ),
+		);
+
+		$plan = extrachill_analytics_revenue_build_ingestion_plan( $records, $existing, 'replace' );
+
+		$this->assertSame( array(), $this->slugs( $plan['inserts'] ) );
+		$this->assertSame( array( 'a', 'b', 'c' ), $this->slugs( $plan['replaces'] ) );
+		$this->assertSame( array(), $plan['deletes'] );
+	}
+
+	/**
+	 * Re-running identical inputs is idempotent: totals do not double.
+	 */
+	public function test_repeat_ingest_is_idempotent_totals_unchanged(): void {
+		$rows = $this->rows(
+			array(
+				'a' => 1000.0,
+				'b' => 500.0,
+			)
+		);
+
+		$first = $this->ingest( $rows, array( 'period' => '2026-05' ) );
+		$this->assertTrue( $first['success'] );
+		$this->assertSame( 2, $first['inserted'] );
+		$this->assertSame( 0, $first['replaced'] );
+		$this->assertSame( 0, $first['deleted'] );
+
+		$totals_after_first = $this->store_totals( '2026-05' );
+
+		$second = $this->ingest( $rows, array( 'period' => '2026-05' ) );
+		$this->assertTrue( $second['success'] );
+		$this->assertSame( 0, $second['inserted'], 'no new slugs on repeat' );
+		$this->assertSame( 2, $second['replaced'] );
+		$this->assertSame( 0, $second['deleted'] );
+
+		$this->assertSame( $totals_after_first, $this->store_totals( '2026-05' ) );
+		$this->assertSame( $first['identity']['import_batch'], $second['identity']['import_batch'] );
+	}
+
+	/**
+	 * Replace mode removes rows that disappeared from the refreshed source.
+	 */
+	public function test_replace_removes_stale_rows_that_disappeared(): void {
+		$this->ingest(
+			$this->rows(
+				array(
+					'a' => 100.0,
+					'b' => 50.0,
+					'c' => 25.0,
+				)
+			),
+			array( 'period' => '2026-05' )
+		);
+		$this->assertCount( 3, $this->store_records( '2026-05' ) );
+
+		$result = $this->ingest(
+			$this->rows(
+				array(
+					'a' => 100.0,
+					'b' => 50.0,
+				)
+			),
+			array( 'period' => '2026-05' )
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 0, $result['inserted'] );
+		$this->assertSame( 2, $result['replaced'] );
+		$this->assertSame( 1, $result['deleted'], 'stale row c must be removed' );
+
+		$this->assertSame( array( 'a', 'b' ), $this->slugs( $this->store_records( '2026-05' ) ) );
+	}
+
+	/**
+	 * Replace updates changed metrics in place without duplicating.
+	 */
+	public function test_replace_updates_changed_metrics_in_place(): void {
+		$this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+		$this->ingest(
+			array(
+				array(
+					'slug'    => '/a/',
+					'views'   => 2000,
+					'revenue' => 300.0,
+				),
+			),
+			array( 'period' => '2026-05' )
+		);
+
+		$totals = $this->store_totals( '2026-05' );
+		$this->assertSame( 300.0, $totals['revenue'] );
+		$this->assertSame( 2000, $totals['views'] );
+	}
+
+	/**
+	 * Additive mode without an explicit snapshot is rejected and writes nothing.
+	 */
+	public function test_additive_without_explicit_snapshot_is_rejected(): void {
+		$result = $this->ingest(
+			$this->rows( array( 'a' => 1.0 ) ),
+			array(
+				'period' => '2026-05',
+				'mode'   => 'additive',
+			)
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'additive mode requires an explicit snapshot', $result['error'] );
+		$this->assertSame( 0, count( $this->store->rows ) );
+	}
+
+	/**
+	 * Additive mode never deletes and creates a distinct parallel snapshot.
+	 */
+	public function test_additive_never_removes_stale_and_creates_distinct_snapshot(): void {
+		$this->ingest(
+			$this->rows(
+				array(
+					'a' => 100.0,
+					'b' => 50.0,
+					'c' => 25.0,
+				)
+			),
+			array( 'period' => '2026-05' )
+		);
+		$replace_batch = extrachill_analytics_revenue_snapshot_identity(
+			array(
+				'source'      => 'mediavine',
+				'source_site' => 'extrachill.com',
+				'blog_id'     => 1,
+				'period'      => '2026-05',
+			)
+		)['import_batch'];
+
+		$result = $this->ingest(
+			$this->rows(
+				array(
+					'a' => 100.0,
+					'b' => 50.0,
+				)
+			),
+			array(
+				'period'   => '2026-05',
+				'mode'     => 'additive',
+				'snapshot' => 'manual-recheck-2026-05',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 0, $result['deleted'], 'additive must not delete' );
+		$this->assertSame( 'manual-recheck-2026-05', $result['identity']['import_batch'] );
+		$this->assertNotSame( $replace_batch, $result['identity']['import_batch'] );
+
+		$this->assertCount( 3, $this->store->snapshot_records( 1, '2026-05', $replace_batch ) );
+		$this->assertCount( 2, $this->store->snapshot_records( 1, '2026-05', 'manual-recheck-2026-05' ) );
+	}
+
+	/**
+	 * Different periods land in different snapshots and never collide.
+	 */
+	public function test_different_periods_do_not_collide(): void {
+		$this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+		$this->ingest( $this->rows( array( 'a' => 200.0 ) ), array( 'period' => '2026-06' ) );
+
+		$this->assertSame( 100.0, $this->store_totals( '2026-05' )['revenue'] );
+		$this->assertSame( 200.0, $this->store_totals( '2026-06' )['revenue'] );
+	}
+
+	/**
+	 * Different blogs are isolated even for the same period/slug.
+	 */
+	public function test_different_blogs_do_not_collide(): void {
+		$this->ingest(
+			$this->rows( array( 'a' => 100.0 ) ),
+			array(
+				'period'  => '2026-05',
+				'blog_id' => 1,
+			)
+		);
+		$this->ingest(
+			$this->rows( array( 'a' => 999.0 ) ),
+			array(
+				'period'  => '2026-05',
+				'blog_id' => 7,
+			)
+		);
+
+		$blog1 = array_filter(
+			$this->store->rows,
+			static function ( $r ) {
+				return 1 === (int) $r['blog_id'];
+			}
+		);
+		$blog7 = array_filter(
+			$this->store->rows,
+			static function ( $r ) {
+				return 7 === (int) $r['blog_id'];
+			}
+		);
+
+		$this->assertCount( 1, $blog1 );
+		$this->assertCount( 1, $blog7 );
+		$this->assertSame( 100.0, (float) reset( $blog1 )['revenue'] );
+		$this->assertSame( 999.0, (float) reset( $blog7 )['revenue'] );
+	}
+
+	/**
+	 * Dry run reports the full plan (including would-delete) but writes nothing.
+	 */
+	public function test_dry_run_writes_nothing_but_reports_plan(): void {
+		$this->ingest(
+			$this->rows(
+				array(
+					'a' => 100.0,
+					'b' => 50.0,
+					'c' => 25.0,
+				)
+			),
+			array( 'period' => '2026-05' )
+		);
+
+		$result = $this->ingest(
+			$this->rows(
+				array(
+					'a' => 100.0,
+					'b' => 50.0,
+				)
+			),
+			array(
+				'period'  => '2026-05',
+				'dry_run' => true,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['written'] );
+		$this->assertTrue( $result['dry_run'] );
+		$this->assertSame( 0, $result['inserted'] );
+		$this->assertSame( 2, $result['replaced'] );
+		$this->assertSame( 0, $result['deleted'], 'dry run must report zero actual deletes' );
+		$this->assertSame( 1, $result['would_delete'], 'dry run reports what it WOULD delete' );
+		$this->assertCount( 3, $this->store_records( '2026-05' ) );
+	}
+
+	/**
+	 * Dry run on an empty store writes nothing.
+	 */
+	public function test_dry_run_on_empty_store_writes_nothing(): void {
+		$result = $this->ingest(
+			$this->rows( array( 'a' => 100.0 ) ),
+			array(
+				'period'  => '2026-05',
+				'dry_run' => true,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['written'] );
+		$this->assertSame( 1, $result['inserted'] );
+		$this->assertSame( 0, count( $this->store->rows ) );
+	}
+
+	/**
+	 * An invalid mode is rejected with an error and no writes.
+	 */
+	public function test_invalid_mode_is_rejected(): void {
+		$result = $this->ingest(
+			$this->rows( array( 'a' => 1.0 ) ),
+			array(
+				'period' => '2026-05',
+				'mode'   => 'bogus',
+			)
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'mode must be', $result['error'] );
+	}
+
+	/**
+	 * Empty input rows is a clean, successful no-op.
+	 */
+	public function test_empty_rows_is_a_clean_noop(): void {
+		$result = $this->ingest( array(), array( 'period' => '2026-05' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 0, $result['rows'] );
+		$this->assertSame( 0, $result['inserted'] );
+	}
+
+	/**
+	 * Resolution counts one resolved post and one unresolved route.
+	 */
+	public function test_resolution_counts_resolved_and_unresolved(): void {
+		$GLOBALS['extrachill_ingest_url_map']  = array( '/some-post/' => 42 );
+		$GLOBALS['extrachill_ingest_post_map'] = array( 42 => 'some-post' );
+
+		$result = $this->ingest(
+			array(
+				array(
+					'slug'    => '/some-post/',
+					'revenue' => 10.0,
+				),
+				array(
+					'slug'    => '/old-ghost.html',
+					'revenue' => 1.0,
+				),
+			),
+			array( 'period' => '2026-05' )
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['resolved'] );
+		$this->assertSame( 1, $result['unresolved'] );
+		$this->assertSame( 2, $result['rows'] );
+	}
+
+	/**
+	 * A mid-write failure rolls the snapshot back and reports an error.
+	 */
+	public function test_mid_write_failure_rolls_back_and_reports_error(): void {
+		$this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+		$before = $this->store_records( '2026-05' );
+
+		$this->store->fail_upsert_after = 1;
+
+		$result = $this->ingest(
+			$this->rows(
+				array(
+					'a' => 100.0,
+					'b' => 50.0,
+					'c' => 25.0,
+				)
+			),
+			array( 'period' => '2026-05' )
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertFalse( $result['written'] );
+		$this->assertStringContainsString( 'Failed to', $result['error'] );
+
+		$after = $this->store_records( '2026-05' );
+		$this->assertSame( $this->slugs( $before ), $this->slugs( $after ) );
+		$this->assertCount( 1, $after );
+	}
+
+	/**
+	 * The output exposes all required count and identity keys.
+	 */
+	public function test_output_contract_keys(): void {
+		$result = $this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+
+		$this->assertArrayHasKey( 'success', $result );
+		$this->assertArrayHasKey( 'written', $result );
+		$this->assertArrayHasKey( 'mode', $result );
+		$this->assertArrayHasKey( 'dry_run', $result );
+		foreach ( array( 'rows', 'resolved', 'unresolved', 'inserted', 'replaced', 'deleted' ) as $key ) {
+			$this->assertArrayHasKey( $key, $result, "output must report $key" );
+		}
+
+		$identity = $result['identity'];
+		foreach ( array( 'import_batch', 'period_label', 'period_start', 'period_end', 'source', 'source_site', 'blog_id' ) as $key ) {
+			$this->assertArrayHasKey( $key, $identity, "identity must report $key" );
+		}
+
+		$this->assertSame( '2026-05', $identity['period_label'] );
+		$this->assertSame( 'mediavine', $identity['source'] );
+	}
+
+	/**
+	 * Registration marks the mutation destructive, idempotent, and gated.
+	 */
+	public function test_registration_marks_mutation_destructive_and_gates_permissions(): void {
+		$source = $this->ability_source();
+
+		$this->assertStringContainsString( "'readonly'    => false", $source );
+		$this->assertStringContainsString( "'destructive' => true", $source );
+		$this->assertStringContainsString( "'idempotent'  => true", $source );
+		$this->assertStringContainsString( "current_user_can( 'manage_options' )", $source );
+		$this->assertStringContainsString( 'defined( \'WP_CLI\' ) && WP_CLI', $source );
+		$this->assertStringContainsString( "'rows'", $source );
+		$this->assertStringContainsString( "'mode'", $source );
+		$this->assertStringContainsString( "'snapshot'", $source );
+		$this->assertStringContainsString( "'dry_run'", $source );
+		$this->assertStringContainsString( 'inserted', $source );
+		$this->assertStringContainsString( 'replaced', $source );
+		$this->assertStringContainsString( 'deleted', $source );
+		$this->assertStringContainsString( 'additive mode requires an explicit snapshot', $source );
+	}
+
+	/**
+	 * Registration uses the deterministic identity helper (never a filename).
+	 */
+	public function test_registration_uses_deterministic_identity_not_filename(): void {
+		$source = $this->ability_source();
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_snapshot_identity', $source );
+		$this->assertStringContainsString( "sanitize_key( (string) \$args['source'] )", $source );
+	}
+
+	/**
+	 * Run the engine with the fake store.
+	 *
+	 * @param array $rows  Input revenue rows.
+	 * @param array $args  Ingestion options.
+	 * @return array Engine result.
+	 */
+	private function ingest( array $rows, array $args ): array {
+		$args = array_merge(
+			array(
+				'blog_id' => 1,
+				'source'  => 'mediavine',
+			),
+			$args
+		);
+		return extrachill_analytics_revenue_ingest_rows( $rows, $args, $this->store );
+	}
+
+	/**
+	 * Build slug-keyed revenue rows.
+	 *
+	 * @param array<string,float> $slug_to_revenue Map of slug => revenue.
+	 * @return array<int, array>
+	 */
+	private function rows( array $slug_to_revenue ): array {
+		$out = array();
+		foreach ( $slug_to_revenue as $slug => $revenue ) {
+			$out[] = array(
+				'slug'    => '/' . $slug . '/',
+				'views'   => 1000,
+				'revenue' => (float) $revenue,
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Build minimal slug-only records.
+	 *
+	 * @param array<int, string> $slugs Slugs.
+	 * @return array<int, array>
+	 */
+	private function records( array $slugs ): array {
+		$out = array();
+		foreach ( $slugs as $slug ) {
+			$out[] = array( 'slug' => $slug );
+		}
+		return $out;
+	}
+
+	/**
+	 * Build a fake existing snapshot row object.
+	 *
+	 * @param int    $id   Row id.
+	 * @param string $slug Slug.
+	 * @return stdClass
+	 */
+	private function existing_row( $id, $slug ): stdClass {
+		$r       = new stdClass();
+		$r->id   = $id;
+		$r->slug = $slug;
+		return $r;
+	}
+
+	/**
+	 * Pull slugs from a list of records/objects.
+	 *
+	 * @param array $records Records (arrays or objects).
+	 * @return array<int, string>
+	 */
+	private function slugs( array $records ): array {
+		$out = array();
+		foreach ( $records as $rec ) {
+			$slug = is_object( $rec ) && isset( $rec->slug ) ? $rec->slug : ( isset( $rec['slug'] ) ? $rec['slug'] : null );
+			if ( null !== $slug ) {
+				$out[] = (string) $slug;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Snapshot records for a period on the deterministic identity.
+	 *
+	 * @param string $period Period token.
+	 * @return array<int, array>
+	 */
+	private function store_records( $period ): array {
+		$identity = $this->identity( $period );
+		return $this->store->snapshot_records( 1, $identity['period_label'], $identity['import_batch'] );
+	}
+
+	/**
+	 * Snapshot totals (views, revenue) for a period.
+	 *
+	 * @param string $period Period token.
+	 * @return array{views:int,revenue:float}
+	 */
+	private function store_totals( $period ): array {
+		$identity = $this->identity( $period );
+		return $this->store->snapshot_totals( 1, $identity['period_label'], $identity['import_batch'] );
+	}
+
+	/**
+	 * Resolve the deterministic identity for a period on the default source/site.
+	 *
+	 * @param string $period Period token.
+	 * @return array Identity.
+	 */
+	private function identity( $period ): array {
+		return extrachill_analytics_revenue_snapshot_identity(
+			array(
+				'source'      => 'mediavine',
+				'source_site' => 'extrachill.com',
+				'blog_id'     => 1,
+				'period'      => $period,
+			)
+		);
+	}
+
+	/**
+	 * Read the production ability source for a string-contract assertion.
+	 *
+	 * @return string
+	 */
+	private function ability_source(): string {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- reading a local source file.
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/abilities/ingest-revenue.php' );
+		$this->assertNotFalse( $source );
+		return $source;
+	}
+}

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -643,6 +643,7 @@ final class IngestRevenueTest extends TestCase {
 		$rows = $this->rows( array( 'a' => 1.0 ) );
 
 		$this->assertFalse( $this->ingest( $rows, array( 'period' => '2026-13' ) )['success'] );
+		$this->assertFalse( $this->ingest( $rows, array( 'period' => 'May 2026' ) )['success'] );
 		$this->assertFalse( $this->ingest( $rows, array( 'period_start' => '2026-05-02' ) )['success'] );
 		$this->assertFalse(
 			$this->ingest(
@@ -662,6 +663,34 @@ final class IngestRevenueTest extends TestCase {
 				)
 			)['success']
 		);
+
+		$canonical = $this->identity( '2026-05' )['import_batch'];
+		$this->assertFalse(
+			$this->ingest(
+				$rows,
+				array(
+					'period'   => '2026-05',
+					'mode'     => 'additive',
+					'snapshot' => $canonical,
+				)
+			)['success']
+		);
+	}
+
+	/**
+	 * Replace checks the target site while additive always requires network auth.
+	 */
+	public function test_target_blog_and_network_authorization(): void {
+		$GLOBALS['extrachill_ingest_capabilities'] = array( 'manage_options' => true );
+		$this->assertTrue( extrachill_analytics_revenue_ingest_authorize( 1, 'replace' ) );
+		$this->assertFalse( extrachill_analytics_revenue_ingest_authorize( 7, 'replace' ) );
+		$this->assertFalse( extrachill_analytics_revenue_ingest_authorize( 1, 'additive' ) );
+
+		$GLOBALS['extrachill_ingest_site_capabilities'][7]['manage_options'] = true;
+		$this->assertTrue( extrachill_analytics_revenue_ingest_authorize( 7, 'replace' ) );
+
+		$GLOBALS['extrachill_ingest_capabilities']['manage_network_options'] = true;
+		$this->assertTrue( extrachill_analytics_revenue_ingest_authorize( 7, 'additive' ) );
 	}
 
 	/**

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -40,7 +40,7 @@ final class IngestRevenueTest extends TestCase {
 	 */
 	protected function setUp(): void {
 		$this->store = new Fake_Revenue_Store();
-		unset( $GLOBALS['extrachill_ingest_url_map'], $GLOBALS['extrachill_ingest_post_map'] );
+		unset( $GLOBALS['extrachill_ingest_url_map'], $GLOBALS['extrachill_ingest_post_map'], $GLOBALS['extrachill_ingest_capabilities'], $GLOBALS['extrachill_ingest_site_capabilities'] );
 	}
 
 	/**
@@ -58,11 +58,31 @@ final class IngestRevenueTest extends TestCase {
 		$b = extrachill_analytics_revenue_snapshot_identity( $base );
 
 		$this->assertSame( $a['import_batch'], $b['import_batch'], 'identical inputs must yield identical batch' );
-		$this->assertSame( 'mediavine-extrachillcom-b1-2026-05', $a['import_batch'] );
+		$this->assertMatchesRegularExpression( '/^mediavine-extrachillcom-b1-2026-05-[a-f0-9]{12}$/', $a['import_batch'] );
 		$this->assertSame( '2026-05', $a['period_label'] );
 		$this->assertSame( '2026-05-01', $a['period_start'] );
 		$this->assertSame( '2026-05-31', $a['period_end'] );
 		$this->assertStringNotContainsString( 'tmp', $a['import_batch'] );
+		$this->assertLessThanOrEqual( 64, strlen( $a['import_batch'] ) );
+	}
+
+	/**
+	 * Hash suffixes prevent sanitized and truncated identity collisions.
+	 */
+	public function test_identity_hash_prevents_sanitization_and_truncation_collisions(): void {
+		$base = array(
+			'blog_id' => 1,
+			'period'  => '2026-05',
+		);
+
+		$dotted = extrachill_analytics_revenue_snapshot_identity( array_merge( $base, array( 'source_site' => 'a.b' ) ) );
+		$plain  = extrachill_analytics_revenue_snapshot_identity( array_merge( $base, array( 'source_site' => 'ab' ) ) );
+		$long_a = extrachill_analytics_revenue_snapshot_identity( array_merge( $base, array( 'source_site' => str_repeat( 'a', 100 ) . 'x' ) ) );
+		$long_b = extrachill_analytics_revenue_snapshot_identity( array_merge( $base, array( 'source_site' => str_repeat( 'a', 100 ) . 'y' ) ) );
+
+		$this->assertNotSame( $dotted['import_batch'], $plain['import_batch'] );
+		$this->assertNotSame( $long_a['import_batch'], $long_b['import_batch'] );
+		$this->assertLessThanOrEqual( 64, strlen( $long_a['import_batch'] ) );
 	}
 
 	/**
@@ -394,6 +414,18 @@ final class IngestRevenueTest extends TestCase {
 	}
 
 	/**
+	 * A real replace inserts all rows when the canonical snapshot is empty.
+	 */
+	public function test_replace_writes_when_existing_snapshot_is_empty(): void {
+		$result = $this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( $result['written'] );
+		$this->assertSame( 1, $result['inserted'] );
+		$this->assertCount( 1, $this->store_records( '2026-05' ) );
+	}
+
+	/**
 	 * An invalid mode is rejected with an error and no writes.
 	 */
 	public function test_invalid_mode_is_rejected(): void {
@@ -410,14 +442,14 @@ final class IngestRevenueTest extends TestCase {
 	}
 
 	/**
-	 * Empty input rows is a clean, successful no-op.
+	 * Empty input rows are rejected so a source outage cannot clear a snapshot.
 	 */
-	public function test_empty_rows_is_a_clean_noop(): void {
+	public function test_empty_rows_are_rejected(): void {
 		$result = $this->ingest( array(), array( 'period' => '2026-05' ) );
 
-		$this->assertTrue( $result['success'] );
-		$this->assertSame( 0, $result['rows'] );
-		$this->assertSame( 0, $result['inserted'] );
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'non-empty', $result['error'] );
+		$this->assertEmpty( $this->store->rows );
 	}
 
 	/**
@@ -477,6 +509,162 @@ final class IngestRevenueTest extends TestCase {
 	}
 
 	/**
+	 * The first replace adopts a legacy batch so period totals cannot double.
+	 */
+	public function test_replace_adopts_legacy_batch_without_double_counting(): void {
+		$this->store->rows[] = array(
+			'id'           => 99,
+			'blog_id'      => 1,
+			'slug'         => 'a',
+			'period_label' => '2026-05',
+			'import_batch' => 'mediavine-pages-random-csv',
+			'views'        => 1000,
+			'revenue'      => 100.0,
+		);
+
+		$result = $this->ingest(
+			$this->rows(
+				array(
+					'a' => 150.0,
+					'b' => 50.0,
+				)
+			),
+			array( 'period' => '2026-05' )
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['adopted'] );
+		$this->assertSame(
+			array(
+				'views'   => 2000,
+				'revenue' => 200.0,
+			),
+			$this->store->period_totals( 1, '2026-05' )
+		);
+	}
+
+	/**
+	 * The write path starts its transaction and takes its period lock before read.
+	 */
+	public function test_write_begins_and_locks_before_reading_snapshot(): void {
+		$result = $this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 'begin', 'lock', 'read' ), array_slice( $this->store->operation_log, 0, 3 ) );
+	}
+
+	/**
+	 * Begin failure aborts before any lock, read, or write.
+	 */
+	public function test_begin_failure_fails_closed_before_read(): void {
+		$this->store->fail_begin = true;
+		$result                  = $this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'begin' ), $this->store->operation_log );
+		$this->assertEmpty( $this->store->rows );
+	}
+
+	/**
+	 * Lock failure rolls the open transaction back before returning an error.
+	 */
+	public function test_lock_failure_rolls_back_and_never_reads(): void {
+		$this->store->fail_lock = true;
+		$result                 = $this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( array( 'begin', 'lock', 'rollback' ), $this->store->operation_log );
+		$this->assertEmpty( $this->store->rows );
+	}
+
+	/**
+	 * Commit failure rolls all writes back and releases the lock.
+	 */
+	public function test_commit_failure_rolls_back_and_fails_closed(): void {
+		$this->store->fail_commit = true;
+		$result                   = $this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'commit', $result['error'] );
+		$this->assertContains( 'rollback', $this->store->operation_log );
+		$this->assertContains( 'unlock', $this->store->operation_log );
+		$this->assertEmpty( $this->store->rows );
+	}
+
+	/**
+	 * A failed rollback remains a hard failure and is disclosed to the caller.
+	 */
+	public function test_rollback_failure_is_reported_and_never_returns_success(): void {
+		$this->store->fail_commit   = true;
+		$this->store->fail_rollback = true;
+		$result                     = $this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertFalse( $result['written'] );
+		$this->assertStringContainsString( 'Rollback also failed', $result['error'] );
+		$this->assertSame( array( 'begin', 'lock', 'read', 'commit', 'rollback', 'unlock' ), $this->store->operation_log );
+	}
+
+	/**
+	 * Duplicate raw routes that normalize to one slug keep only the final row.
+	 */
+	public function test_duplicate_normalized_rows_are_deduped(): void {
+		$result = $this->ingest(
+			array(
+				array(
+					'slug'    => '/a/',
+					'views'   => 100,
+					'revenue' => 10.0,
+				),
+				array(
+					'slug'    => 'a',
+					'views'   => 200,
+					'revenue' => 20.0,
+				),
+			),
+			array( 'period' => '2026-05' )
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['duplicate_rows_deduped'] );
+		$this->assertSame(
+			array(
+				'views'   => 200,
+				'revenue' => 20.0,
+			),
+			$this->store_totals( '2026-05' )
+		);
+	}
+
+	/**
+	 * Malformed period/date windows and invalid batch labels are rejected.
+	 */
+	public function test_period_date_and_additive_batch_validation(): void {
+		$rows = $this->rows( array( 'a' => 1.0 ) );
+
+		$this->assertFalse( $this->ingest( $rows, array( 'period' => '2026-13' ) )['success'] );
+		$this->assertFalse( $this->ingest( $rows, array( 'period_start' => '2026-05-02' ) )['success'] );
+		$this->assertFalse(
+			$this->ingest(
+				$rows,
+				array(
+					'period_start' => '2026-05-02',
+					'period_end'   => '2026-05-01',
+				)
+			)['success']
+		);
+		$this->assertFalse(
+			$this->ingest(
+				$rows,
+				array(
+					'mode'     => 'additive',
+					'snapshot' => 'Invalid Label',
+				)
+			)['success']
+		);
+	}
+
+	/**
 	 * The output exposes all required count and identity keys.
 	 */
 	public function test_output_contract_keys(): void {
@@ -526,7 +714,8 @@ final class IngestRevenueTest extends TestCase {
 	public function test_registration_uses_deterministic_identity_not_filename(): void {
 		$source = $this->ability_source();
 		$this->assertStringContainsString( 'extrachill_analytics_revenue_snapshot_identity', $source );
-		$this->assertStringContainsString( "sanitize_key( (string) \$args['source'] )", $source );
+		$this->assertStringContainsString( "hash( 'sha256'", $source );
+		$this->assertStringContainsString( 'sanitize/truncation collisions', $source );
 	}
 
 	/**

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -509,15 +509,15 @@ final class IngestRevenueTest extends TestCase {
 	}
 
 	/**
-	 * The first replace adopts a legacy batch so period totals cannot double.
+	 * Replace never mutates a legacy batch; cleanup is an explicit operator action.
 	 */
-	public function test_replace_adopts_legacy_batch_without_double_counting(): void {
+	public function test_replace_preserves_legacy_batch(): void {
 		$this->store->rows[] = array(
 			'id'           => 99,
 			'blog_id'      => 1,
 			'slug'         => 'a',
 			'period_label' => '2026-05',
-			'import_batch' => 'mediavine-pages-random-csv',
+			'import_batch' => 'mediavine-revenue-a1b2c3tmp-2026-05',
 			'views'        => 1000,
 			'revenue'      => 100.0,
 		);
@@ -533,14 +533,73 @@ final class IngestRevenueTest extends TestCase {
 		);
 
 		$this->assertTrue( $result['success'] );
-		$this->assertSame( 1, $result['adopted'] );
+		$this->assertCount( 1, $this->store->snapshot_records( 1, '2026-05', 'mediavine-revenue-a1b2c3tmp-2026-05' ) );
 		$this->assertSame(
 			array(
-				'views'   => 2000,
-				'revenue' => 200.0,
+				'views'   => 3000,
+				'revenue' => 300.0,
 			),
 			$this->store->period_totals( 1, '2026-05' )
 		);
+	}
+
+	/**
+	 * A deliberate additive snapshot must survive a later canonical replace.
+	 */
+	public function test_additive_snapshot_survives_later_replace(): void {
+		$this->ingest( $this->rows( array( 'a' => 100.0 ) ), array( 'period' => '2026-05' ) );
+		$this->ingest(
+			$this->rows( array( 'a' => 25.0 ) ),
+			array(
+				'period'   => '2026-05',
+				'mode'     => 'additive',
+				'snapshot' => 'manual-recheck-2026-05',
+			)
+		);
+
+		$result = $this->ingest( $this->rows( array( 'a' => 150.0 ) ), array( 'period' => '2026-05' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $this->store->snapshot_records( 1, '2026-05', 'manual-recheck-2026-05' ) );
+	}
+
+	/**
+	 * A deterministic snapshot from another revenue source is never legacy data.
+	 */
+	public function test_alternate_source_canonical_snapshot_survives_replace(): void {
+		$alternate = $this->ingest(
+			$this->rows( array( 'a' => 25.0 ) ),
+			array(
+				'period'      => '2026-05',
+				'source'      => 'adthrive',
+				'source_site' => 'wire.extrachill.com',
+			)
+		);
+
+		$result = $this->ingest( $this->rows( array( 'a' => 150.0 ) ), array( 'period' => '2026-05' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $this->store->snapshot_records( 1, '2026-05', $alternate['identity']['import_batch'] ) );
+	}
+
+	/**
+	 * A non-temp manual batch survives replacement even when it shares a period.
+	 */
+	public function test_unrelated_manual_batch_survives_replace(): void {
+		$this->store->rows[] = array(
+			'id'           => 99,
+			'blog_id'      => 1,
+			'slug'         => 'a',
+			'period_label' => '2026-05',
+			'import_batch' => 'operator-audit-2026-05',
+			'views'        => 1000,
+			'revenue'      => 100.0,
+		);
+
+		$result = $this->ingest( $this->rows( array( 'a' => 150.0 ) ), array( 'period' => '2026-05' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $this->store->snapshot_records( 1, '2026-05', 'operator-audit-2026-05' ) );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -141,6 +141,102 @@ if ( ! function_exists( 'update_site_option' ) ) {
 		return true;
 	}
 }
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	/**
+	 * Stub for sanitize_text_field().
+	 *
+	 * @param mixed $str Input value.
+	 * @return string Scalar cast to string, else empty string.
+	 */
+	function sanitize_text_field( $str ) {
+		return is_scalar( $str ) ? (string) $str : '';
+	}
+}
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	/**
+	 * Stub for get_current_blog_id().
+	 *
+	 * @return int Always 1 in the stub.
+	 */
+	function get_current_blog_id() {
+		return 1;
+	}
+}
+if ( ! function_exists( 'switch_to_blog' ) ) {
+	/**
+	 * Stub for switch_to_blog().
+	 *
+	 * @return bool Always true.
+	 */
+	function switch_to_blog() {
+		return true;
+	}
+}
+if ( ! function_exists( 'restore_current_blog' ) ) {
+	/**
+	 * Stub for restore_current_blog().
+	 *
+	 * @return bool Always true.
+	 */
+	function restore_current_blog() {
+		return true;
+	}
+}
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	/**
+	 * Stub for wp_parse_url().
+	 *
+	 * @param string $url The URL to parse.
+	 * @return array<string,mixed> Parse components.
+	 */
+	function wp_parse_url( $url ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+		return parse_url( (string) $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+	}
+}
+if ( ! function_exists( 'url_to_postid' ) ) {
+	/**
+	 * Stub url_to_postid against a per-test map in $GLOBALS.
+	 *
+	 * Matches the supplied URL, its trimmed path, and slash-bracketed path
+	 * against the `extrachill_ingest_url_map` map so a test can key on any form.
+	 *
+	 * @param string $url URL to resolve.
+	 * @return int Post ID or 0.
+	 */
+	function url_to_postid( $url ) {
+		$map        = isset( $GLOBALS['extrachill_ingest_url_map'] ) ? $GLOBALS['extrachill_ingest_url_map'] : array();
+		$url        = (string) $url;
+		$path       = isset( wp_parse_url( $url )['path'] ) ? trim( (string) wp_parse_url( $url )['path'], '/' ) : '';
+		$candidates = array( $url, $path, '/' . $path . '/' );
+		foreach ( $candidates as $candidate ) {
+			if ( isset( $map[ $candidate ] ) ) {
+				return (int) $map[ $candidate ];
+			}
+		}
+		return 0;
+	}
+}
+if ( ! function_exists( 'get_post' ) ) {
+	/**
+	 * Stub get_post returning an object with post_name from a $GLOBALS map.
+	 *
+	 * Reads the `extrachill_ingest_post_map` map (post_id => post_name).
+	 *
+	 * @param int $id Post ID.
+	 * @return stdClass|null
+	 */
+	function get_post( $id ) {
+		$map = isset( $GLOBALS['extrachill_ingest_post_map'] ) ? $GLOBALS['extrachill_ingest_post_map'] : array();
+		$id  = (int) $id;
+		if ( isset( $map[ $id ] ) ) {
+			$post            = new stdClass();
+			$post->ID        = $id;
+			$post->post_name = $map[ $id ];
+			return $post;
+		}
+		return null;
+	}
+}
 
 require_once dirname( __DIR__ ) . '/inc/core/php-error-log.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-php-error-summary.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -162,6 +162,31 @@ if ( ! function_exists( 'get_current_blog_id' ) ) {
 		return 1;
 	}
 }
+if ( ! function_exists( 'current_user_can' ) ) {
+	/**
+	 * Stub current_user_can() against a capability map in $GLOBALS.
+	 *
+	 * @param string $capability Capability name.
+	 * @return bool Whether the test granted the capability.
+	 */
+	function current_user_can( $capability ) {
+		$caps = isset( $GLOBALS['extrachill_ingest_capabilities'] ) ? $GLOBALS['extrachill_ingest_capabilities'] : array();
+		return ! empty( $caps[ $capability ] );
+	}
+}
+if ( ! function_exists( 'current_user_can_for_site' ) ) {
+	/**
+	 * Stub target-site capability checks against a per-site map.
+	 *
+	 * @param int    $site_id    Site ID.
+	 * @param string $capability Capability name.
+	 * @return bool Whether the test granted the capability on that site.
+	 */
+	function current_user_can_for_site( $site_id, $capability ) {
+		$sites = isset( $GLOBALS['extrachill_ingest_site_capabilities'] ) ? $GLOBALS['extrachill_ingest_site_capabilities'] : array();
+		return ! empty( $sites[ (int) $site_id ][ $capability ] );
+	}
+}
 if ( ! function_exists( 'switch_to_blog' ) ) {
 	/**
 	 * Stub for switch_to_blog().

--- a/tests/class-fake-revenue-store.php
+++ b/tests/class-fake-revenue-store.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * In-memory revenue store for the ingestion ability tests.
+ *
+ * Mirrors the production store contract: get_snapshot / upsert (REPLACE on the
+ * unique key) / delete_ids / begin / commit / rollback. upsert assigns stable
+ * ids; transactions capture a restorable snapshot so rollback behavior is
+ * testable. Used by IngestRevenueTest because this repository has no
+ * WordPress-DB test scaffold.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+/**
+ * Fake revenue store mirroring the production contract.
+ */
+final class Fake_Revenue_Store {
+
+	/**
+	 * Stored snapshot rows.
+	 *
+	 * @var array<int, array>
+	 */
+	public $rows = array();
+
+	/**
+	 * Next auto-increment id.
+	 *
+	 * @var int
+	 */
+	private $next_id = 1;
+
+	/**
+	 * Restorable snapshot captured at begin().
+	 *
+	 * @var array<int, array>|null
+	 */
+	private $snapshot = null;
+
+	/**
+	 * When > 0, the Nth+1 upsert returns false to simulate a write failure.
+	 *
+	 * @var int
+	 */
+	public $fail_upsert_after = 0;
+
+	/**
+	 * Running upsert counter (for failure simulation).
+	 *
+	 * @var int
+	 */
+	public $upsert_count = 0;
+
+	/**
+	 * Return the existing rows of exactly one snapshot (objects with id, slug).
+	 *
+	 * @param int    $blog_id      Blog ID.
+	 * @param string $period_label Period label.
+	 * @param string $import_batch Batch identity.
+	 * @return array<int, stdClass>
+	 */
+	public function get_snapshot( $blog_id, $period_label, $import_batch ) {
+		$out = array();
+		foreach ( $this->rows as $r ) {
+			if ( $this->matches( $r, $blog_id, $period_label, $import_batch ) ) {
+				$obj       = new stdClass();
+				$obj->id   = (int) $r['id'];
+				$obj->slug = (string) $r['slug'];
+				$out[]     = $obj;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Insert or replace one row on the unique (blog, slug, period, batch) key.
+	 *
+	 * @param array $rec Record to write.
+	 * @return int|false Row id, or false on simulated failure.
+	 */
+	public function upsert( array $rec ) {
+		++$this->upsert_count;
+		if ( $this->fail_upsert_after > 0 && $this->upsert_count > $this->fail_upsert_after ) {
+			return false;
+		}
+		foreach ( $this->rows as $i => $r ) {
+			if ( $this->matches( $r, $rec['blog_id'], $rec['period_label'], $rec['import_batch'] ) && (string) $r['slug'] === (string) $rec['slug'] ) {
+				$rec['id']        = $r['id'];
+				$this->rows[ $i ] = $rec;
+				return (int) $rec['id'];
+			}
+		}
+		$rec['id']    = $this->next_id++;
+		$this->rows[] = $rec;
+		return (int) $rec['id'];
+	}
+
+	/**
+	 * Delete rows by primary-key id.
+	 *
+	 * @param array<int> $ids Row ids to delete.
+	 * @return int Rows deleted.
+	 */
+	public function delete_ids( array $ids ) {
+		$ids     = array_map( 'intval', $ids );
+		$removed = 0;
+		foreach ( $this->rows as $i => $r ) {
+			if ( in_array( (int) $r['id'], $ids, true ) ) {
+				unset( $this->rows[ $i ] );
+				++$removed;
+			}
+		}
+		$this->rows = array_values( $this->rows );
+		return $removed;
+	}
+
+	/**
+	 * Begin a transaction, capturing a restorable snapshot.
+	 *
+	 * @return bool
+	 */
+	public function begin() {
+		$this->snapshot = array_map(
+			static function ( $r ) {
+				return $r;
+			},
+			$this->rows
+		);
+		return true;
+	}
+
+	/**
+	 * Commit the active transaction.
+	 *
+	 * @return bool
+	 */
+	public function commit() {
+		$this->snapshot = null;
+		return true;
+	}
+
+	/**
+	 * Roll back to the snapshot captured at begin().
+	 *
+	 * @return bool
+	 */
+	public function rollback() {
+		if ( null !== $this->snapshot ) {
+			$this->rows     = $this->snapshot;
+			$this->snapshot = null;
+		}
+		return true;
+	}
+
+	/**
+	 * Return full records for one snapshot (for assertions).
+	 *
+	 * @param int    $blog_id      Blog ID.
+	 * @param string $period_label Period label.
+	 * @param string $import_batch Batch identity.
+	 * @return array<int, array>
+	 */
+	public function snapshot_records( $blog_id, $period_label, $import_batch ) {
+		$out = array();
+		foreach ( $this->rows as $r ) {
+			if ( $this->matches( $r, $blog_id, $period_label, $import_batch ) ) {
+				$out[] = $r;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Sum views + revenue for one snapshot.
+	 *
+	 * @param int    $blog_id      Blog ID.
+	 * @param string $period_label Period label.
+	 * @param string $import_batch Batch identity.
+	 * @return array{views:int,revenue:float}
+	 */
+	public function snapshot_totals( $blog_id, $period_label, $import_batch ) {
+		$views = 0;
+		$rev   = 0.0;
+		foreach ( $this->snapshot_records( $blog_id, $period_label, $import_batch ) as $r ) {
+			$views += (int) $r['views'];
+			$rev   += (float) $r['revenue'];
+		}
+		return array(
+			'views'   => $views,
+			'revenue' => round( $rev, 4 ),
+		);
+	}
+
+	/**
+	 * Does a stored row belong to the given snapshot key?
+	 *
+	 * @param array  $r            Stored row.
+	 * @param int    $blog_id      Blog ID.
+	 * @param string $period_label Period label.
+	 * @param string $import_batch Batch identity.
+	 * @return bool
+	 */
+	private function matches( array $r, $blog_id, $period_label, $import_batch ) {
+		return (int) $r['blog_id'] === (int) $blog_id
+			&& (string) $r['period_label'] === (string) $period_label
+			&& (string) $r['import_batch'] === (string) $import_batch;
+	}
+}

--- a/tests/class-fake-revenue-store.php
+++ b/tests/class-fake-revenue-store.php
@@ -3,8 +3,8 @@
  * In-memory revenue store for the ingestion ability tests.
  *
  * Mirrors the production store contract: get_snapshot / upsert (REPLACE on the
- * unique key) / delete_ids / count_period_other_batches / adopt_period /
- * begin / commit / rollback / lock / unlock. upsert assigns stable ids;
+ * unique key) / delete_ids / begin / commit / rollback / lock / unlock. upsert
+ * assigns stable ids;
  * transactions capture a restorable snapshot so rollback behavior is testable;
  * failure flags (fail_begin / fail_commit / fail_lock / fail_upsert_after) let
  * tests exercise fail-closed paths. Used by IngestRevenueTest because this
@@ -160,44 +160,6 @@ final class Fake_Revenue_Store {
 	}
 
 	/**
-	 * Count rows for a period that belong to a DIFFERENT batch (adoption preview).
-	 *
-	 * @param int    $blog_id      Blog ID.
-	 * @param string $period_label Period label.
-	 * @param string $import_batch Canonical batch to exclude.
-	 * @return int
-	 */
-	public function count_period_other_batches( $blog_id, $period_label, $import_batch ) {
-		$count = 0;
-		foreach ( $this->rows as $r ) {
-			if ( (int) $r['blog_id'] === (int) $blog_id && (string) $r['period_label'] === (string) $period_label && (string) $r['import_batch'] !== (string) $import_batch ) {
-				++$count;
-			}
-		}
-		return $count;
-	}
-
-	/**
-	 * Adopt a period: delete every row whose batch is not the canonical one.
-	 *
-	 * @param int    $blog_id      Blog ID.
-	 * @param string $period_label Period label.
-	 * @param string $import_batch Canonical batch to keep.
-	 * @return int Rows deleted.
-	 */
-	public function adopt_period( $blog_id, $period_label, $import_batch ) {
-		$removed = 0;
-		foreach ( $this->rows as $i => $r ) {
-			if ( (int) $r['blog_id'] === (int) $blog_id && (string) $r['period_label'] === (string) $period_label && (string) $r['import_batch'] !== (string) $import_batch ) {
-				unset( $this->rows[ $i ] );
-				++$removed;
-			}
-		}
-		$this->rows = array_values( $this->rows );
-		return $removed;
-	}
-
-	/**
 	 * Acquire an advisory lock (single-threaded fake: always succeeds unless flagged).
 	 *
 	 * @param string $name    Lock name.
@@ -317,7 +279,7 @@ final class Fake_Revenue_Store {
 
 	/**
 	 * Sum views + revenue across ALL batches for a (blog, period) — mirrors the
-	 * ARC's period-level SUM, so tests can prove adoption prevents doubling.
+	 * ARC's period-level SUM, so tests can assert snapshot isolation behavior.
 	 *
 	 * @param int    $blog_id      Blog ID.
 	 * @param string $period_label Period label.

--- a/tests/class-fake-revenue-store.php
+++ b/tests/class-fake-revenue-store.php
@@ -3,10 +3,12 @@
  * In-memory revenue store for the ingestion ability tests.
  *
  * Mirrors the production store contract: get_snapshot / upsert (REPLACE on the
- * unique key) / delete_ids / begin / commit / rollback. upsert assigns stable
- * ids; transactions capture a restorable snapshot so rollback behavior is
- * testable. Used by IngestRevenueTest because this repository has no
- * WordPress-DB test scaffold.
+ * unique key) / delete_ids / count_period_other_batches / adopt_period /
+ * begin / commit / rollback / lock / unlock. upsert assigns stable ids;
+ * transactions capture a restorable snapshot so rollback behavior is testable;
+ * failure flags (fail_begin / fail_commit / fail_lock / fail_upsert_after) let
+ * tests exercise fail-closed paths. Used by IngestRevenueTest because this
+ * repository has no WordPress-DB test scaffold.
  *
  * @package ExtraChill\Analytics
  */
@@ -52,6 +54,48 @@ final class Fake_Revenue_Store {
 	public $upsert_count = 0;
 
 	/**
+	 * When true, begin() returns false (fail-closed simulation).
+	 *
+	 * @var bool
+	 */
+	public $fail_begin = false;
+
+	/**
+	 * When true, commit() returns false without clearing the snapshot.
+	 *
+	 * @var bool
+	 */
+	public $fail_commit = false;
+
+	/**
+	 * When true, lock() returns false (lock-contention simulation).
+	 *
+	 * @var bool
+	 */
+	public $fail_lock = false;
+
+	/**
+	 * When true, rollback() returns false after restoring the snapshot.
+	 *
+	 * @var bool
+	 */
+	public $fail_rollback = false;
+
+	/**
+	 * Ordered store calls for transaction/lock sequencing assertions.
+	 *
+	 * @var array<int,string>
+	 */
+	public $operation_log = array();
+
+	/**
+	 * Names of currently held advisory locks (the fake is single-threaded).
+	 *
+	 * @var array<string,true>
+	 */
+	public $locks_held = array();
+
+	/**
 	 * Return the existing rows of exactly one snapshot (objects with id, slug).
 	 *
 	 * @param int    $blog_id      Blog ID.
@@ -60,7 +104,8 @@ final class Fake_Revenue_Store {
 	 * @return array<int, stdClass>
 	 */
 	public function get_snapshot( $blog_id, $period_label, $import_batch ) {
-		$out = array();
+		$this->operation_log[] = 'read';
+		$out                   = array();
 		foreach ( $this->rows as $r ) {
 			if ( $this->matches( $r, $blog_id, $period_label, $import_batch ) ) {
 				$obj       = new stdClass();
@@ -115,11 +160,84 @@ final class Fake_Revenue_Store {
 	}
 
 	/**
-	 * Begin a transaction, capturing a restorable snapshot.
+	 * Count rows for a period that belong to a DIFFERENT batch (adoption preview).
+	 *
+	 * @param int    $blog_id      Blog ID.
+	 * @param string $period_label Period label.
+	 * @param string $import_batch Canonical batch to exclude.
+	 * @return int
+	 */
+	public function count_period_other_batches( $blog_id, $period_label, $import_batch ) {
+		$count = 0;
+		foreach ( $this->rows as $r ) {
+			if ( (int) $r['blog_id'] === (int) $blog_id && (string) $r['period_label'] === (string) $period_label && (string) $r['import_batch'] !== (string) $import_batch ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
+	/**
+	 * Adopt a period: delete every row whose batch is not the canonical one.
+	 *
+	 * @param int    $blog_id      Blog ID.
+	 * @param string $period_label Period label.
+	 * @param string $import_batch Canonical batch to keep.
+	 * @return int Rows deleted.
+	 */
+	public function adopt_period( $blog_id, $period_label, $import_batch ) {
+		$removed = 0;
+		foreach ( $this->rows as $i => $r ) {
+			if ( (int) $r['blog_id'] === (int) $blog_id && (string) $r['period_label'] === (string) $period_label && (string) $r['import_batch'] !== (string) $import_batch ) {
+				unset( $this->rows[ $i ] );
+				++$removed;
+			}
+		}
+		$this->rows = array_values( $this->rows );
+		return $removed;
+	}
+
+	/**
+	 * Acquire an advisory lock (single-threaded fake: always succeeds unless flagged).
+	 *
+	 * @param string $name    Lock name.
+	 * @param int    $timeout Seconds to wait (unused in the fake).
+	 * @return bool
+	 */
+	public function lock( $name, $timeout = 10 ) {
+		$this->operation_log[] = 'lock';
+		if ( $timeout < 0 ) {
+			return false;
+		}
+		if ( $this->fail_lock ) {
+			return false;
+		}
+		$this->locks_held[ $name ] = true;
+		return true;
+	}
+
+	/**
+	 * Release an advisory lock.
+	 *
+	 * @param string $name Lock name.
+	 * @return bool
+	 */
+	public function unlock( $name ) {
+		$this->operation_log[] = 'unlock';
+		unset( $this->locks_held[ $name ] );
+		return true;
+	}
+
+	/**
+	 * Begin a transaction, capturing a restorable snapshot. Fail-closed sim.
 	 *
 	 * @return bool
 	 */
 	public function begin() {
+		$this->operation_log[] = 'begin';
+		if ( $this->fail_begin ) {
+			return false;
+		}
 		$this->snapshot = array_map(
 			static function ( $r ) {
 				return $r;
@@ -130,11 +248,16 @@ final class Fake_Revenue_Store {
 	}
 
 	/**
-	 * Commit the active transaction.
+	 * Commit the active transaction. Fail-closed sim leaves the snapshot so
+	 * rollback() can restore the pre-transaction state.
 	 *
 	 * @return bool
 	 */
 	public function commit() {
+		$this->operation_log[] = 'commit';
+		if ( $this->fail_commit ) {
+			return false;
+		}
 		$this->snapshot = null;
 		return true;
 	}
@@ -145,11 +268,12 @@ final class Fake_Revenue_Store {
 	 * @return bool
 	 */
 	public function rollback() {
+		$this->operation_log[] = 'rollback';
 		if ( null !== $this->snapshot ) {
 			$this->rows     = $this->snapshot;
 			$this->snapshot = null;
 		}
-		return true;
+		return ! $this->fail_rollback;
 	}
 
 	/**
@@ -184,6 +308,29 @@ final class Fake_Revenue_Store {
 		foreach ( $this->snapshot_records( $blog_id, $period_label, $import_batch ) as $r ) {
 			$views += (int) $r['views'];
 			$rev   += (float) $r['revenue'];
+		}
+		return array(
+			'views'   => $views,
+			'revenue' => round( $rev, 4 ),
+		);
+	}
+
+	/**
+	 * Sum views + revenue across ALL batches for a (blog, period) — mirrors the
+	 * ARC's period-level SUM, so tests can prove adoption prevents doubling.
+	 *
+	 * @param int    $blog_id      Blog ID.
+	 * @param string $period_label Period label.
+	 * @return array{views:int,revenue:float}
+	 */
+	public function period_totals( $blog_id, $period_label ) {
+		$views = 0;
+		$rev   = 0.0;
+		foreach ( $this->rows as $r ) {
+			if ( (int) $r['blog_id'] === (int) $blog_id && (string) $r['period_label'] === (string) $period_label ) {
+				$views += (int) $r['views'];
+				$rev   += (float) $r['revenue'];
+			}
 		}
 		return array(
 			'views'   => $views,


### PR DESCRIPTION
Fixes #140

## Summary

Adds `extrachill/ingest-revenue`, an idempotent revenue-snapshot mutation ability with deterministic, collision-resistant identity and explicit replace/additive modes.

- Replace mutates only its exact `(blog_id, period_label, import_batch)` snapshot: it upserts incoming rows and removes stale rows from that same snapshot. It never discovers, adopts, or deletes another batch.
- Additive requires an explicit non-colliding snapshot plus network-level authorization.
- Existing filename-derived legacy batches are deliberately untouched. A one-time operator migration or purge must be performed outside this runtime ability.
- The write path begins a transaction and takes a per-period lock before reading, fails closed on transaction/lock/write/commit errors, and rolls back before releasing the lock.
- Rows are required and non-empty; target-blog authorization, period/date/batch validation, duplicate normalized rows, complete schemas, and collision-resistant identity are covered.

## Tests

- Repeat idempotency, stale row removal, exact-snapshot isolation, dry runs, validation, and authorization.
- Begin, lock, write, commit, and rollback failure paths.
- Replace never touches legacy temp, additive, manual, or alternate-source canonical batches.

## Validation

- `./vendor/bin/phpunit --configuration phpunit.xml.dist`
- `./vendor/bin/phpcs --standard=WordPress` on changed PHP files
- `git diff --check`

No changelog/version changes. PR only: no merge, release, or deploy.