### PR TITLE
Fix canonical revenue path aggregation

### DIFF
--- a/inc/core/abilities/ingest-revenue.php
+++ b/inc/core/abilities/ingest-revenue.php
@@ -812,7 +812,7 @@ function extrachill_analytics_register_ingest_revenue_ability() {
 				'properties' => array(
 					'rows'         => array(
 						'type'        => 'array',
-						'description' => __( 'REQUIRED, non-empty. Normalized per-URL revenue rows. Each row carries a slug/url plus metrics (views, revenue, rpm, cpm, viewability, fill_rate, impressions_per_pageview) and an optional pre-resolved post_id. Duplicate slugs are deduped (last wins).', 'extrachill-analytics' ),
+						'description' => __( 'REQUIRED, non-empty. Normalized per-URL revenue rows. Each row carries a slug/url plus metrics (views, revenue, rpm, cpm, viewability, fill_rate, impressions_per_pageview) and an optional pre-resolved post_id. Rows sharing a normalized slug are deterministically aggregated into one canonical row with summed views/revenue and derived or weighted rates.', 'extrachill-analytics' ),
 						'minItems'    => 1,
 						'items'       => array(
 							'type'       => 'object',

--- a/inc/core/abilities/ingest-revenue.php
+++ b/inc/core/abilities/ingest-revenue.php
@@ -294,6 +294,75 @@ function extrachill_analytics_revenue_ingest_authorize( $blog_id, $mode ) {
 }
 
 /**
+ * Aggregate metrics from rows that normalize to the same revenue identity.
+ *
+ * Impressions are inferred as views * impressions-per-pageview. Delivery rates
+ * use inferred-impression weighting when possible, then view weighting when no
+ * impressions can be inferred, then an arithmetic mean for all-zero-view rows.
+ * Sorting first makes floating-point addition deterministic for reordered input.
+ *
+ * @param array<int,array> $rows Metric-bearing normalized rows.
+ * @return array Aggregated metrics.
+ */
+function extrachill_analytics_revenue_aggregate_metrics( array $rows ) {
+	usort(
+		$rows,
+		static function ( $a, $b ) {
+			$fields = array( 'slug', 'url', 'views', 'revenue', 'rpm', 'cpm', 'viewability', 'fill_rate', 'impressions_per_pageview' );
+			$left   = array();
+			$right  = array();
+			foreach ( $fields as $field ) {
+				$left[]  = isset( $a[ $field ] ) ? (string) $a[ $field ] : '';
+				$right[] = isset( $b[ $field ] ) ? (string) $b[ $field ] : '';
+			}
+			return strcmp( implode( "\0", $left ), implode( "\0", $right ) );
+		}
+	);
+
+	$total_views       = 0;
+	$total_revenue     = 0.0;
+	$total_impressions = 0.0;
+	$weighted          = array_fill_keys( array( 'cpm', 'viewability', 'fill_rate' ), 0.0 );
+	$view_weighted     = array_fill_keys( array( 'cpm', 'viewability', 'fill_rate' ), 0.0 );
+	$unweighted        = array_fill_keys( array( 'cpm', 'viewability', 'fill_rate' ), 0.0 );
+
+	foreach ( $rows as $row ) {
+		$views       = max( 0, isset( $row['views'] ) ? (int) $row['views'] : 0 );
+		$revenue     = isset( $row['revenue'] ) ? (float) $row['revenue'] : 0.0;
+		$impressions = $views * max( 0.0, isset( $row['impressions_per_pageview'] ) ? (float) $row['impressions_per_pageview'] : 0.0 );
+
+		$total_views       += $views;
+		$total_revenue     += $revenue;
+		$total_impressions += $impressions;
+
+		foreach ( array_keys( $weighted ) as $metric ) {
+			$value                     = isset( $row[ $metric ] ) ? (float) $row[ $metric ] : 0.0;
+			$weighted[ $metric ]      += $value * $impressions;
+			$view_weighted[ $metric ] += $value * $views;
+			$unweighted[ $metric ]    += $value;
+		}
+	}
+
+	$metrics = array(
+		'views'                    => $total_views,
+		'revenue'                  => $total_revenue,
+		'rpm'                      => $total_views > 0 ? $total_revenue / $total_views * 1000 : 0.0,
+		'impressions_per_pageview' => $total_views > 0 ? $total_impressions / $total_views : 0.0,
+	);
+	foreach ( array_keys( $weighted ) as $metric ) {
+		if ( $total_impressions > 0 ) {
+			$metrics[ $metric ] = $weighted[ $metric ] / $total_impressions;
+		} elseif ( $total_views > 0 ) {
+			$metrics[ $metric ] = $view_weighted[ $metric ] / $total_views;
+		} else {
+			$metrics[ $metric ] = $unweighted[ $metric ] / count( $rows );
+		}
+	}
+
+	return $metrics;
+}
+
+/**
  * Ingest a set of normalized revenue rows into the store with deterministic
  * snapshot identity and explicit replace/additive semantics.
  *
@@ -417,8 +486,8 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 	$period_start = $identity['period_start'];
 	$period_end   = $identity['period_end'];
 
-	// Resolve + normalize each incoming row against the target blog, deduping
-	// by normalized slug (last occurrence wins). Resolution (url_to_postid) is
+	// Resolve + normalize each incoming row against the target blog, aggregating
+	// rows that share a normalized slug. Resolution (url_to_postid) is
 	// current-blog-scoped, so switch for the duration to keep the stamped
 	// blog_id and resolved post_id in agreement on a multisite.
 	$switched = false;
@@ -457,14 +526,26 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 			continue;
 		}
 		$canonical_url = $post_id > 0 && function_exists( 'get_permalink' ) ? (string) get_permalink( $post_id ) : '';
+		$source_url    = extrachill_analytics_revenue_frontend_path( $raw_slug );
+		$source_url    = null !== $source_url ? $source_url : trim( $raw_slug );
 
 		if ( isset( $by_slug[ $slug ] ) ) {
 			++$duplicates;
+			$by_slug[ $slug ]['_metric_rows'][] = $input;
+			if ( strcmp( $source_url, $by_slug[ $slug ]['url'] ) < 0 ) {
+				$by_slug[ $slug ]['url'] = $source_url;
+			}
+			if ( $post_id > 0 && ( 0 === $by_slug[ $slug ]['post_id'] || $post_id < $by_slug[ $slug ]['post_id'] ) ) {
+				$by_slug[ $slug ]['post_id']         = $post_id;
+				$by_slug[ $slug ]['content_blog_id'] = $blog_id;
+				$by_slug[ $slug ]['canonical_url']   = $canonical_url;
+			}
+			continue;
 		}
 		$by_slug[ $slug ] = array(
 			'blog_id'                  => $blog_id,
 			'slug'                     => $slug,
-			'url'                      => $raw_slug,
+			'url'                      => $source_url,
 			'post_id'                  => $post_id,
 			'content_blog_id'          => $post_id > 0 ? $blog_id : null,
 			'canonical_url'            => $canonical_url,
@@ -479,12 +560,18 @@ function extrachill_analytics_revenue_ingest_rows( array $input_rows, array $arg
 			'period_start'             => $period_start,
 			'period_end'               => $period_end,
 			'import_batch'             => $batch,
+			'_metric_rows'             => array( $input ),
 		);
 	}
 
 	if ( $switched && function_exists( 'restore_current_blog' ) ) {
 		restore_current_blog();
 	}
+	foreach ( $by_slug as &$record ) {
+		$record = array_merge( $record, extrachill_analytics_revenue_aggregate_metrics( $record['_metric_rows'] ) );
+		unset( $record['_metric_rows'] );
+	}
+	unset( $record );
 
 	// Local resolution is authoritative for the snapshot site. Resolve only the
 	// remaining host-relative paths through Network, once per unique path. This

--- a/tests/IngestRevenueTest.php
+++ b/tests/IngestRevenueTest.php
@@ -990,20 +990,28 @@ final class IngestRevenueTest extends TestCase {
 	}
 
 	/**
-	 * Duplicate raw routes that normalize to one slug keep only the final row.
+	 * Slash variants aggregate exact totals and derive weighted delivery metrics.
 	 */
-	public function test_duplicate_normalized_rows_are_deduped(): void {
+	public function test_duplicate_normalized_rows_are_aggregated(): void {
 		$result = $this->ingest(
 			array(
 				array(
-					'slug'    => '/a/',
-					'views'   => 100,
-					'revenue' => 10.0,
+					'slug'                     => '/mama-say-mama-sa-mama-coosa-meaning/',
+					'views'                    => 591,
+					'revenue'                  => 13.45,
+					'cpm'                      => 2.0,
+					'viewability'              => 70.0,
+					'fill_rate'                => 90.0,
+					'impressions_per_pageview' => 2.0,
 				),
 				array(
-					'slug'    => 'a',
-					'views'   => 200,
-					'revenue' => 20.0,
+					'slug'                     => '/mama-say-mama-sa-mama-coosa-meaning',
+					'views'                    => 83,
+					'revenue'                  => 2.20,
+					'cpm'                      => 4.0,
+					'viewability'              => 80.0,
+					'fill_rate'                => 100.0,
+					'impressions_per_pageview' => 3.0,
 				),
 			),
 			array( 'period' => '2026-05' )
@@ -1011,13 +1019,151 @@ final class IngestRevenueTest extends TestCase {
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 1, $result['duplicate_rows_deduped'] );
+		$row = reset( $this->store->rows );
 		$this->assertSame(
 			array(
-				'views'   => 200,
-				'revenue' => 20.0,
+				'views'   => 674,
+				'revenue' => 15.65,
 			),
 			$this->store_totals( '2026-05' )
 		);
+		$this->assertSame( '/mama-say-mama-sa-mama-coosa-meaning/', $row['url'] );
+		$this->assertEqualsWithDelta( 15.65 / 674 * 1000, $row['rpm'], 0.000001 );
+		$this->assertEqualsWithDelta( ( 591 * 2 + 83 * 3 ) / 674, $row['impressions_per_pageview'], 0.000001 );
+		$this->assertEqualsWithDelta( ( 2 * 1182 + 4 * 249 ) / 1431, $row['cpm'], 0.000001 );
+		$this->assertEqualsWithDelta( ( 70 * 1182 + 80 * 249 ) / 1431, $row['viewability'], 0.000001 );
+		$this->assertEqualsWithDelta( ( 90 * 1182 + 100 * 249 ) / 1431, $row['fill_rate'], 0.000001 );
+	}
+
+	/**
+	 * Aggregation is independent of source order and repeat replacement is stable.
+	 */
+	public function test_aggregation_is_order_independent_and_repeatable(): void {
+		$rows = array(
+			array(
+				'slug'                     => '/a',
+				'views'                    => 2,
+				'revenue'                  => 0.2,
+				'cpm'                      => 4,
+				'impressions_per_pageview' => 2,
+			),
+			array(
+				'slug'                     => '/a/',
+				'views'                    => 3,
+				'revenue'                  => 0.3,
+				'cpm'                      => 6,
+				'impressions_per_pageview' => 1,
+			),
+			array(
+				'slug'                     => '/a/?source=feed',
+				'views'                    => 5,
+				'revenue'                  => 0.5,
+				'cpm'                      => 8,
+				'impressions_per_pageview' => 3,
+			),
+		);
+
+		$first      = $this->ingest( $rows, array( 'period' => '2026-05' ) );
+		$first_row  = reset( $this->store->rows );
+		$second     = $this->ingest( array_reverse( $rows ), array( 'period' => '2026-05' ) );
+		$second_row = reset( $this->store->rows );
+
+		$this->assertTrue( $first['success'] );
+		$this->assertTrue( $second['success'] );
+		$this->assertSame( 2, $second['duplicate_rows_deduped'] );
+		$this->assertSame( 0, $second['inserted'] );
+		$this->assertSame( 1, $second['replaced'] );
+		$this->assertSame( $first_row, $second_row );
+		$this->assertSame( 10, $second_row['views'] );
+		$this->assertSame( 1.0, $second_row['revenue'] );
+		$this->assertSame( '/a/', $second_row['url'] );
+	}
+
+	/**
+	 * Zero-impression rows use view weighting; all-zero-view rows use a mean.
+	 */
+	public function test_zero_view_and_zero_impression_rate_fallbacks(): void {
+		$this->ingest(
+			array(
+				array(
+					'slug'        => '/views/',
+					'views'       => 10,
+					'cpm'         => 2,
+					'viewability' => 20,
+					'fill_rate'   => 40,
+				),
+				array(
+					'slug'        => '/views',
+					'views'       => 30,
+					'cpm'         => 6,
+					'viewability' => 60,
+					'fill_rate'   => 80,
+				),
+				array(
+					'slug'        => '/zero/',
+					'views'       => 0,
+					'revenue'     => 1.25,
+					'cpm'         => 2,
+					'viewability' => 20,
+					'fill_rate'   => 40,
+					'rpm'         => 99,
+				),
+				array(
+					'slug'        => '/zero',
+					'views'       => 0,
+					'revenue'     => 2.75,
+					'cpm'         => 6,
+					'viewability' => 60,
+					'fill_rate'   => 80,
+					'rpm'         => 199,
+				),
+			),
+			array( 'period' => '2026-05' )
+		);
+
+		$records = array_column( $this->store->rows, null, 'slug' );
+		$this->assertSame( 5.0, $records['views']['cpm'] );
+		$this->assertSame( 50.0, $records['views']['viewability'] );
+		$this->assertSame( 70.0, $records['views']['fill_rate'] );
+		$this->assertSame( 0.0, $records['views']['impressions_per_pageview'] );
+		$this->assertSame( 0.0, $records['zero']['rpm'] );
+		$this->assertSame( 4.0, $records['zero']['cpm'] );
+		$this->assertSame( 40.0, $records['zero']['viewability'] );
+		$this->assertSame( 60.0, $records['zero']['fill_rate'] );
+		$this->assertSame( 4.0, $records['zero']['revenue'] );
+	}
+
+	/**
+	 * Homepage variants remain one unresolved canonical row with summed metrics.
+	 */
+	public function test_homepage_variants_aggregate_without_network_attribution(): void {
+		$result = $this->ingest(
+			array(
+				array(
+					'slug'    => '/',
+					'views'   => 7,
+					'revenue' => 1.25,
+				),
+				array(
+					'slug'    => '/?source=feed',
+					'views'   => 3,
+					'revenue' => 0.75,
+				),
+			),
+			array( 'period' => '2026-05' )
+		);
+		$row    = reset( $this->store->rows );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['rows'] );
+		$this->assertSame( 1, $result['duplicate_rows_deduped'] );
+		$this->assertSame( '', $row['slug'] );
+		$this->assertSame( '/', $row['url'] );
+		$this->assertSame( 10, $row['views'] );
+		$this->assertSame( 2.0, $row['revenue'] );
+		$this->assertSame( 0, $row['post_id'] );
+		$this->assertNull( $row['content_blog_id'] );
+		$this->assertEmpty( $GLOBALS['extrachill_network_resolver_calls'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- aggregate every raw revenue row that normalizes to the same canonical slug instead of applying last-row-wins replacement
- preserve a deterministic canonical trailing-slash source path while retaining homepage handling and cross-network content attribution
- cover exact totals, weighted delivery metrics, replacement idempotency, order independence, zero-volume fallbacks, and homepage variants

## Production evidence
April 2026 contains 1,103 raw paths with 20,562 views and $342.03 in revenue. Those paths normalize to 966 canonical slugs, including 137 trailing-slash/non-slash collision pairs. The prior last-row-wins behavior retained only 10,705 views and $130.05, losing 9,857 views and $211.98.

The representative pair `/mama-say-mama-sa-mama-coosa-meaning/` (591 views / $13.45) plus `/mama-say-mama-sa-mama-coosa-meaning` (83 views / $2.20) now stores one canonical `/mama-say-mama-sa-mama-coosa-meaning/` row with exactly 674 views and $15.65.

## Aggregation formulae
- `views = sum(row views)` and `revenue = sum(row revenue)`
- `source RPM = total revenue / total views * 1000` when views are positive; otherwise `0`
- inferred impressions per row are `views * impressions_per_pageview`
- aggregate `impressions_per_pageview = total inferred impressions / total views` when views are positive; otherwise `0`
- CPM, viewability, and fill rate are weighted by inferred impressions when inferred impressions exist
- when inferred impressions are zero but views exist, delivery rates use view weighting
- when both impressions and views are zero, delivery rates use the arithmetic mean, producing a deterministic result without inventing volume
- contributors are sorted by a stable scalar key before floating-point reduction, and source paths are canonicalized, making results independent of input order

`duplicate_rows_deduped` keeps its existing contract: the count of usable input rows beyond the number of canonical identities.

## Verification
- `vendor/bin/phpunit` (199 tests, 691 assertions)
- `vendor/bin/phpcs --standard=WordPress inc/core/abilities/ingest-revenue.php tests/IngestRevenueTest.php`
- `php -l inc/core/abilities/ingest-revenue.php`
- `php -l tests/IngestRevenueTest.php`
- `git diff --check`

No production replacement, release, or deployment was performed.

Closes #152