### PR TITLE
fix: expand revenue format coverage

### DIFF
--- a/inc/core/content-format-classifier.php
+++ b/inc/core/content-format-classifier.php
@@ -42,8 +42,8 @@ function extrachill_analytics_format_category_map() {
 		// Song meanings / lyric explainers — the HCU-dead but high-$/page legacy.
 		'song-meaning'     => array( 'song-meanings', 'song-meaning', 'lyrics', 'lyric-meanings' ),
 		// Music history / artist history / guitar history deep-dives.
-		'guitar-history'   => array( 'guitar-history', 'guitars', 'gear' ),
-		'music-history'    => array( 'music-history', 'history' ),
+		'guitar-history'   => array( 'guitar-history', 'guitars', 'gear', 'famous-guitars' ),
+		'music-history'    => array( 'music-history', 'history', 'band-art', 'musical-curiosities' ),
 		// Charleston / local scene — the defensible moat with an events funnel.
 		'charleston-local' => array( 'charleston', 'charleston-music', 'local', 'local-music', 'sc-music', 'south-carolina', 'columbia', 'savannah' ),
 		// Interviews / artist Q&As.

--- a/inc/core/content-format-classifier.php
+++ b/inc/core/content-format-classifier.php
@@ -43,7 +43,7 @@ function extrachill_analytics_format_category_map() {
 		'song-meaning'     => array( 'song-meanings', 'song-meaning', 'lyrics', 'lyric-meanings' ),
 		// Music history / artist history / guitar history deep-dives.
 		'guitar-history'   => array( 'guitar-history', 'guitars', 'gear', 'famous-guitars' ),
-		'music-history'    => array( 'music-history', 'history', 'band-art', 'musical-curiosities' ),
+		'music-history'    => array( 'music-history', 'history', 'band-art' ),
 		// Charleston / local scene — the defensible moat with an events funnel.
 		'charleston-local' => array( 'charleston', 'charleston-music', 'local', 'local-music', 'sc-music', 'south-carolina', 'columbia', 'savannah' ),
 		// Interviews / artist Q&As.

--- a/tests/ContentFormatClassifierTest.php
+++ b/tests/ContentFormatClassifierTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Content-format category-map tests.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/content-format-classifier.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue.php';
+
+/**
+ * Verify conservative taxonomy coverage additions preserve revenue semantics.
+ */
+final class ContentFormatClassifierTest extends TestCase {
+
+	/**
+	 * High-revenue editorial categories map to their existing semantic formats.
+	 */
+	public function test_high_revenue_categories_use_existing_formats(): void {
+		$map = extrachill_analytics_format_category_map();
+
+		$this->assertContains( 'famous-guitars', $map['guitar-history'] );
+		$this->assertContains( 'band-art', $map['music-history'] );
+		$this->assertContains( 'musical-curiosities', $map['music-history'] );
+	}
+
+	/**
+	 * A format label changes only the rollup bucket, never resolved totals.
+	 */
+	public function test_reclassification_preserves_resolved_revenue_totals(): void {
+		$record = array(
+			'is_content' => true,
+			'page_key'   => 'p145',
+			'categories' => array( 'band-art' ),
+			'views'      => 1250,
+			'revenue'    => 37.50,
+			'url'        => '/album-art-history/',
+		);
+
+		$before = extrachill_analytics_revenue_build_rollups(
+			array( array_merge( $record, array( 'format' => 'uncategorized' ) ) ),
+			'format'
+		);
+		$after  = extrachill_analytics_revenue_build_rollups(
+			array( array_merge( $record, array( 'format' => 'music-history' ) ) ),
+			'format'
+		);
+
+		$this->assertSame( $before['totals'], $after['totals'] );
+		$this->assertSame( $before['unresolved'], $after['unresolved'] );
+		$this->assertSame( 'music-history', $after['rollups']['by_format'][0]['bucket'] );
+	}
+}

--- a/tests/ContentFormatClassifierTest.php
+++ b/tests/ContentFormatClassifierTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Content-format category-map tests.
+ * Content-format classifier tests.
  *
  * @package ExtraChill\Analytics
  */
@@ -16,20 +16,58 @@ require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue.php';
 final class ContentFormatClassifierTest extends TestCase {
 
 	/**
-	 * High-revenue editorial categories map to their existing semantic formats.
+	 * Reset classifier fixtures after each test.
 	 */
-	public function test_high_revenue_categories_use_existing_formats(): void {
-		$map = extrachill_analytics_format_category_map();
-
-		$this->assertContains( 'famous-guitars', $map['guitar-history'] );
-		$this->assertContains( 'band-art', $map['music-history'] );
-		$this->assertContains( 'musical-curiosities', $map['music-history'] );
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['extrachill_analytics_classifier_posts'],
+			$GLOBALS['extrachill_analytics_classifier_permalinks'],
+			$GLOBALS['extrachill_analytics_classifier_terms']
+		);
 	}
 
 	/**
-	 * A format label changes only the rollup bucket, never resolved totals.
+	 * Configure one published post and its category fixtures.
+	 *
+	 * @param int                $id Post ID.
+	 * @param array<int, string> $categories Category slugs.
+	 * @param string             $title Post title.
 	 */
-	public function test_reclassification_preserves_resolved_revenue_totals(): void {
+	private function fixture_post( int $id, array $categories, string $title = 'Fixture post' ): void {
+		$post             = new WP_Post();
+		$post->ID         = $id;
+		$post->post_title = $title;
+
+		$GLOBALS['extrachill_analytics_classifier_posts'][ $id ]      = $post;
+		$GLOBALS['extrachill_analytics_classifier_terms'][ $id ]      = $categories;
+		$GLOBALS['extrachill_analytics_classifier_permalinks'][ $id ] = 'https://extrachill.com/fixture-' . $id . '/';
+	}
+
+	/**
+	 * Defensible revenue-bearing categories classify into their existing formats.
+	 */
+	public function test_defensible_categories_classify_into_existing_formats(): void {
+		$this->fixture_post( 145, array( 'famous-guitars' ) );
+		$this->fixture_post( 146, array( 'band-art' ) );
+
+		$this->assertSame( 'guitar-history', extrachill_analytics_classify_format( 145 ) );
+		$this->assertSame( 'music-history', extrachill_analytics_classify_format( 146 ) );
+	}
+
+	/**
+	 * The mixed root category must not override an existing listicle taxonomy.
+	 */
+	public function test_musical_curiosities_preserves_listicle_precedence(): void {
+		$this->fixture_post( 147, array( 'musical-curiosities', 'lists' ) );
+
+		$this->assertSame( 'listicle', extrachill_analytics_classify_format( 147 ) );
+	}
+
+	/**
+	 * Reclassification changes a format bucket, never totals or the unresolved partition.
+	 */
+	public function test_reclassification_preserves_totals_and_unresolved_partition(): void {
+		$this->fixture_post( 145, array( 'band-art' ) );
 		$record = array(
 			'is_content' => true,
 			'page_key'   => 'p145',
@@ -39,17 +77,26 @@ final class ContentFormatClassifierTest extends TestCase {
 			'url'        => '/album-art-history/',
 		);
 
-		$before = extrachill_analytics_revenue_build_rollups(
-			array( array_merge( $record, array( 'format' => 'uncategorized' ) ) ),
+		$unresolved = array(
+			'is_content' => false,
+			'page_key'   => 'u123',
+			'views'      => 500,
+			'revenue'    => 2.50,
+			'url'        => '/not-a-post/',
+		);
+		$before     = extrachill_analytics_revenue_build_rollups(
+			array( array_merge( $record, array( 'format' => 'uncategorized' ) ), $unresolved ),
 			'format'
 		);
-		$after  = extrachill_analytics_revenue_build_rollups(
-			array( array_merge( $record, array( 'format' => 'music-history' ) ) ),
+		$after      = extrachill_analytics_revenue_build_rollups(
+			array( array_merge( $record, array( 'format' => extrachill_analytics_classify_format( 145 ) ) ), $unresolved ),
 			'format'
 		);
 
 		$this->assertSame( $before['totals'], $after['totals'] );
 		$this->assertSame( $before['unresolved'], $after['unresolved'] );
+		$this->assertSame( 1, $after['unresolved']['pages'] );
+		$this->assertEquals( 2.50, $after['unresolved']['revenue'] );
 		$this->assertSame( 'music-history', $after['rollups']['by_format'][0]['bucket'] );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,6 +36,8 @@ if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 	define( 'WP_CONTENT_DIR', sys_get_temp_dir() . '/ec-analytics-wp-content' );
 }
 
+require_once __DIR__ . '/class-wp-post.php';
+
 // Minimal WordPress function stubs (only when a real WP is not present). These
 // are intentional polyfill stubs for the unit-test harness, written to satisfy
 // the WordPress coding standard rather than wrap WP_Filesystem.
@@ -274,8 +276,17 @@ if ( ! function_exists( 'get_post' ) ) {
 	 * @return stdClass|null
 	 */
 	function get_post( $id ) {
+		if ( $id instanceof WP_Post ) {
+			return $id;
+		}
+
+		$classifier_posts = isset( $GLOBALS['extrachill_analytics_classifier_posts'] ) ? $GLOBALS['extrachill_analytics_classifier_posts'] : array();
+		$id               = (int) $id;
+		if ( isset( $classifier_posts[ $id ] ) ) {
+			return $classifier_posts[ $id ];
+		}
+
 		$map = isset( $GLOBALS['extrachill_ingest_post_map'] ) ? $GLOBALS['extrachill_ingest_post_map'] : array();
-		$id  = (int) $id;
 		if ( isset( $map[ $id ] ) ) {
 			$post            = new stdClass();
 			$post->ID        = $id;
@@ -283,6 +294,41 @@ if ( ! function_exists( 'get_post' ) ) {
 			return $post;
 		}
 		return null;
+	}
+}
+if ( ! function_exists( 'get_permalink' ) ) {
+	/**
+	 * Return a classifier-test permalink.
+	 *
+	 * @param WP_Post|int $post Post fixture or ID.
+	 * @return string Permalink.
+	 */
+	function get_permalink( $post ) {
+		$id         = $post instanceof WP_Post ? $post->ID : (int) $post;
+		$permalinks = isset( $GLOBALS['extrachill_analytics_classifier_permalinks'] ) ? $GLOBALS['extrachill_analytics_classifier_permalinks'] : array();
+		return isset( $permalinks[ $id ] ) ? $permalinks[ $id ] : 'https://extrachill.com/post-' . $id . '/';
+	}
+}
+if ( ! function_exists( 'get_the_terms' ) ) {
+	/**
+	 * Return classifier-test category fixtures.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $taxonomy Taxonomy name.
+	 * @return array<int,object>|false Category terms or false.
+	 */
+	function get_the_terms( $post_id, $taxonomy ) {
+		$terms = isset( $GLOBALS['extrachill_analytics_classifier_terms'][ (int) $post_id ] ) ? $GLOBALS['extrachill_analytics_classifier_terms'][ (int) $post_id ] : array();
+		if ( 'category' !== $taxonomy || empty( $terms ) ) {
+			return false;
+		}
+
+		return array_map(
+			static function ( $slug ) {
+				return (object) array( 'slug' => $slug );
+			},
+			$terms
+		);
 	}
 }
 

--- a/tests/class-wp-post.php
+++ b/tests/class-wp-post.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Minimal WP_Post fixture.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+if ( ! class_exists( 'WP_Post' ) ) {
+	/**
+	 * Minimal post fixture for classifier tests.
+	 */
+	class WP_Post {
+		/**
+		 * Post ID.
+		 *
+		 * @var int
+		 */
+		public $ID;
+
+		/**
+		 * Post title.
+		 *
+		 * @var string
+		 */
+		public $post_title = '';
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #145 by extending only the existing `extrachill_analytics_format_category_map()`; no revenue rows, resolution rules, or taxonomy infrastructure change.
- Map `famous-guitars` to `guitar-history` and `band-art` to `music-history`.
- Exercise `extrachill_analytics_classify_format()` directly and preserve both rollup totals and the non-empty unresolved partition during reclassification.

## Coverage Evidence
Before (production `revenue diagnose`, lifetime scope): 1,316 of 2,085 resolved pages were `uncategorized` (63.1%).

The two defensible mapped categories account for 30 distinct currently-uncategorized resolved pages, 137,807 views, and $1,956.56 in attributed lifetime revenue. With the new map, projected coverage is 1,286 of 2,085 uncategorized pages (61.7%), a 1.4 percentage-point improvement. This is classification coverage only; imported revenue and page resolution remain unchanged.

## Mapping Rationale
- `famous-guitars` -> `guitar-history`: editorial guitar-history deep dives.
- `band-art` -> `music-history`: historical/artifact coverage of artists and albums.

## Intentionally Unmapped
`musical-curiosities` remains unmapped because it is a mixed root bucket containing explainers, facts, generators, and galleries. Mapping it to `music-history` would take precedence over `listicle` and regress ten existing listicles; a classifier fixture proves a `musical-curiosities` + `lists` post remains `listicle`.

`travel`, `spotify`, `premieres`, `music-news`, `music-business`, and `extra-chill-presents` also remain unmapped because none fits an existing format without conflating distinct editorial work.

## Verification
- `php -l inc/core/content-format-classifier.php`
- `php -l tests/bootstrap.php`
- `php -l tests/class-wp-post.php`
- `php -l tests/ContentFormatClassifierTest.php`
- `/tmp/opencode/vendor/bin/phpunit --configuration phpunit.xml.dist` (185 tests, 581 assertions)
- `/tmp/opencode/vendor/bin/phpcs --standard=WordPress --extensions=php inc/core/content-format-classifier.php tests/bootstrap.php tests/class-wp-post.php tests/ContentFormatClassifierTest.php`
- `git diff --check`
- Full-repository PHPCS was also run and remains red solely on pre-existing violations outside this diff (for example `stubs/phpstan/`, `inc/core/view-counts.php`, and existing security/docblock findings).