### PR TITLE
fix: warn on low-volume revenue rates

### DIFF
--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -303,6 +303,11 @@ function extrachill_analytics_revenue_diagnostic_totals_schema() {
 		'ratio'               => array( 'type' => 'number' ),
 		'checked'             => array( 'type' => 'integer' ),
 		'high_variance'       => array( 'type' => 'integer' ),
+		'high_rate_rows'      => array( 'type' => 'integer' ),
+		'high_rate_samples'   => array(
+			'type'  => 'array',
+			'items' => $sample,
+		),
 		'missing_batch'       => array( 'type' => 'integer' ),
 		'missing_period'      => array( 'type' => 'integer' ),
 	);
@@ -1177,6 +1182,7 @@ function extrachill_analytics_revenue_diag_views_zero_revenue( array $rows ) {
  */
 function extrachill_analytics_revenue_diag_negative_impossible_values( array $rows ) {
 	$bad               = array();
+	$high_rate_rows    = 0;
 	$high_rate_samples = array();
 	$samples           = array();
 
@@ -1219,6 +1225,9 @@ function extrachill_analytics_revenue_diag_negative_impossible_values( array $ro
 		if ( $rpm < 0 ) {
 			$issues[] = "negative source rpm ({$rpm})";
 		}
+		if ( $derived_rpm < 0 ) {
+			$issues[] = "negative derived rpm ({$derived_rpm})";
+		}
 		if ( $cpm < 0 ) {
 			$issues[] = "negative cpm ({$cpm})";
 		}
@@ -1251,15 +1260,18 @@ function extrachill_analytics_revenue_diag_negative_impossible_values( array $ro
 				);
 			}
 		}
-		if ( ! empty( $high_rates ) && count( $high_rate_samples ) < 5 ) {
-			$high_rate_samples[] = array(
-				'slug'   => $slug,
-				'issues' => $high_rates,
-			);
+		if ( ! empty( $high_rates ) ) {
+			++$high_rate_rows;
+			if ( count( $high_rate_samples ) < 5 ) {
+				$high_rate_samples[] = array(
+					'slug'   => $slug,
+					'issues' => $high_rates,
+				);
+			}
 		}
 	}
 
-	$status   = ! empty( $bad ) ? 'fail' : ( ! empty( $high_rate_samples ) ? 'warning' : 'pass' );
+	$status   = ! empty( $bad ) ? 'fail' : ( $high_rate_rows > 0 ? 'warning' : 'pass' );
 	$evidence = array();
 	if ( ! empty( $bad ) ) {
 		$evidence[] = count( $bad ) . ' row(s) with negative or impossible values:';
@@ -1268,14 +1280,14 @@ function extrachill_analytics_revenue_diag_negative_impossible_values( array $ro
 		}
 		$evidence[] = 'Negative/out-of-range values are genuine integrity violations — investigate the import source.';
 	}
-	if ( ! empty( $high_rate_samples ) ) {
-		$evidence[] = count( $high_rate_samples ) . ' sampled row(s) have unusually high rate values:';
+	if ( $high_rate_rows > 0 ) {
+		$evidence[] = $high_rate_rows . ' row(s) have unusually high rate values (up to 5 shown):';
 		foreach ( $high_rate_samples as $s ) {
 			$evidence[] = "  {$s['slug']}: " . implode( '; ', $s['issues'] );
 		}
-		$evidence[] = 'High rate values are warnings, not integrity failures: low pageview denominators can produce them legitimately.';
+		$evidence[] = 'High rate values are anomalies, not structurally impossible values; inspect source metrics and their denominators before treating them as corruption.';
 	}
-	if ( empty( $bad ) && empty( $high_rate_samples ) ) {
+	if ( empty( $bad ) && 0 === $high_rate_rows ) {
 		$evidence[] = 'No negative, non-finite, or out-of-range values detected (views/revenue/rpm/cpm >= 0; viewability/fill_rate in [0,100]; impressions/pageview in [0,1000]).';
 	}
 
@@ -1286,6 +1298,7 @@ function extrachill_analytics_revenue_diag_negative_impossible_values( array $ro
 		'totals'   => array(
 			'rows'              => count( $bad ),
 			'samples'           => $samples,
+			'high_rate_rows'    => $high_rate_rows,
 			'high_rate_samples' => $high_rate_samples,
 		),
 	);

--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -1159,13 +1159,15 @@ function extrachill_analytics_revenue_diag_views_zero_revenue( array $rows ) {
 
 /**
  * Negative / impossible values: negative views/revenue/rpm/cpm, OR rates/views
- * outside plausible ranges. This is the one check where 'fail' is warranted on a
- * genuine data-integrity violation.
+ * outside their structurally valid ranges. This is the one check where 'fail' is
+ * warranted on a genuine data-integrity violation.
  *
  * Range contract:
  *   - views, revenue, rpm, cpm: must be >= 0.
  *   - viewability, fill_rate: must be in [0, 100] (percentages).
- *   - source/derived rpm, cpm: flagged as impossibly high above 1000.
+ *   - source/derived rpm, cpm: must be finite and non-negative. High values are
+ *     warnings, not failures: a small pageview denominator can legitimately
+ *     produce an extreme rate.
  *   - impressions/pageview: must be in [0, 1000].
  *   - views: flagged as impossibly high above 1,000,000,000.
  *   - every floating-point metric must be finite.
@@ -1174,8 +1176,9 @@ function extrachill_analytics_revenue_diag_views_zero_revenue( array $rows ) {
  * @return array Check.
  */
 function extrachill_analytics_revenue_diag_negative_impossible_values( array $rows ) {
-	$bad     = array();
-	$samples = array();
+	$bad               = array();
+	$high_rate_samples = array();
+	$samples           = array();
 
 	foreach ( $rows as $r ) {
 		$issues      = array();
@@ -1219,14 +1222,15 @@ function extrachill_analytics_revenue_diag_negative_impossible_values( array $ro
 		if ( $cpm < 0 ) {
 			$issues[] = "negative cpm ({$cpm})";
 		}
+		$high_rates = array();
 		if ( $rpm > 1000 ) {
-			$issues[] = "impossibly high source rpm ({$rpm})";
+			$high_rates[] = "high source rpm ({$rpm})";
 		}
-		if ( $derived_rpm < 0 || $derived_rpm > 1000 ) {
-			$issues[] = "derived rpm out of [0,1000] ({$derived_rpm})";
+		if ( $derived_rpm > 1000 ) {
+			$high_rates[] = "high derived rpm ({$derived_rpm})";
 		}
 		if ( $cpm > 1000 ) {
-			$issues[] = "impossibly high cpm ({$cpm})";
+			$high_rates[] = "high cpm ({$cpm})";
 		}
 		if ( $viewability < 0 || $viewability > 100 ) {
 			$issues[] = "viewability out of [0,100] ({$viewability})";
@@ -1247,18 +1251,32 @@ function extrachill_analytics_revenue_diag_negative_impossible_values( array $ro
 				);
 			}
 		}
+		if ( ! empty( $high_rates ) && count( $high_rate_samples ) < 5 ) {
+			$high_rate_samples[] = array(
+				'slug'   => $slug,
+				'issues' => $high_rates,
+			);
+		}
 	}
 
-	$status   = empty( $bad ) ? 'pass' : 'fail';
+	$status   = ! empty( $bad ) ? 'fail' : ( ! empty( $high_rate_samples ) ? 'warning' : 'pass' );
 	$evidence = array();
-	if ( empty( $bad ) ) {
-		$evidence[] = 'No negative, non-finite, or out-of-range values detected (views/revenue/rpm/cpm >= 0 and capped; viewability/fill_rate in [0,100]; impressions/pageview in [0,1000]).';
-	} else {
+	if ( ! empty( $bad ) ) {
 		$evidence[] = count( $bad ) . ' row(s) with negative or impossible values:';
 		foreach ( $samples as $s ) {
 			$evidence[] = "  {$s['slug']}: " . implode( '; ', $s['issues'] );
 		}
 		$evidence[] = 'Negative/out-of-range values are genuine integrity violations — investigate the import source.';
+	}
+	if ( ! empty( $high_rate_samples ) ) {
+		$evidence[] = count( $high_rate_samples ) . ' sampled row(s) have unusually high rate values:';
+		foreach ( $high_rate_samples as $s ) {
+			$evidence[] = "  {$s['slug']}: " . implode( '; ', $s['issues'] );
+		}
+		$evidence[] = 'High rate values are warnings, not integrity failures: low pageview denominators can produce them legitimately.';
+	}
+	if ( empty( $bad ) && empty( $high_rate_samples ) ) {
+		$evidence[] = 'No negative, non-finite, or out-of-range values detected (views/revenue/rpm/cpm >= 0; viewability/fill_rate in [0,100]; impressions/pageview in [0,1000]).';
 	}
 
 	return array(
@@ -1266,8 +1284,9 @@ function extrachill_analytics_revenue_diag_negative_impossible_values( array $ro
 		'status'   => $status,
 		'evidence' => $evidence,
 		'totals'   => array(
-			'rows'    => count( $bad ),
-			'samples' => $samples,
+			'rows'              => count( $bad ),
+			'samples'           => $samples,
+			'high_rate_samples' => $high_rate_samples,
 		),
 	);
 }

--- a/tests/GetContentRevenueDiagnosticsTest.php
+++ b/tests/GetContentRevenueDiagnosticsTest.php
@@ -798,17 +798,19 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 		$neg = $this->check( $built, 'negative_impossible_values' );
 		$this->assertSame( 'warning', $neg['status'] );
 		$this->assertSame( 0, $neg['totals']['rows'] );
+		$this->assertSame( 1, $neg['totals']['high_rate_rows'] );
 		$this->assertCount( 1, $neg['totals']['high_rate_samples'] );
 		$this->assertSame( 'warning', $built['overall_status'] );
 	}
 
 	/**
-	 * Negative impressions/pageview is flagged as impossible.
+	 * Negative derived RPM and impressions/pageview are flagged as impossible.
 	 */
 	public function test_additional_impossible_metrics_are_flagged(): void {
 		$rows = array(
 			$this->row(
 				array(
+					'derived_rpm'              => -1.0,
 					'impressions_per_pageview' => -1.0,
 				)
 			),
@@ -824,7 +826,40 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 
 		$check = $this->check( $built, 'negative_impossible_values' );
 		$this->assertSame( 'fail', $check['status'] );
+		$this->assertStringContainsString( 'negative derived rpm', implode( ' ', $check['totals']['samples'][0]['issues'] ) );
 		$this->assertStringContainsString( 'impressions_per_pageview', implode( ' ', $check['totals']['samples'][0]['issues'] ) );
+	}
+
+	/**
+	 * High-rate totals count every anomaly while evidence remains bounded.
+	 */
+	public function test_high_rate_counts_are_complete_and_samples_are_bounded(): void {
+		$rows = array();
+		for ( $i = 0; $i < 6; ++$i ) {
+			$rows[] = $this->row(
+				array(
+					'slug'  => '/high-cpm-' . $i . '/',
+					'views' => 1000,
+					'cpm'   => 1001.0,
+				)
+			);
+		}
+
+		$check = $this->check(
+			extrachill_analytics_revenue_build_diagnostics(
+				array(
+					'periods'            => array( $this->period() ),
+					'rows'               => $rows,
+					'independent_totals' => $this->reconciling_totals( $rows ),
+				)
+			),
+			'negative_impossible_values'
+		);
+
+		$this->assertSame( 'warning', $check['status'] );
+		$this->assertSame( 6, $check['totals']['high_rate_rows'] );
+		$this->assertCount( 5, $check['totals']['high_rate_samples'] );
+		$this->assertStringContainsString( '6 row(s)', $check['evidence'][0] );
 	}
 
 	/**

--- a/tests/GetContentRevenueDiagnosticsTest.php
+++ b/tests/GetContentRevenueDiagnosticsTest.php
@@ -769,16 +769,20 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
-	 * M7: impossibly high RPM (> 1000) is flagged.
+	 * High rates are warnings, not integrity failures: a low pageview denominator
+	 * can legitimately produce them.
 	 */
-	public function test_impossibly_high_rpm_is_flagged(): void {
+	public function test_high_rpm_on_low_volume_row_warns(): void {
 		$rows = array(
 			$this->row(
 				array(
 					'slug'           => '/bad-rpm/',
 					'post_id'        => 2,
 					'stored_post_id' => 2,
-					'source_rpm'     => 5000.0,
+					'views'          => 1,
+					'revenue'        => 1.16,
+					'source_rpm'     => 1163.3,
+					'derived_rpm'    => 1160.0,
 				)
 			),
 		);
@@ -792,18 +796,20 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 		);
 
 		$neg = $this->check( $built, 'negative_impossible_values' );
-		$this->assertSame( 'fail', $neg['status'] );
+		$this->assertSame( 'warning', $neg['status'] );
+		$this->assertSame( 0, $neg['totals']['rows'] );
+		$this->assertCount( 1, $neg['totals']['high_rate_samples'] );
+		$this->assertSame( 'warning', $built['overall_status'] );
 	}
 
 	/**
-	 * Negative impressions/pageview and impossible derived RPM are flagged.
+	 * Negative impressions/pageview is flagged as impossible.
 	 */
 	public function test_additional_impossible_metrics_are_flagged(): void {
 		$rows = array(
 			$this->row(
 				array(
 					'impressions_per_pageview' => -1.0,
-					'derived_rpm'              => 1500.0,
 				)
 			),
 		);
@@ -818,7 +824,6 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 
 		$check = $this->check( $built, 'negative_impossible_values' );
 		$this->assertSame( 'fail', $check['status'] );
-		$this->assertStringContainsString( 'derived rpm', implode( ' ', $check['totals']['samples'][0]['issues'] ) );
 		$this->assertStringContainsString( 'impressions_per_pageview', implode( ' ', $check['totals']['samples'][0]['issues'] ) );
 	}
 


### PR DESCRIPTION
## Summary
- Reclassify high RPM and CPM values as warnings while preserving failures for negative, non-finite, and structurally invalid metrics.
- Preserve raw source metrics and expose high-rate samples in diagnostic evidence.
- Add a regression matching the flagged production row.

## Evidence
Production row `ai-generated-bob-marley-images` is in period `2024-03`, batch `mediavine-revenue-ad36kktmp-2024-03`: 1 view, $1.1600 revenue, source RPM 1163.3, derived RPM 1160. The derived value is exact low-volume arithmetic and closely agrees with the source RPM, so the former [0,1000] failure threshold was overly strict rather than evidence of malformed source data or import normalization.

## Verification
- `composer test` (182 tests, 575 assertions)
- `vendor/bin/phpcs --standard=WordPress --extensions=php inc/core/abilities/get-content-revenue-diagnostics.php tests/GetContentRevenueDiagnosticsTest.php`
- `git ls-files "*.php" | xargs -r -n1 php -l`
- `git diff --check`

The repository-wide Composer PHPCS script times out because it scans `vendor/`; direct tracked-file PHPCS completed and reports pre-existing unrelated violations only.