### PR TITLE
fix: preserve homepage revenue snapshots

### DIFF
--- a/inc/core/abilities/ingest-revenue.php
+++ b/inc/core/abilities/ingest-revenue.php
@@ -434,8 +434,12 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 		if ( '' === trim( $raw_slug ) ) {
 			continue;
 		}
+		$is_home = '/' === extrachill_analytics_revenue_frontend_path( $raw_slug );
 
-		if ( isset( $input['post_id'] ) && (int) $input['post_id'] > 0 ) {
+		if ( $is_home ) {
+			$post_id = 0;
+			$slug    = '';
+		} elseif ( isset( $input['post_id'] ) && (int) $input['post_id'] > 0 ) {
 			$post_id = (int) $input['post_id'];
 			if ( function_exists( 'get_post' ) ) {
 				$post = get_post( $post_id );
@@ -449,7 +453,6 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 			$slug         = $resolved_row['slug'];
 		}
 
-		$is_home = '/' === extrachill_analytics_revenue_frontend_path( $raw_slug );
 		if ( '' === $slug && ! $is_home ) {
 			continue;
 		}
@@ -489,7 +492,7 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 	// replace any part of the existing snapshot.
 	$network_paths = array();
 	foreach ( $by_slug as $record ) {
-		if ( empty( $record['post_id'] ) ) {
+		if ( empty( $record['post_id'] ) && '' !== $record['slug'] ) {
 			$path = extrachill_analytics_revenue_frontend_path( $record['url'] );
 			if ( null !== $path ) {
 				$network_paths[ $path ] = true;
@@ -505,7 +508,7 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 		);
 	}
 	foreach ( $by_slug as &$record ) {
-		if ( ! empty( $record['post_id'] ) ) {
+		if ( ! empty( $record['post_id'] ) || '' === $record['slug'] ) {
 			continue;
 		}
 		$path   = extrachill_analytics_revenue_frontend_path( $record['url'] );

--- a/inc/core/abilities/ingest-revenue.php
+++ b/inc/core/abilities/ingest-revenue.php
@@ -165,11 +165,9 @@ function extrachill_analytics_revenue_snapshot_identity( array $args ) {
 function extrachill_analytics_revenue_build_ingestion_plan( array $records, array $existing, $mode ) {
 	$existing_by_slug = array();
 	foreach ( $existing as $row ) {
-		$slug = is_object( $row ) && isset( $row->slug ) ? (string) $row->slug : (string) ( isset( $row['slug'] ) ? $row['slug'] : '' );
-		if ( '' !== $slug ) {
-			$id                        = is_object( $row ) && isset( $row->id ) ? (int) $row->id : (int) ( isset( $row['id'] ) ? $row['id'] : 0 );
-			$existing_by_slug[ $slug ] = $id;
-		}
+		$slug                      = is_object( $row ) && isset( $row->slug ) ? (string) $row->slug : (string) ( isset( $row['slug'] ) ? $row['slug'] : '' );
+		$id                        = is_object( $row ) && isset( $row->id ) ? (int) $row->id : (int) ( isset( $row['id'] ) ? $row['id'] : 0 );
+		$existing_by_slug[ $slug ] = $id;
 	}
 
 	$inserts  = array();
@@ -178,9 +176,6 @@ function extrachill_analytics_revenue_build_ingestion_plan( array $records, arra
 
 	foreach ( $records as $rec ) {
 		$slug = isset( $rec['slug'] ) ? (string) $rec['slug'] : '';
-		if ( '' === $slug ) {
-			continue;
-		}
 		if ( isset( $existing_by_slug[ $slug ] ) ) {
 			$replaces[] = $rec;
 		} else {
@@ -454,7 +449,8 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 			$slug         = $resolved_row['slug'];
 		}
 
-		if ( '' === $slug ) {
+		$is_home = '/' === extrachill_analytics_revenue_frontend_path( $raw_slug );
+		if ( '' === $slug && ! $is_home ) {
 			continue;
 		}
 		$canonical_url = $post_id > 0 && function_exists( 'get_permalink' ) ? (string) get_permalink( $post_id ) : '';

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -196,6 +196,15 @@ final class IngestRevenueTest extends TestCase {
 	 * The homepage remains an unresolved revenue row instead of being discarded.
 	 */
 	public function test_homepage_row_is_preserved_and_idempotent(): void {
+		$GLOBALS['extrachill_network_resolver_results']['/'] = array(
+			'path'      => '/',
+			'status'    => 'resolved',
+			'candidate' => array(
+				'blog_id'       => 7,
+				'post_id'       => 99,
+				'canonical_url' => 'https://events.extrachill.com/',
+			),
+		);
 		$rows = array(
 			array(
 				'slug'    => '/',
@@ -230,6 +239,7 @@ final class IngestRevenueTest extends TestCase {
 		$this->assertSame( '/', $home['url'] );
 		$this->assertSame( 0, $home['post_id'] );
 		$this->assertNull( $home['content_blog_id'] );
+		$this->assertNotContains( '/', array_merge( ...$GLOBALS['extrachill_network_resolver_calls'] ) );
 		$this->assertSame(
 			array(
 				'views'   => 7127,

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -193,6 +193,65 @@ final class IngestRevenueTest extends TestCase {
 	}
 
 	/**
+	 * The homepage remains an unresolved revenue row instead of being discarded.
+	 */
+	public function test_homepage_row_is_preserved_and_idempotent(): void {
+		$rows = array(
+			array(
+				'slug'    => '/',
+				'views'   => 7027,
+				'revenue' => 1.08,
+			),
+			array(
+				'slug'    => '/article/',
+				'views'   => 100,
+				'revenue' => 5.00,
+			),
+		);
+
+		$first = $this->ingest( $rows, array( 'period' => '2026-06' ) );
+		$this->assertTrue( $first['success'] );
+		$this->assertSame( 2, $first['input_rows'] );
+		$this->assertSame( 2, $first['rows'] );
+		$this->assertSame( 2, $first['inserted'] );
+		$this->assertSame( 0, $first['resolved'] );
+		$this->assertSame( 2, $first['unresolved'] );
+
+		$records = $this->store_records( '2026-06' );
+		$this->assertCount( 2, $records );
+		$home = array_values(
+			array_filter(
+				$records,
+				static function ( $row ) {
+					return '' === $row['slug'];
+				}
+			)
+		)[0];
+		$this->assertSame( '/', $home['url'] );
+		$this->assertSame( 0, $home['post_id'] );
+		$this->assertNull( $home['content_blog_id'] );
+		$this->assertSame(
+			array(
+				'views'   => 7127,
+				'revenue' => 6.08,
+			),
+			$this->store_totals( '2026-06' )
+		);
+
+		$second = $this->ingest( $rows, array( 'period' => '2026-06' ) );
+		$this->assertTrue( $second['success'] );
+		$this->assertSame( 0, $second['inserted'] );
+		$this->assertSame( 2, $second['replaced'] );
+		$this->assertSame(
+			array(
+				'views'   => 7127,
+				'revenue' => 6.08,
+			),
+			$this->store_totals( '2026-06' )
+		);
+	}
+
+	/**
 	 * Path-only rows resolved by Network retain snapshot scope separately from
 	 * their authoritative content identity.
 	 */


### PR DESCRIPTION
## Summary
- preserve the `/` Mediavine row under its existing empty-slug storage identity
- keep invalid empty paths rejected while retaining homepage views and revenue
- make deterministic replacement recognize and replace existing empty-slug rows
- add idempotency and totals regression coverage for homepage plus content ingestion

Closes #150.

## Verification
- 196 PHPUnit tests, 656 assertions
- changed-file WordPress PHPCS passes
- PHP syntax and `git diff --check` pass

## Production evidence
June 2026 source includes homepage `/` with 7,027 views and $1.08 revenue. Before this fix, dry-run reported 1,049 rows from 1,050 source rows; a real replacement would have broken exact reconciliation.