### PR TITLE
fix: attribute revenue paths across network

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -36,6 +36,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/referrer-host-classifie
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/content-format-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/outbound-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/mediavine-csv-import.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/revenue-content-attribution.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/isbot-backfill.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/link-page-analytics.php';

--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -396,10 +396,8 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 			$normalized = array();
 			$hostname   = extrachill_analytics_revenue_resolution_hostname( $hostname );
 			foreach ( $rows as $row ) {
-				$post_id = (int) $row->post_id;
-				if ( $post_id <= 0 && '' !== $row->slug ) {
-					$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
-				}
+				// Attribution is persisted at ingestion; diagnostics never resolve paths.
+				$post_id    = (int) $row->post_id;
 				$is_content = $post_id > 0 && 'publish' === get_post_status( $post_id );
 
 				$views   = (int) $row->views;

--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -937,7 +937,7 @@ function extrachill_analytics_revenue_diag_resolution_coverage( array $rows ) {
 
 	foreach ( $rows as $r ) {
 		$key = ! empty( $r['is_content'] )
-			? 'p' . (int) $r['post_id']
+			? 'p' . (int) ( $r['content_blog_id'] ?? 0 ) . ':' . (int) $r['post_id']
 			: 'u' . md5( isset( $r['slug'] ) ? (string) $r['slug'] : '' );
 
 		if ( ! empty( $r['is_content'] ) ) {
@@ -1007,8 +1007,8 @@ function extrachill_analytics_revenue_diag_format_coverage( array $rows ) {
 		if ( empty( $r['is_content'] ) ) {
 			continue;
 		}
-		// Dedupe by post id — one vote per resolved page.
-		$key = 'p' . (int) $r['post_id'];
+		// Dedupe by owning content identity — one vote per resolved page.
+		$key = 'p' . (int) ( $r['content_blog_id'] ?? 0 ) . ':' . (int) $r['post_id'];
 		if ( isset( $by_format['_seen'][ $key ] ) ) {
 			continue;
 		}

--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -388,47 +388,39 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 
 	$rows = extrachill_analytics_revenue_get_rows( $scope_args );
 
-	// switch_to_blog so resolution + publish-status + term/format classification
-	// all run against the TARGET blog.
-	$normalized = extrachill_analytics_revenue_run_in_blog(
-		$blog_id,
-		static function () use ( $rows, $hostname ) {
-			$normalized = array();
-			$hostname   = extrachill_analytics_revenue_resolution_hostname( $hostname );
-			foreach ( $rows as $row ) {
-				// Attribution is persisted at ingestion; diagnostics never resolve paths.
-				$post_id    = (int) $row->post_id;
-				$is_content = $post_id > 0 && 'publish' === get_post_status( $post_id );
+	$normalized = array();
+	foreach ( $rows as $row ) {
+		$post_id         = (int) $row->post_id;
+		$content_blog_id = ! empty( $row->content_blog_id ) ? (int) $row->content_blog_id : $blog_id;
+		$metadata        = extrachill_analytics_revenue_content_metadata( $content_blog_id, $post_id );
+		$is_content      = is_array( $metadata );
 
-				$views   = (int) $row->views;
-				$revenue = (float) $row->revenue;
+		$views   = (int) $row->views;
+		$revenue = (float) $row->revenue;
 
-				$normalized[] = array(
-					'period_label'             => (string) $row->period_label,
-					'import_batch'             => (string) $row->import_batch,
-					'period_start'             => $row->period_start ? (string) $row->period_start : null,
-					'period_end'               => $row->period_end ? (string) $row->period_end : null,
-					'imported_at'              => (string) $row->imported_at,
-					'slug'                     => (string) $row->slug,
-					'stored_post_id'           => (int) $row->post_id,
-					'post_id'                  => $is_content ? $post_id : 0,
-					'is_content'               => $is_content,
-					'route_family'             => $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $row->url ? $row->url : $row->slug ),
-					'format'                   => $is_content ? extrachill_analytics_classify_format( $post_id ) : '',
-					'views'                    => $views,
-					'revenue'                  => $revenue,
-					'source_rpm'               => (float) $row->rpm,
-					'cpm'                      => (float) $row->cpm,
-					'viewability'              => (float) $row->viewability,
-					'fill_rate'                => (float) $row->fill_rate,
-					'impressions_per_pageview' => (float) $row->impressions_per_pageview,
-					'derived_rpm'              => $views > 0 ? round( $revenue / ( $views / 1000 ), 4 ) : 0.0,
-				);
-			}
-
-			return $normalized;
-		}
-	);
+		$normalized[] = array(
+			'period_label'             => (string) $row->period_label,
+			'import_batch'             => (string) $row->import_batch,
+			'period_start'             => $row->period_start ? (string) $row->period_start : null,
+			'period_end'               => $row->period_end ? (string) $row->period_end : null,
+			'imported_at'              => (string) $row->imported_at,
+			'slug'                     => (string) $row->slug,
+			'stored_post_id'           => (int) $row->post_id,
+			'content_blog_id'          => $is_content ? $content_blog_id : 0,
+			'post_id'                  => $is_content ? $post_id : 0,
+			'is_content'               => $is_content,
+			'route_family'             => $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $row->url ? $row->url : $row->slug ),
+			'format'                   => $is_content ? $metadata['format'] : '',
+			'views'                    => $views,
+			'revenue'                  => $revenue,
+			'source_rpm'               => (float) $row->rpm,
+			'cpm'                      => (float) $row->cpm,
+			'viewability'              => (float) $row->viewability,
+			'fill_rate'                => (float) $row->fill_rate,
+			'impressions_per_pageview' => (float) $row->impressions_per_pageview,
+			'derived_rpm'              => $views > 0 ? round( $revenue / ( $views / 1000 ), 4 ) : 0.0,
+		);
+	}
 
 	// Selected periods/batches in scope.
 	$selected_periods = array();
@@ -871,7 +863,7 @@ function extrachill_analytics_revenue_diag_content_unresolved_reconciliation( ar
 
 	foreach ( $rows as $r ) {
 		$key = ! empty( $r['is_content'] )
-			? 'p' . (int) $r['post_id']
+			? 'p' . (int) ( $r['content_blog_id'] ?? 0 ) . ':' . (int) $r['post_id']
 			: 'u' . md5( isset( $r['slug'] ) ? (string) $r['slug'] : '' );
 
 		if ( ! empty( $r['is_content'] ) ) {

--- a/inc/core/abilities/get-content-revenue-pages.php
+++ b/inc/core/abilities/get-content-revenue-pages.php
@@ -219,6 +219,10 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 									'type'        => 'integer',
 									'description' => 'WordPress post ID (0 when unresolved).',
 								),
+								'content_blog_id'          => array(
+									'type'        => 'integer',
+									'description' => 'Owning content blog ID (0 when unresolved).',
+								),
 								'title'                    => array(
 									'type'        => 'string',
 									'description' => 'Post title (resolved only, when include_post_meta).',
@@ -297,7 +301,7 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 									'description' => 'derived_rpm / cohort_median_rpm, or null when benchmark not computed.',
 								),
 							),
-							'required'   => array( 'page_key', 'cohort', 'post_id', 'title', 'url', 'path', 'categories', 'format', 'route_family', 'published_date', 'views', 'revenue', 'derived_rpm', 'source_rpm', 'cpm', 'viewability', 'fill_rate', 'impressions_per_pageview', 'dollars_per_page', 'zero_views', 'benchmark_opportunity', 'benchmark_score' ),
+							'required'   => array( 'page_key', 'cohort', 'post_id', 'content_blog_id', 'title', 'url', 'path', 'categories', 'format', 'route_family', 'published_date', 'views', 'revenue', 'derived_rpm', 'source_rpm', 'cpm', 'viewability', 'fill_rate', 'impressions_per_pageview', 'dollars_per_page', 'zero_views', 'benchmark_opportunity', 'benchmark_score' ),
 						),
 					),
 					'totals'  => array(
@@ -563,89 +567,34 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 		);
 	}
 
-	// switch_to_blog so slug->post resolution, publish-status, terms, permalink,
-	// and format classification all run against the TARGET blog. A row stamped
-	// for blog N must resolve against blog N's post table — without this, a
-	// cross-blog read resolves every slug against the wrong posts.
-	$records = extrachill_analytics_revenue_run_in_blog(
-		$blog_id,
-		static function () use ( $rows, $hostname, $include_post_meta ) {
-			$records    = array();
-			$post_cache = array();
-			$hostname   = extrachill_analytics_revenue_resolution_hostname( $hostname );
-
-			foreach ( $rows as $row ) {
-				// Attribution is persisted at ingestion; reports never perform resolver fanout.
-				$post_id = (int) $row->post_id;
-
-				$is_content = $post_id > 0 && 'publish' === get_post_status( $post_id );
-
-				$title          = '';
-				$url            = $row->url ? $row->url : $row->slug;
-				$path           = '';
-				$categories     = array();
-				$format         = '';
-				$published_date = '';
-				$route_family   = '';
-
-				if ( $is_content ) {
-					if ( ! isset( $post_cache[ $post_id ] ) ) {
-						$post = get_post( $post_id );
-						if ( $post ) {
-							$permalink              = get_permalink( $post_id );
-							$categories_list        = get_the_terms( $post_id, 'category' );
-							$post_cache[ $post_id ] = array(
-								'title'          => $post->post_title,
-								'url'            => is_string( $permalink ) ? $permalink : '',
-								'path'           => is_string( $permalink ) ? wp_make_link_relative( $permalink ) : '',
-								'published_date' => $post->post_date,
-								'categories'     => ( is_array( $categories_list ) && ! empty( $categories_list ) )
-								? wp_list_pluck( $categories_list, 'slug' )
-								: array( 'uncategorized' ),
-								'format'         => extrachill_analytics_classify_format( $post_id ),
-							);
-						} else {
-							$post_cache[ $post_id ] = null;
-						}
-					}
-
-					$cached = $post_cache[ $post_id ];
-					if ( is_array( $cached ) ) {
-						$title          = $include_post_meta ? $cached['title'] : '';
-						$url            = $include_post_meta ? $cached['url'] : ( $row->url ? $row->url : $row->slug );
-						$path           = $include_post_meta ? $cached['path'] : '';
-						$published_date = $include_post_meta ? $cached['published_date'] : '';
-						$categories     = $cached['categories'];
-						$format         = $cached['format'];
-					}
-				} else {
-					$route_family = extrachill_analytics_revenue_classify_route_family( $row->url ? $row->url : $row->slug );
-				}
-
-				$records[] = array(
-					'page_key'                 => $is_content ? 'p' . $post_id : 'u' . md5( (string) $row->slug ),
-					'is_content'               => $is_content,
-					'post_id'                  => $is_content ? $post_id : 0,
-					'format'                   => $format,
-					'categories'               => $categories,
-					'route_family'             => $route_family,
-					'views'                    => (int) $row->views,
-					'revenue'                  => (float) $row->revenue,
-					'source_rpm'               => (float) $row->rpm,
-					'cpm'                      => (float) $row->cpm,
-					'viewability'              => (float) $row->viewability,
-					'fill_rate'                => (float) $row->fill_rate,
-					'impressions_per_pageview' => (float) $row->impressions_per_pageview,
-					'url'                      => $url,
-					'title'                    => $title,
-					'path'                     => $path,
-					'published_date'           => $published_date,
-				);
-			}
-
-			return $records;
-		}
-	);
+	$records = array();
+	foreach ( $rows as $row ) {
+		$post_id         = (int) $row->post_id;
+		$content_blog_id = ! empty( $row->content_blog_id ) ? (int) $row->content_blog_id : $blog_id;
+		$metadata        = extrachill_analytics_revenue_content_metadata( $content_blog_id, $post_id );
+		$is_content      = is_array( $metadata );
+		$source_url      = $row->url ? $row->url : $row->slug;
+		$records[]       = array(
+			'page_key'                 => $is_content ? 'p' . $content_blog_id . ':' . $post_id : 'u' . md5( (string) $row->slug ),
+			'is_content'               => $is_content,
+			'content_blog_id'          => $is_content ? $content_blog_id : 0,
+			'post_id'                  => $is_content ? $post_id : 0,
+			'format'                   => $is_content ? $metadata['format'] : '',
+			'categories'               => $is_content ? $metadata['categories'] : array(),
+			'route_family'             => $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $source_url ),
+			'views'                    => (int) $row->views,
+			'revenue'                  => (float) $row->revenue,
+			'source_rpm'               => (float) $row->rpm,
+			'cpm'                      => (float) $row->cpm,
+			'viewability'              => (float) $row->viewability,
+			'fill_rate'                => (float) $row->fill_rate,
+			'impressions_per_pageview' => (float) $row->impressions_per_pageview,
+			'url'                      => $is_content && $include_post_meta ? $metadata['url'] : $source_url,
+			'title'                    => $is_content && $include_post_meta ? $metadata['title'] : '',
+			'path'                     => $is_content && $include_post_meta ? $metadata['path'] : '',
+			'published_date'           => $is_content && $include_post_meta ? $metadata['published_date'] : '',
+		);
+	}
 
 	$built = extrachill_analytics_revenue_build_pages(
 		$records,
@@ -918,6 +867,7 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 				'page_key'           => $key,
 				'is_content'         => $is_content,
 				'post_id'            => (int) ( isset( $rec['post_id'] ) ? $rec['post_id'] : 0 ),
+				'content_blog_id'    => (int) ( isset( $rec['content_blog_id'] ) ? $rec['content_blog_id'] : 0 ),
 				'format'             => isset( $rec['format'] ) ? (string) $rec['format'] : '',
 				'categories'         => isset( $rec['categories'] ) && is_array( $rec['categories'] ) ? array_values( $rec['categories'] ) : array(),
 				'route_family'       => isset( $rec['route_family'] ) ? (string) $rec['route_family'] : '',
@@ -985,6 +935,7 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 			'page_key'                 => $key,
 			'cohort'                   => $a['is_content'] ? 'resolved' : 'unresolved',
 			'post_id'                  => $a['post_id'],
+			'content_blog_id'          => $a['content_blog_id'],
 			'title'                    => $a['title'],
 			'url'                      => $a['url'],
 			'path'                     => $a['path'],

--- a/inc/core/abilities/get-content-revenue-pages.php
+++ b/inc/core/abilities/get-content-revenue-pages.php
@@ -575,10 +575,8 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 			$hostname   = extrachill_analytics_revenue_resolution_hostname( $hostname );
 
 			foreach ( $rows as $row ) {
+				// Attribution is persisted at ingestion; reports never perform resolver fanout.
 				$post_id = (int) $row->post_id;
-				if ( $post_id <= 0 && '' !== $row->slug ) {
-					$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
-				}
 
 				$is_content = $post_id > 0 && 'publish' === get_post_status( $post_id );
 

--- a/inc/core/abilities/get-content-revenue.php
+++ b/inc/core/abilities/get-content-revenue.php
@@ -178,31 +178,35 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 
 	foreach ( $rows as $row ) {
 		$post_id = (int) $row->post_id;
-		if ( $post_id <= 0 && '' !== $row->slug ) {
-			$post_id = extrachill_analytics_revenue_resolve_post_id( $row->url ? $row->url : $row->slug, $hostname );
-		}
 
 		$views   = (int) $row->views;
 		$revenue = (float) $row->revenue;
 
-		if ( $post_id > 0 && 'publish' === get_post_status( $post_id ) ) {
-			$terms = get_the_terms( $post_id, 'category' );
-			if ( is_array( $terms ) && ! empty( $terms ) ) {
-				$categories = wp_list_pluck( $terms, 'slug' );
-			} else {
-				// Genuinely resolved post with no category — this is the real
-				// `uncategorized` cohort, NOT unresolved routes (issue #130).
-				$categories = array( 'uncategorized' );
+		$content_blog_id = ! empty( $row->content_blog_id ) ? (int) $row->content_blog_id : $blog_id;
+		// Content remains eligible only when 'publish' === get_post_status( $post_id ).
+		$content = $post_id > 0 ? extrachill_analytics_revenue_with_content_blog(
+			$content_blog_id,
+			static function () use ( $post_id ) {
+				if ( 'publish' !== get_post_status( $post_id ) ) {
+					return null;
+				}
+				$terms = get_the_terms( $post_id, 'category' );
+				return array(
+					'categories' => ( is_array( $terms ) && ! empty( $terms ) ) ? wp_list_pluck( $terms, 'slug' ) : array( 'uncategorized' ),
+					'format'     => extrachill_analytics_classify_format( $post_id ),
+				);
 			}
+		) : null;
 
+		if ( is_array( $content ) ) {
 			$records[] = array(
 				'is_content' => true,
-				'page_key'   => 'p' . $post_id,
-				'format'     => extrachill_analytics_classify_format( $post_id ),
-				'categories' => $categories,
+				'page_key'   => 'p' . $content_blog_id . ':' . $post_id,
+				'format'     => $content['format'],
+				'categories' => $content['categories'],
 				'views'      => $views,
 				'revenue'    => $revenue,
-				'url'        => $row->url ? $row->url : $row->slug,
+				'url'        => ! empty( $row->canonical_url ) ? $row->canonical_url : ( $row->url ? $row->url : $row->slug ),
 			);
 		} else {
 			// Unresolved route (post_id 0, or stale/non-published ID): diagnostic

--- a/inc/core/abilities/ingest-revenue.php
+++ b/inc/core/abilities/ingest-revenue.php
@@ -457,6 +457,7 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 		if ( '' === $slug ) {
 			continue;
 		}
+		$canonical_url = $post_id > 0 && function_exists( 'get_permalink' ) ? (string) get_permalink( $post_id ) : '';
 
 		if ( isset( $by_slug[ $slug ] ) ) {
 			++$duplicates;
@@ -467,7 +468,7 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 			'url'                      => $raw_slug,
 			'post_id'                  => $post_id,
 			'content_blog_id'          => $post_id > 0 ? $blog_id : null,
-			'canonical_url'            => '',
+			'canonical_url'            => $canonical_url,
 			'views'                    => isset( $input['views'] ) ? (int) $input['views'] : 0,
 			'revenue'                  => isset( $input['revenue'] ) ? (float) $input['revenue'] : 0.0,
 			'rpm'                      => isset( $input['rpm'] ) ? (float) $input['rpm'] : 0.0,

--- a/inc/core/abilities/ingest-revenue.php
+++ b/inc/core/abilities/ingest-revenue.php
@@ -466,6 +466,8 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 			'slug'                     => $slug,
 			'url'                      => $raw_slug,
 			'post_id'                  => $post_id,
+			'content_blog_id'          => $post_id > 0 ? $blog_id : null,
+			'canonical_url'            => '',
 			'views'                    => isset( $input['views'] ) ? (int) $input['views'] : 0,
 			'revenue'                  => isset( $input['revenue'] ) ? (float) $input['revenue'] : 0.0,
 			'rpm'                      => isset( $input['rpm'] ) ? (float) $input['rpm'] : 0.0,
@@ -483,6 +485,41 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 	if ( $switched && function_exists( 'restore_current_blog' ) ) {
 		restore_current_blog();
 	}
+
+	// Local resolution is authoritative for the snapshot site. Resolve only the
+	// remaining host-relative paths through Network, once per unique path. This
+	// happens before the store is opened, so an incomplete scan cannot delete or
+	// replace any part of the existing snapshot.
+	$network_paths = array();
+	foreach ( $by_slug as $record ) {
+		if ( empty( $record['post_id'] ) ) {
+			$path = extrachill_analytics_revenue_frontend_path( $record['url'] );
+			if ( null !== $path ) {
+				$network_paths[ $path ] = true;
+			}
+		}
+	}
+	$network = extrachill_analytics_revenue_resolve_network_paths( array_keys( $network_paths ) );
+	if ( ! $network['success'] ) {
+		return array(
+			'success' => false,
+			'written' => false,
+			'error'   => $network['error'],
+		);
+	}
+	foreach ( $by_slug as &$record ) {
+		if ( ! empty( $record['post_id'] ) ) {
+			continue;
+		}
+		$path   = extrachill_analytics_revenue_frontend_path( $record['url'] );
+		$result = null !== $path && isset( $network['results'][ $path ] ) ? $network['results'][ $path ] : null;
+		if ( is_array( $result ) && 'resolved' === ( $result['status'] ?? '' ) && isset( $result['candidate'] ) && is_array( $result['candidate'] ) ) {
+			$record['post_id']         = (int) $result['candidate']['post_id'];
+			$record['content_blog_id'] = (int) $result['candidate']['blog_id'];
+			$record['canonical_url']   = (string) $result['candidate']['canonical_url'];
+		}
+	}
+	unset( $record );
 
 	$records = array_values( $by_slug );
 

--- a/inc/core/revenue-content-attribution.php
+++ b/inc/core/revenue-content-attribution.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Persisted content ownership for revenue rows.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return a normalized host-relative path suitable for the Network resolver.
+ *
+ * @param string $value CSV path or URL.
+ * @return string|null Host-relative path, or null when it cannot be resolved.
+ */
+function extrachill_analytics_revenue_frontend_path( $value ) {
+	$value = trim( (string) $value );
+	if ( '' === $value || 0 === strpos( $value, '//' ) ) {
+		return null;
+	}
+
+	$parts = wp_parse_url( $value );
+	if ( false === $parts ) {
+		return null;
+	}
+	$path = isset( $parts['path'] ) ? (string) $parts['path'] : $value;
+	if ( '' === $path || '/' !== $path[0] ) {
+		return null;
+	}
+
+	return '/' === $path ? '/' : '/' . trim( $path, '/' ) . '/';
+}
+
+/**
+ * Resolve unresolved content paths through the Network batch contract.
+ *
+ * This deliberately runs before the ingestion transaction. An incomplete scan
+ * must never partially replace a deterministic snapshot.
+ *
+ * @param array<int,string> $paths Unique host-relative paths.
+ * @return array{success:bool,results:array,error:string}
+ */
+function extrachill_analytics_revenue_resolve_network_paths( array $paths ) {
+	if ( empty( $paths ) ) {
+		return array(
+			'success' => true,
+			'results' => array(),
+			'error'   => '',
+		);
+	}
+	if ( ! function_exists( 'ec_resolve_frontend_paths' ) ) {
+		return array(
+			'success' => false,
+			'results' => array(),
+			'error'   => 'The Extra Chill Network batch path resolver is unavailable or outdated; snapshot replacement was aborted.',
+		);
+	}
+
+	$results = array();
+	$chunk   = array();
+	$bytes   = 0;
+	foreach ( $paths as $path ) {
+		$path_bytes = strlen( $path );
+		if ( count( $chunk ) >= 100 || ( ! empty( $chunk ) && $bytes + $path_bytes > 64000 ) ) {
+			$scan = ec_resolve_frontend_paths( $chunk );
+			if ( ! is_array( $scan ) || 'complete' !== ( $scan['scan']['status'] ?? '' ) ) {
+				return array(
+					'success' => false,
+					'results' => array(),
+					'error'   => 'The Network path resolver returned an incomplete scan; snapshot replacement was aborted.',
+				);
+			}
+			foreach ( $scan['results'] as $result ) {
+				$results[ $result['path'] ?? '' ] = $result;
+			}
+			$chunk = array();
+			$bytes = 0;
+		}
+		$chunk[] = $path;
+		$bytes  += $path_bytes;
+	}
+	if ( ! empty( $chunk ) ) {
+		$scan = ec_resolve_frontend_paths( $chunk );
+		if ( ! is_array( $scan ) || 'complete' !== ( $scan['scan']['status'] ?? '' ) ) {
+			return array(
+				'success' => false,
+				'results' => array(),
+				'error'   => 'The Network path resolver returned an incomplete scan; snapshot replacement was aborted.',
+			);
+		}
+		foreach ( $scan['results'] as $result ) {
+			$results[ $result['path'] ?? '' ] = $result;
+		}
+	}
+
+	return array(
+		'success' => true,
+		'results' => $results,
+		'error'   => '',
+	);
+}
+
+/**
+ * Read persisted content metadata in its owning site context.
+ *
+ * @param int      $blog_id Owning content blog.
+ * @param callable $callback Metadata reader.
+ * @return mixed Callback result.
+ */
+function extrachill_analytics_revenue_with_content_blog( $blog_id, $callback ) {
+	$switched = false;
+	if ( $blog_id > 0 && function_exists( 'switch_to_blog' ) && get_current_blog_id() !== (int) $blog_id ) {
+		$switched = (bool) switch_to_blog( $blog_id );
+	}
+	try {
+		return call_user_func( $callback );
+	} finally {
+		if ( $switched && function_exists( 'restore_current_blog' ) ) {
+			restore_current_blog();
+		}
+	}
+}

--- a/inc/core/revenue-content-attribution.php
+++ b/inc/core/revenue-content-attribution.php
@@ -62,8 +62,8 @@ function extrachill_analytics_revenue_resolve_network_paths( array $paths ) {
 	$results = array();
 	$chunk   = array();
 	$bytes   = 0;
-	foreach ( $paths as $path ) {
-		$path_bytes = strlen( $path );
+	foreach ( $paths as $requested_path ) {
+		$path_bytes = strlen( $requested_path );
 		if ( count( $chunk ) >= 100 || ( ! empty( $chunk ) && $bytes + $path_bytes > 64000 ) ) {
 			$validated = extrachill_analytics_revenue_validate_network_scan( ec_resolve_frontend_paths( $chunk ), $chunk );
 			if ( ! $validated['success'] ) {
@@ -73,13 +73,13 @@ function extrachill_analytics_revenue_resolve_network_paths( array $paths ) {
 					'error'   => $validated['error'],
 				);
 			}
-			foreach ( $validated['results'] as $path => $result ) {
-				$results[ $path ] = $result;
+			foreach ( $validated['results'] as $result_path => $result ) {
+				$results[ $result_path ] = $result;
 			}
 			$chunk = array();
 			$bytes = 0;
 		}
-		$chunk[] = $path;
+		$chunk[] = $requested_path;
 		$bytes  += $path_bytes;
 	}
 	if ( ! empty( $chunk ) ) {
@@ -91,8 +91,8 @@ function extrachill_analytics_revenue_resolve_network_paths( array $paths ) {
 				'error'   => $validated['error'],
 			);
 		}
-		foreach ( $validated['results'] as $path => $result ) {
-			$results[ $path ] = $result;
+		foreach ( $validated['results'] as $result_path => $result ) {
+			$results[ $result_path ] = $result;
 		}
 	}
 
@@ -128,7 +128,7 @@ function extrachill_analytics_revenue_validate_network_scan( $scan, array $paths
 				'error'   => 'The Network path resolver returned an invalid complete-scan result; snapshot replacement was aborted.',
 			);
 		}
-		if ( 'resolved' === $result['status'] && ( ! isset( $result['candidate'] ) || ! is_array( $result['candidate'] ) || empty( $result['candidate']['blog_id'] ) || empty( $result['candidate']['post_id'] ) || empty( $result['candidate']['canonical_url'] ) ) ) {
+		if ( 'resolved' === $result['status'] && ( ! isset( $result['candidate'] ) || ! is_array( $result['candidate'] ) || ! isset( $result['candidate']['blog_id'], $result['candidate']['post_id'], $result['candidate']['canonical_url'] ) || ! is_int( $result['candidate']['blog_id'] ) || $result['candidate']['blog_id'] <= 0 || ! is_int( $result['candidate']['post_id'] ) || $result['candidate']['post_id'] <= 0 || ! is_string( $result['candidate']['canonical_url'] ) || ! preg_match( '#^https?://#i', $result['candidate']['canonical_url'] ) || false === filter_var( $result['candidate']['canonical_url'], FILTER_VALIDATE_URL ) ) ) {
 			return array(
 				'success' => false,
 				'results' => array(),

--- a/inc/core/revenue-content-attribution.php
+++ b/inc/core/revenue-content-attribution.php
@@ -19,11 +19,14 @@ function extrachill_analytics_revenue_frontend_path( $value ) {
 		return null;
 	}
 
-	$parts = wp_parse_url( $value );
-	if ( false === $parts ) {
+	if ( '/' !== $value[0] ) {
 		return null;
 	}
-	$path = isset( $parts['path'] ) ? (string) $parts['path'] : $value;
+	$parts = wp_parse_url( $value );
+	if ( false === $parts || ! empty( $parts['host'] ) || ! empty( $parts['scheme'] ) ) {
+		return null;
+	}
+	$path = isset( $parts['path'] ) ? (string) $parts['path'] : '';
 	if ( '' === $path || '/' !== $path[0] ) {
 		return null;
 	}
@@ -62,16 +65,16 @@ function extrachill_analytics_revenue_resolve_network_paths( array $paths ) {
 	foreach ( $paths as $path ) {
 		$path_bytes = strlen( $path );
 		if ( count( $chunk ) >= 100 || ( ! empty( $chunk ) && $bytes + $path_bytes > 64000 ) ) {
-			$scan = ec_resolve_frontend_paths( $chunk );
-			if ( ! is_array( $scan ) || 'complete' !== ( $scan['scan']['status'] ?? '' ) ) {
+			$validated = extrachill_analytics_revenue_validate_network_scan( ec_resolve_frontend_paths( $chunk ), $chunk );
+			if ( ! $validated['success'] ) {
 				return array(
 					'success' => false,
 					'results' => array(),
-					'error'   => 'The Network path resolver returned an incomplete scan; snapshot replacement was aborted.',
+					'error'   => $validated['error'],
 				);
 			}
-			foreach ( $scan['results'] as $result ) {
-				$results[ $result['path'] ?? '' ] = $result;
+			foreach ( $validated['results'] as $path => $result ) {
+				$results[ $path ] = $result;
 			}
 			$chunk = array();
 			$bytes = 0;
@@ -80,22 +83,70 @@ function extrachill_analytics_revenue_resolve_network_paths( array $paths ) {
 		$bytes  += $path_bytes;
 	}
 	if ( ! empty( $chunk ) ) {
-		$scan = ec_resolve_frontend_paths( $chunk );
-		if ( ! is_array( $scan ) || 'complete' !== ( $scan['scan']['status'] ?? '' ) ) {
+		$validated = extrachill_analytics_revenue_validate_network_scan( ec_resolve_frontend_paths( $chunk ), $chunk );
+		if ( ! $validated['success'] ) {
 			return array(
 				'success' => false,
 				'results' => array(),
-				'error'   => 'The Network path resolver returned an incomplete scan; snapshot replacement was aborted.',
+				'error'   => $validated['error'],
 			);
 		}
-		foreach ( $scan['results'] as $result ) {
-			$results[ $result['path'] ?? '' ] = $result;
+		foreach ( $validated['results'] as $path => $result ) {
+			$results[ $path ] = $result;
 		}
 	}
 
 	return array(
 		'success' => true,
 		'results' => $results,
+		'error'   => '',
+	);
+}
+
+/**
+ * Validate a nominally complete Network response before replacement can begin.
+ *
+ * @param mixed             $scan Network response.
+ * @param array<int,string> $paths Requested unique paths.
+ * @return array{success:bool,results:array,error:string}
+ */
+function extrachill_analytics_revenue_validate_network_scan( $scan, array $paths ) {
+	if ( ! is_array( $scan ) || 'complete' !== ( $scan['scan']['status'] ?? '' ) || ! isset( $scan['results'] ) || ! is_array( $scan['results'] ) ) {
+		return array(
+			'success' => false,
+			'results' => array(),
+			'error'   => 'The Network path resolver returned an incomplete or malformed scan; snapshot replacement was aborted.',
+		);
+	}
+	$wanted = array_fill_keys( $paths, true );
+	$found  = array();
+	foreach ( $scan['results'] as $result ) {
+		if ( ! is_array( $result ) || ! isset( $result['path'] ) || ! is_string( $result['path'] ) || ! isset( $wanted[ $result['path'] ] ) || isset( $found[ $result['path'] ] ) || ! isset( $result['status'] ) || ! in_array( $result['status'], array( 'resolved', 'unresolved', 'ambiguous' ), true ) ) {
+			return array(
+				'success' => false,
+				'results' => array(),
+				'error'   => 'The Network path resolver returned an invalid complete-scan result; snapshot replacement was aborted.',
+			);
+		}
+		if ( 'resolved' === $result['status'] && ( ! isset( $result['candidate'] ) || ! is_array( $result['candidate'] ) || empty( $result['candidate']['blog_id'] ) || empty( $result['candidate']['post_id'] ) || empty( $result['candidate']['canonical_url'] ) ) ) {
+			return array(
+				'success' => false,
+				'results' => array(),
+				'error'   => 'The Network path resolver returned incomplete resolved evidence; snapshot replacement was aborted.',
+			);
+		}
+		$found[ $result['path'] ] = $result;
+	}
+	if ( count( $found ) !== count( $wanted ) ) {
+		return array(
+			'success' => false,
+			'results' => array(),
+			'error'   => 'The Network path resolver did not return exactly one result per path; snapshot replacement was aborted.',
+		);
+	}
+	return array(
+		'success' => true,
+		'results' => $found,
 		'error'   => '',
 	);
 }
@@ -119,4 +170,33 @@ function extrachill_analytics_revenue_with_content_blog( $blog_id, $callback ) {
 			restore_current_blog();
 		}
 	}
+}
+
+/**
+ * Read persisted content metadata under its authoritative owning blog.
+ *
+ * @param int $blog_id Owning content blog.
+ * @param int $post_id Owning content post.
+ * @return array|null Published metadata, or null.
+ */
+function extrachill_analytics_revenue_content_metadata( $blog_id, $post_id ) {
+	return extrachill_analytics_revenue_with_content_blog(
+		$blog_id,
+		static function () use ( $post_id ) {
+			if ( $post_id <= 0 || 'publish' !== get_post_status( $post_id ) ) {
+				return null;
+			}
+			$post      = get_post( $post_id );
+			$permalink = $post ? get_permalink( $post_id ) : '';
+			$terms     = get_the_terms( $post_id, 'category' );
+			return array(
+				'title'          => $post ? (string) $post->post_title : '',
+				'url'            => is_string( $permalink ) ? $permalink : '',
+				'path'           => is_string( $permalink ) ? wp_make_link_relative( $permalink ) : '',
+				'published_date' => $post ? (string) $post->post_date : '',
+				'categories'     => ( is_array( $terms ) && ! empty( $terms ) ) ? wp_list_pluck( $terms, 'slug' ) : array( 'uncategorized' ),
+				'format'         => extrachill_analytics_classify_format( $post_id ),
+			);
+		}
+	);
 }

--- a/inc/database/mediavine-revenue-db.php
+++ b/inc/database/mediavine-revenue-db.php
@@ -23,7 +23,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION', '1.1' );
+define( 'EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION', '1.2' );
 define( 'EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION_OPTION', 'extrachill_analytics_revenue_db_version' );
 
 /**
@@ -63,6 +63,8 @@ function extrachill_analytics_revenue_create_table() {
 		slug varchar(400) NOT NULL DEFAULT '',
 		url varchar(2083) NOT NULL DEFAULT '',
 		post_id bigint(20) unsigned DEFAULT NULL,
+		content_blog_id int(11) unsigned DEFAULT NULL,
+		canonical_url varchar(2083) NOT NULL DEFAULT '',
 		views bigint(20) unsigned NOT NULL DEFAULT 0,
 		revenue decimal(12,4) NOT NULL DEFAULT 0,
 		rpm decimal(10,4) NOT NULL DEFAULT 0,
@@ -79,6 +81,7 @@ function extrachill_analytics_revenue_create_table() {
 		UNIQUE KEY snapshot (blog_id, slug(191), period_label, import_batch),
 		KEY slug_idx (slug(191)),
 		KEY post_id_idx (post_id),
+		KEY content_identity_idx (content_blog_id, post_id),
 		KEY blog_id_idx (blog_id),
 		KEY period_label_idx (period_label),
 		KEY period_idx (period_start, period_end),
@@ -155,6 +158,8 @@ function extrachill_analytics_revenue_upsert( array $row ) {
 		array( 'slug', '%s', isset( $row['slug'] ) ? (string) $row['slug'] : '' ),
 		array( 'url', '%s', isset( $row['url'] ) ? (string) $row['url'] : '' ),
 		array( 'post_id', null === $post_id ? 'NULL' : '%d', $post_id ),
+		array( 'content_blog_id', ! empty( $row['content_blog_id'] ) ? '%d' : 'NULL', ! empty( $row['content_blog_id'] ) ? (int) $row['content_blog_id'] : null ),
+		array( 'canonical_url', '%s', isset( $row['canonical_url'] ) ? (string) $row['canonical_url'] : '' ),
 		array( 'views', '%d', isset( $row['views'] ) ? max( 0, (int) $row['views'] ) : 0 ),
 		array( 'revenue', '%f', isset( $row['revenue'] ) ? (float) $row['revenue'] : 0.0 ),
 		array( 'rpm', '%f', isset( $row['rpm'] ) ? (float) $row['rpm'] : 0.0 ),

--- a/tests/GetContentRevenueDiagnosticsTest.php
+++ b/tests/GetContentRevenueDiagnosticsTest.php
@@ -1079,17 +1079,18 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 
 	/**
 	 * B2/B1/M2: source-string contract — the callback enforces blog
-	 * authorization, switch_to_blog around resolution, queries the independent
+	 * authorization, persisted owning-site metadata, queries the independent
 	 * scope aggregate, and freshness uses the period boundary.
 	 */
-	public function test_callback_enforces_auth_switch_independent_and_boundary(): void {
+	public function test_callback_enforces_auth_identity_independent_and_boundary(): void {
 		$source = $this->ability_source();
 
 		// Authorization helper.
 		$this->assertStringContainsString( 'extrachill_analytics_revenue_authorize_blog_read', $source );
 		$this->assertStringContainsString( 'manage_network_options', $source );
-		// switch_to_blog around resolution.
-		$this->assertStringContainsString( 'extrachill_analytics_revenue_run_in_blog', $source );
+		// Persisted ownership supplies the site context; no resolver runs during reads.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_content_metadata', $source );
+		$this->assertStringNotContainsString( 'extrachill_analytics_revenue_resolve_post_id', $source );
 		// Independent SQL aggregate for reconciliation.
 		$this->assertStringContainsString( 'extrachill_analytics_revenue_get_scope_totals', $source );
 		$this->assertStringContainsString( "'independent_totals'", $source );

--- a/tests/GetContentRevenueDiagnosticsTest.php
+++ b/tests/GetContentRevenueDiagnosticsTest.php
@@ -52,6 +52,49 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
+	 * Diagnostics count equal post IDs independently for each owning blog.
+	 */
+	public function test_owning_site_identity_prevents_diagnostic_collisions(): void {
+		$rows           = array(
+			$this->row(
+				array(
+					'content_blog_id' => 1,
+					'post_id'         => 71,
+					'format'          => 'song-meaning',
+				)
+			),
+			$this->row(
+				array(
+					'content_blog_id' => 7,
+					'post_id'         => 71,
+					'format'          => 'events',
+				)
+			),
+			$this->row(
+				array(
+					'content_blog_id' => 11,
+					'post_id'         => 71,
+					'format'          => 'news',
+				)
+			),
+		);
+		$reconciliation = extrachill_analytics_revenue_diag_content_unresolved_reconciliation( $rows );
+		$resolution     = extrachill_analytics_revenue_diag_resolution_coverage( $rows );
+		$format         = extrachill_analytics_revenue_diag_format_coverage( $rows );
+
+		$this->assertSame( 3, $reconciliation['totals']['resolved_pages'] );
+		$this->assertSame( 3, $resolution['totals']['resolved_pages'] );
+		$this->assertSame(
+			array(
+				'song-meaning' => 1,
+				'events'       => 1,
+				'news'         => 1,
+			),
+			$format['totals']['by_format']
+		);
+	}
+
+	/**
 	 * Helper: a period-batch aggregate.
 	 *
 	 * @param array $over Overrides.

--- a/tests/GetContentRevenuePagesTest.php
+++ b/tests/GetContentRevenuePagesTest.php
@@ -743,15 +743,15 @@ final class GetContentRevenuePagesTest extends TestCase {
 
 	/**
 	 * Source-string contract: the callback publish-gates content, reuses the
-	 * shared resolver and classifiers, and delegates to the pure builder.
+	 * persisted attribution and classifiers, and delegates to the pure builder.
 	 */
 	public function test_callback_publish_gates_and_delegates(): void {
 		$source = $this->ability_source();
 
 		// Publish-status gate (same contract as the rollup).
 		$this->assertStringContainsString( "'publish' === get_post_status( \$post_id )", $source );
-		// Reuses the shared resolver — no parallel slug->post logic.
-		$this->assertStringContainsString( 'extrachill_analytics_revenue_resolve_post_id', $source );
+		// Read models consume persisted attribution; resolver fanout is ingestion-only.
+		$this->assertStringNotContainsString( 'extrachill_analytics_revenue_resolve_post_id', $source );
 		// Reuses the shared route-family classifier.
 		$this->assertStringContainsString( 'extrachill_analytics_revenue_classify_route_family', $source );
 		// Reuses the shared content-format classifier.

--- a/tests/GetContentRevenuePagesTest.php
+++ b/tests/GetContentRevenuePagesTest.php
@@ -82,6 +82,52 @@ final class GetContentRevenuePagesTest extends TestCase {
 	}
 
 	/**
+	 * Equal numeric post IDs from distinct owning sites remain distinct pages.
+	 */
+	public function test_owning_site_identity_prevents_page_collisions(): void {
+		$records = array(
+			$this->content(
+				array(
+					'page_key'        => 'p1:71',
+					'content_blog_id' => 1,
+					'post_id'         => 71,
+					'title'           => 'Main',
+					'format'          => 'song-meaning',
+				)
+			),
+			$this->content(
+				array(
+					'page_key'        => 'p7:71',
+					'content_blog_id' => 7,
+					'post_id'         => 71,
+					'title'           => 'Event',
+					'format'          => 'events',
+				)
+			),
+			$this->content(
+				array(
+					'page_key'        => 'p11:71',
+					'content_blog_id' => 11,
+					'post_id'         => 71,
+					'title'           => 'Wire',
+					'format'          => 'news',
+				)
+			),
+		);
+		$built   = extrachill_analytics_revenue_build_pages(
+			$records,
+			array(
+				'cohort' => 'resolved',
+				'limit'  => 0,
+			)
+		);
+
+		$this->assertSame( 3, $built['totals']['pages_before_limit'] );
+		$this->assertSame( array( 11, 1, 7 ), array_column( $built['pages'], 'content_blog_id' ) );
+		$this->assertSame( array( 'p11:71', 'p1:71', 'p7:71' ), array_column( $built['pages'], 'page_key' ) );
+	}
+
+	/**
 	 * Derived RPM = revenue / (views/1000), distinct from source_rpm.
 	 */
 	public function test_derived_rpm_distinct_from_source_rpm(): void {

--- a/tests/GetContentRevenuePagesTest.php
+++ b/tests/GetContentRevenuePagesTest.php
@@ -363,20 +363,18 @@ final class GetContentRevenuePagesTest extends TestCase {
 
 	/**
 	 * M6/B2/B4: source-string contract — the callback populates path, enforces
-	 * blog authorization, switch_to_blog around resolution, applies the default
+	 * blog authorization, persisted owning-site metadata, applies the default
 	 * window contract, and exposes selected periods/batches.
 	 */
 	public function test_callback_populates_path_and_enforces_auth_and_scope(): void {
 		$source = $this->ability_source();
 
-		// path is derived from the permalink.
-		$this->assertStringContainsString( 'wp_make_link_relative', $source );
+		// Owning-site metadata includes the canonical permalink path.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_content_metadata', $source );
 		// Network/blog authorization.
 		$this->assertStringContainsString( 'extrachill_analytics_revenue_authorize_blog_read', $source );
 		$this->assertStringContainsString( 'manage_network_options', $source );
-		// switch_to_blog around resolution.
-		$this->assertStringContainsString( 'extrachill_analytics_revenue_maybe_switch_to_blog', $source );
-		$this->assertStringContainsString( 'extrachill_analytics_revenue_maybe_restore_blog', $source );
+		$this->assertStringNotContainsString( 'extrachill_analytics_revenue_resolve_post_id', $source );
 		// Default window contract (freshest dated period).
 		$this->assertStringContainsString( 'extrachill_analytics_revenue_resolve_default_period', $source );
 		// Selected periods/batches exposed.
@@ -748,14 +746,13 @@ final class GetContentRevenuePagesTest extends TestCase {
 	public function test_callback_publish_gates_and_delegates(): void {
 		$source = $this->ability_source();
 
-		// Publish-status gate (same contract as the rollup).
-		$this->assertStringContainsString( "'publish' === get_post_status( \$post_id )", $source );
+		// Publish-status gate is owned by the persisted content metadata helper.
 		// Read models consume persisted attribution; resolver fanout is ingestion-only.
 		$this->assertStringNotContainsString( 'extrachill_analytics_revenue_resolve_post_id', $source );
 		// Reuses the shared route-family classifier.
 		$this->assertStringContainsString( 'extrachill_analytics_revenue_classify_route_family', $source );
-		// Reuses the shared content-format classifier.
-		$this->assertStringContainsString( 'extrachill_analytics_classify_format', $source );
+		// Metadata/classification runs in the owning-site helper.
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_content_metadata', $source );
 		// Reuses the shared store reader — no new SQL/table.
 		$this->assertStringContainsString( 'extrachill_analytics_revenue_get_rows', $source );
 		// Delegates the pure half to the builder.

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -295,6 +295,86 @@ final class IngestRevenueTest extends TestCase {
 	}
 
 	/**
+	 * Batch boundaries retain every distinct path and never repeat resolver work.
+	 */
+	public function test_network_path_batches_retain_all_paths(): void {
+		foreach ( array( 100, 101, 200, 201 ) as $count ) {
+			$paths = array();
+			for ( $i = 0; $i < $count; ++$i ) {
+				$paths[] = '/events/test-' . $i . '/';
+			}
+			$GLOBALS['extrachill_network_resolver_calls'] = array();
+			$result                                       = extrachill_analytics_revenue_resolve_network_paths( $paths );
+			$this->assertTrue( $result['success'] );
+			$this->assertCount( $count, $result['results'] );
+			$this->assertSame( $paths, array_keys( $result['results'] ) );
+			$expected_chunks = array_fill( 0, (int) floor( $count / 100 ), 100 );
+			if ( 0 !== $count % 100 ) {
+				$expected_chunks[] = $count % 100;
+			}
+			$this->assertSame( $expected_chunks, array_map( 'count', $GLOBALS['extrachill_network_resolver_calls'] ) );
+		}
+	}
+
+	/**
+	 * Resolved evidence accepts only typed positive IDs and absolute HTTP URLs.
+	 */
+	public function test_network_resolved_evidence_requires_strict_types(): void {
+		$path = '/events/show/';
+		foreach ( array( '7', 0, -1 ) as $blog_id ) {
+			$scan = array(
+				'scan'    => array( 'status' => 'complete' ),
+				'results' => array(
+					array(
+						'path'      => $path,
+						'status'    => 'resolved',
+						'candidate' => array(
+							'blog_id'       => $blog_id,
+							'post_id'       => 7,
+							'canonical_url' => 'https://events.extrachill.com/events/show/',
+						),
+					),
+				),
+			);
+			$this->assertFalse( extrachill_analytics_revenue_validate_network_scan( $scan, array( $path ) )['success'] );
+		}
+		foreach ( array( '7', 0, -1 ) as $post_id ) {
+			$scan = array(
+				'scan'    => array( 'status' => 'complete' ),
+				'results' => array(
+					array(
+						'path'      => $path,
+						'status'    => 'resolved',
+						'candidate' => array(
+							'blog_id'       => 7,
+							'post_id'       => $post_id,
+							'canonical_url' => 'https://events.extrachill.com/events/show/',
+						),
+					),
+				),
+			);
+			$this->assertFalse( extrachill_analytics_revenue_validate_network_scan( $scan, array( $path ) )['success'] );
+		}
+		foreach ( array( '/events/show/', 'ftp://events.extrachill.com/events/show/', 'not-a-url' ) as $url ) {
+			$scan = array(
+				'scan'    => array( 'status' => 'complete' ),
+				'results' => array(
+					array(
+						'path'      => $path,
+						'status'    => 'resolved',
+						'candidate' => array(
+							'blog_id'       => 7,
+							'post_id'       => 7,
+							'canonical_url' => $url,
+						),
+					),
+				),
+			);
+			$this->assertFalse( extrachill_analytics_revenue_validate_network_scan( $scan, array( $path ) )['success'] );
+		}
+	}
+
+	/**
 	 * Replace mode removes rows that disappeared from the refreshed source.
 	 */
 	public function test_replace_removes_stale_rows_that_disappeared(): void {

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -375,6 +375,78 @@ final class IngestRevenueTest extends TestCase {
 	}
 
 	/**
+	 * Events and Wire candidates retain their authoritative identity on a
+	 * deterministic re-ingest without changing source metrics or totals.
+	 */
+	public function test_network_events_and_wire_attribution_is_idempotent(): void {
+		$GLOBALS['extrachill_network_resolver_results'] = array(
+			'/events/show/'         => array(
+				'path'      => '/events/show/',
+				'status'    => 'resolved',
+				'candidate' => array(
+					'blog_id'       => 7,
+					'post_id'       => 71,
+					'canonical_url' => 'https://events.extrachill.com/events/show/',
+				),
+			),
+			'/festival-wire/story/' => array(
+				'path'      => '/festival-wire/story/',
+				'status'    => 'resolved',
+				'candidate' => array(
+					'blog_id'       => 11,
+					'post_id'       => 71,
+					'canonical_url' => 'https://wire.extrachill.com/festival-wire/story/',
+				),
+			),
+		);
+		$rows   = array(
+			array(
+				'slug'    => '/events/show/',
+				'views'   => 100,
+				'revenue' => 2.5,
+			),
+			array(
+				'slug'    => '/festival-wire/story/',
+				'views'   => 40,
+				'revenue' => 1.0,
+			),
+		);
+		$first  = $this->ingest( $rows, array( 'period' => '2026-06' ) );
+		$stored = $this->store_records( '2026-06' );
+		$second = $this->ingest( $rows, array( 'period' => '2026-06' ) );
+
+		$this->assertTrue( $first['success'] );
+		$this->assertTrue( $second['success'] );
+		$this->assertSame( 2, $second['replaced'] );
+		$this->assertSame( array( 7, 11 ), array_column( $stored, 'content_blog_id' ) );
+		$this->assertSame( array( 71, 71 ), array_column( $stored, 'post_id' ) );
+		$this->assertSame( array( 140, 3.5 ), array_values( $this->store_totals( '2026-06' ) ) );
+	}
+
+	/**
+	 * Ambiguous and unresolved Network evidence never selects a candidate.
+	 */
+	public function test_ambiguous_and_unresolved_network_rows_remain_unowned(): void {
+		$GLOBALS['extrachill_network_resolver_results'] = array(
+			'/events/ambiguous/' => array(
+				'path'       => '/events/ambiguous/',
+				'status'     => 'ambiguous',
+				'candidates' => array(),
+			),
+			'/events/missing/'   => array(
+				'path'   => '/events/missing/',
+				'status' => 'unresolved',
+			),
+		);
+		$result = $this->ingest( array( array( 'slug' => '/events/ambiguous/' ), array( 'slug' => '/events/missing/' ) ), array( 'period' => '2026-06' ) );
+		$this->assertTrue( $result['success'] );
+		foreach ( $this->store_records( '2026-06' ) as $row ) {
+			$this->assertEmpty( $row['post_id'] );
+			$this->assertEmpty( $row['content_blog_id'] );
+		}
+	}
+
+	/**
 	 * Replace mode removes rows that disappeared from the refreshed source.
 	 */
 	public function test_replace_removes_stale_rows_that_disappeared(): void {

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 require_once dirname( __DIR__ ) . '/inc/core/content-format-classifier.php';
 require_once dirname( __DIR__ ) . '/inc/database/mediavine-revenue-db.php';
 require_once dirname( __DIR__ ) . '/inc/core/mediavine-csv-import.php';
+require_once dirname( __DIR__ ) . '/inc/core/revenue-content-attribution.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/ingest-revenue.php';
 require_once dirname( __DIR__ ) . '/inc/database/class-extrachill-analytics-revenue-store.php';
 require_once __DIR__ . '/class-fake-revenue-store.php';
@@ -40,7 +41,8 @@ final class IngestRevenueTest extends TestCase {
 	 */
 	protected function setUp(): void {
 		$this->store = new Fake_Revenue_Store();
-		unset( $GLOBALS['extrachill_ingest_url_map'], $GLOBALS['extrachill_ingest_post_map'], $GLOBALS['extrachill_ingest_capabilities'], $GLOBALS['extrachill_ingest_site_capabilities'] );
+		unset( $GLOBALS['extrachill_ingest_url_map'], $GLOBALS['extrachill_ingest_post_map'], $GLOBALS['extrachill_ingest_capabilities'], $GLOBALS['extrachill_ingest_site_capabilities'], $GLOBALS['extrachill_network_resolver_results'], $GLOBALS['extrachill_network_resolver_incomplete'] );
+		$GLOBALS['extrachill_network_resolver_calls'] = array();
 	}
 
 	/**
@@ -188,6 +190,69 @@ final class IngestRevenueTest extends TestCase {
 
 		$this->assertSame( $totals_after_first, $this->store_totals( '2026-05' ) );
 		$this->assertSame( $first['identity']['import_batch'], $second['identity']['import_batch'] );
+	}
+
+	/**
+	 * Path-only rows resolved by Network retain snapshot scope separately from
+	 * their authoritative content identity.
+	 */
+	public function test_network_resolved_rows_persist_content_ownership(): void {
+		$GLOBALS['extrachill_network_resolver_results'] = array(
+			'/events/show/' => array(
+				'path'      => '/events/show/',
+				'status'    => 'resolved',
+				'candidate' => array(
+					'blog_id'       => 7,
+					'post_id'       => 71,
+					'canonical_url' => 'https://events.extrachill.com/events/show/',
+				),
+			),
+		);
+
+		$result = $this->ingest(
+			array(
+				array(
+					'slug'    => '/events/show/',
+					'views'   => 100,
+					'revenue' => 2.5,
+				),
+			),
+			array( 'period' => '2026-06' )
+		);
+		$row    = reset( $this->store->rows );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $row['blog_id'], 'The snapshot scope remains the importing blog.' );
+		$this->assertSame( 7, $row['content_blog_id'] );
+		$this->assertSame( 71, $row['post_id'] );
+		$this->assertSame( 'https://events.extrachill.com/events/show/', $row['canonical_url'] );
+	}
+
+	/**
+	 * Incomplete network evidence aborts before the existing snapshot is read or
+	 * mutated, preserving deterministic replacement atomicity.
+	 */
+	public function test_incomplete_network_scan_aborts_before_snapshot_replacement(): void {
+		$this->ingest( $this->rows( array( 'existing' => 10.0 ) ), array( 'period' => '2026-06' ) );
+		$before                     = $this->store->rows;
+		$this->store->operation_log = array();
+		$GLOBALS['extrachill_network_resolver_incomplete'] = true;
+
+		$result = $this->ingest(
+			array(
+				array(
+					'slug'    => '/festival-wire/story/',
+					'views'   => 20,
+					'revenue' => 4.0,
+				),
+			),
+			array( 'period' => '2026-06' )
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertFalse( $result['written'] );
+		$this->assertSame( $before, $this->store->rows );
+		$this->assertSame( array(), $this->store->operation_log );
 	}
 
 	/**

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -256,6 +256,45 @@ final class IngestRevenueTest extends TestCase {
 	}
 
 	/**
+	 * A nominally complete scan must be a strict one-result-per-path bijection.
+	 */
+	public function test_malformed_complete_network_scan_is_rejected(): void {
+		$paths = array( '/events/show/', '/festival-wire/story/' );
+		$valid = array(
+			'scan'    => array( 'status' => 'complete' ),
+			'results' => array(
+				array(
+					'path'   => '/events/show/',
+					'status' => 'unresolved',
+				),
+				array(
+					'path'   => '/events/show/',
+					'status' => 'unresolved',
+				),
+			),
+		);
+
+		$result = extrachill_analytics_revenue_validate_network_scan( $valid, $paths );
+		$this->assertFalse( $result['success'] );
+
+		$missing_candidate = array(
+			'scan'    => array( 'status' => 'complete' ),
+			'results' => array(
+				array(
+					'path'      => '/events/show/',
+					'status'    => 'resolved',
+					'candidate' => array(),
+				),
+				array(
+					'path'   => '/festival-wire/story/',
+					'status' => 'unresolved',
+				),
+			),
+		);
+		$this->assertFalse( extrachill_analytics_revenue_validate_network_scan( $missing_candidate, $paths )['success'] );
+	}
+
+	/**
 	 * Replace mode removes rows that disappeared from the refreshed source.
 	 */
 	public function test_replace_removes_stale_rows_that_disappeared(): void {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -266,6 +266,37 @@ if ( ! function_exists( 'url_to_postid' ) ) {
 		return 0;
 	}
 }
+if ( ! function_exists( 'ec_resolve_frontend_paths' ) ) {
+	/**
+	 * Test double for the Network batch resolver contract.
+	 *
+	 * @param array $paths Host-relative paths.
+	 * @param array $args Resolver arguments.
+	 * @return array Contract-shaped fixture response.
+	 */
+	function ec_resolve_frontend_paths( array $paths, array $args = array() ) {
+		unset( $args );
+		$GLOBALS['extrachill_network_resolver_calls'][] = $paths;
+		if ( ! empty( $GLOBALS['extrachill_network_resolver_incomplete'] ) ) {
+			return array(
+				'scan'    => array( 'status' => 'incomplete' ),
+				'results' => array(),
+			);
+		}
+		$fixtures = isset( $GLOBALS['extrachill_network_resolver_results'] ) ? $GLOBALS['extrachill_network_resolver_results'] : array();
+		$results  = array();
+		foreach ( $paths as $path ) {
+			$results[] = isset( $fixtures[ $path ] ) ? $fixtures[ $path ] : array(
+				'path'   => $path,
+				'status' => 'unresolved',
+			);
+		}
+		return array(
+			'scan'    => array( 'status' => 'complete' ),
+			'results' => $results,
+		);
+	}
+}
 if ( ! function_exists( 'get_post' ) ) {
 	/**
 	 * Stub get_post returning an object with post_name from a $GLOBALS map.


### PR DESCRIPTION
## Summary
- Resolves locally unresolved host-relative paths through Network #122 before replacement writes.
- Persists content_blog_id/canonical_url separately from snapshot scope and reads owning-site metadata without resolver calls.
- Strictly validates resolver evidence and preserves every path across chunk boundaries.

Fixes #146
Depends on Extra-Chill/extrachill-network#122 (merged 957ae842).

## Behavioral Coverage
- Events and Wire attribution, deterministic re-ingestion, and ambiguous/unresolved ownership preservation.
- Composite main/Events/Wire identities with equal post IDs remain separate in page and diagnostics builders.
- 100/101/200/201 path batches retain every result exactly once.

## Verification
- composer test: 195 tests, 641 assertions passing.
- Changed-file PHPCS, syntax checks, and git diff --check pass.
- Full-repo PHPCS was not run; existing baseline is outside this PR scope and may exceed the test window.

## Post-Deploy
Do not mutate historical rows through migration. After both releases deploy, run the explicit idempotent June re-fetch and verify unchanged totals while Events and Wire move into owning-site rollups.