### PR TITLE
fix: respect ad eligibility in revenue reports

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -64,6 +64,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-g
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-demand-drill.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-conversion-map.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-crosslink-targets.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/revenue-ad-policy.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-stickiness.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-activation-funnel.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-content-revenue.php';

--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -242,6 +242,7 @@ function extrachill_analytics_revenue_diagnostic_totals_schema() {
 			'source_rpm'  => array( 'type' => 'number' ),
 			'derived_rpm' => array( 'type' => 'number' ),
 			'relative'    => array( 'type' => 'number' ),
+			'reason'      => array( 'type' => 'string' ),
 		),
 	);
 
@@ -310,6 +311,10 @@ function extrachill_analytics_revenue_diagnostic_totals_schema() {
 		),
 		'missing_batch'       => array( 'type' => 'integer' ),
 		'missing_period'      => array( 'type' => 'integer' ),
+		'instrumented_rows'   => array( 'type' => 'integer' ),
+		'unknown_rows'        => array( 'type' => 'integer' ),
+		'conflict_rows'       => array( 'type' => 'integer' ),
+		'conflict_revenue'    => array( 'type' => 'number' ),
 	);
 }
 
@@ -395,8 +400,14 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 		$metadata        = extrachill_analytics_revenue_content_metadata( $content_blog_id, $post_id );
 		$is_content      = is_array( $metadata );
 
-		$views   = (int) $row->views;
-		$revenue = (float) $row->revenue;
+		$views        = (int) $row->views;
+		$revenue      = (float) $row->revenue;
+		$source_url   = $row->url ? $row->url : $row->slug;
+		$route_family = $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $source_url );
+		$post_type    = $is_content && isset( $metadata['post_type'] ) ? (string) $metadata['post_type'] : '';
+		$ad_policy    = extrachill_analytics_revenue_get_ad_policy(
+			extrachill_analytics_revenue_ad_policy_context( $content_blog_id, $source_url, $post_type, $route_family )
+		);
 
 		$normalized[] = array(
 			'period_label'             => (string) $row->period_label,
@@ -409,7 +420,7 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 			'content_blog_id'          => $is_content ? $content_blog_id : 0,
 			'post_id'                  => $is_content ? $post_id : 0,
 			'is_content'               => $is_content,
-			'route_family'             => $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $row->url ? $row->url : $row->slug ),
+			'route_family'             => $route_family,
 			'format'                   => $is_content ? $metadata['format'] : '',
 			'views'                    => $views,
 			'revenue'                  => $revenue,
@@ -419,6 +430,7 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 			'fill_rate'                => (float) $row->fill_rate,
 			'impressions_per_pageview' => (float) $row->impressions_per_pageview,
 			'derived_rpm'              => $views > 0 ? round( $revenue / ( $views / 1000 ), 4 ) : 0.0,
+			'ad_policy'                => $ad_policy,
 		);
 	}
 
@@ -473,7 +485,7 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 		'summary'        => $built['summary'],
 		'checks'         => $built['checks'],
 		'scope'          => $scope_block_base,
-		'caveat'         => __( 'Source quirks (zero-view revenue, duplicate period batches, stored-vs-derived RPM variance, unresolved routes) are warnings — disclosure, not corruption claims. fail is reserved for genuine integrity violations: negative/impossible values or a read model that does not reconcile against the independent SQL aggregate. Freshness uses the period boundary (period_end), not the import timestamp. Resolution/format coverage dedupe by page_key before counting. Freshness/missing-period/duplicate-batch checks consider the whole per-blog history (unscoped); row-level checks honor the requested period/window/batch scope. An empty scoped query never passes. Resolution coverage uses the same publish-status gate as the rollup/pages abilities.', 'extrachill-analytics' ),
+		'caveat'         => __( 'Source quirks are warnings, not corruption claims. The ad_policy_consistency check consumes Extra Chill Network policy: unavailable policy is reported as unknown/not instrumented, and positive imported revenue on a blocked row warns with evidence without changing source revenue. fail remains reserved for impossible values or reconciliation failures. Freshness uses period_end; row-level checks honor the requested scope.', 'extrachill-analytics' ),
 	);
 }
 
@@ -518,6 +530,7 @@ function extrachill_analytics_revenue_build_diagnostics( array $snapshot ) {
 	$checks[] = extrachill_analytics_revenue_diag_negative_impossible_values( $rows );
 	$checks[] = extrachill_analytics_revenue_diag_rpm_variance( $rows );
 	$checks[] = extrachill_analytics_revenue_diag_provenance_coverage( $rows );
+	$checks[] = extrachill_analytics_revenue_diag_ad_policy_consistency( $rows );
 
 	$summary = array(
 		'pass'    => 0,
@@ -545,6 +558,73 @@ function extrachill_analytics_revenue_build_diagnostics( array $snapshot ) {
 		'overall_status' => $overall,
 		'summary'        => $summary,
 		'scope'          => $scope,
+	);
+}
+
+/**
+ * Disclose unavailable policy and positive revenue that contradicts no-ads policy.
+ *
+ * Source revenue is evidence only and is never rewritten.
+ *
+ * @param array $rows Normalized revenue rows.
+ * @return array Check.
+ */
+function extrachill_analytics_revenue_diag_ad_policy_consistency( array $rows ) {
+	$instrumented     = 0;
+	$unknown          = 0;
+	$conflicts        = 0;
+	$conflict_revenue = 0.0;
+	$samples          = array();
+
+	foreach ( $rows as $row ) {
+		$policy = extrachill_analytics_revenue_normalize_ad_policy( isset( $row['ad_policy'] ) ? $row['ad_policy'] : null );
+		if ( null === $policy['serve_ads'] ) {
+			++$unknown;
+			continue;
+		}
+		++$instrumented;
+
+		$revenue = isset( $row['revenue'] ) ? (float) $row['revenue'] : 0.0;
+		if ( ! extrachill_analytics_revenue_policy_conflicts( $policy, $revenue ) ) {
+			continue;
+		}
+
+		++$conflicts;
+		$conflict_revenue += $revenue;
+		if ( count( $samples ) < 5 ) {
+			$samples[] = array(
+				'slug'    => isset( $row['slug'] ) ? (string) $row['slug'] : '',
+				'revenue' => round( $revenue, 4 ),
+				'views'   => isset( $row['views'] ) ? (int) $row['views'] : 0,
+				'reason'  => $policy['reason'],
+			);
+		}
+	}
+
+	$evidence = array();
+	$status   = 'pass';
+	if ( $conflicts > 0 ) {
+		$status     = 'warning';
+		$evidence[] = sprintf( '%d row(s) contain $%0.4f imported revenue while authoritative policy declares ads blocked.', $conflicts, $conflict_revenue );
+		$evidence[] = 'Source revenue is preserved; investigate attribution timing or policy drift.';
+	} elseif ( $unknown > 0 ) {
+		$status     = 'warning';
+		$evidence[] = sprintf( 'Ad policy is unknown/not instrumented for %d row(s); no eligibility conclusion was inferred.', $unknown );
+	} else {
+		$evidence[] = sprintf( 'All %d row(s) have policy context and no imported revenue conflicts with it.', $instrumented );
+	}
+
+	return array(
+		'check'    => 'ad_policy_consistency',
+		'status'   => $status,
+		'evidence' => $evidence,
+		'totals'   => array(
+			'instrumented_rows' => $instrumented,
+			'unknown_rows'      => $unknown,
+			'conflict_rows'     => $conflicts,
+			'conflict_revenue'  => round( $conflict_revenue, 4 ),
+			'samples'           => $samples,
+		),
 	);
 }
 

--- a/inc/core/abilities/get-content-revenue-pages.php
+++ b/inc/core/abilities/get-content-revenue-pages.php
@@ -138,37 +138,41 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'success' => array(
+					'success'   => array(
 						'type'        => 'boolean',
 						'description' => 'Whether the read succeeded.',
 					),
-					'rows'    => array(
+					'rows'      => array(
 						'type'        => 'integer',
 						'description' => 'Snapshot rows examined in scope.',
 					),
-					'blog_id' => array(
+					'blog_id'   => array(
 						'type'        => 'integer',
 						'description' => 'Blog ID the revenue was read for.',
 					),
-					'window'  => array(
+					'window'    => array(
 						'type'        => 'string',
 						'description' => 'Human-readable window label.',
 					),
-					'cohort'  => array(
+					'cohort'    => array(
 						'type'        => 'string',
 						'enum'        => array( 'resolved', 'unresolved', 'all' ),
 						'description' => 'Cohort filter applied.',
 					),
-					'sort_by' => array(
+					'sort_by'   => array(
 						'type'        => 'string',
 						'description' => 'Sort key applied.',
 					),
-					'order'   => array(
+					'order'     => array(
 						'type'        => 'string',
 						'enum'        => array( 'desc', 'asc' ),
 						'description' => 'Sort direction applied.',
 					),
-					'scope'   => array(
+					'ad_policy' => array(
+						'type'        => 'object',
+						'description' => 'Current site-level policy from Extra Chill Network; null fields mean not instrumented.',
+					),
+					'scope'     => array(
 						'type'       => 'object',
 						'properties' => array(
 							'requested_period' => array(
@@ -200,7 +204,7 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 						),
 						'required'   => array( 'requested_period', 'effective_period', 'effective_batch', 'defaulted', 'selected_periods', 'selected_batches' ),
 					),
-					'pages'   => array(
+					'pages'     => array(
 						'type'        => 'array',
 						'description' => 'Ranked page rows.',
 						'items'       => array(
@@ -292,6 +296,19 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 									'type'        => 'boolean',
 									'description' => 'True when views=0 but revenue may be >0.',
 								),
+								'ad_policy'                => array(
+									'type'        => 'object',
+									'description' => 'Effective network-owned ad policy for this page/route.',
+								),
+								'revenue_status'           => array(
+									'type'        => 'string',
+									'enum'        => array( 'applicable', 'not_applicable', 'unknown' ),
+									'description' => 'Whether ad-revenue performance analysis applies to this row.',
+								),
+								'policy_conflict'          => array(
+									'type'        => 'boolean',
+									'description' => 'Imported revenue is positive while policy declares ads blocked.',
+								),
 								'benchmark_opportunity'    => array(
 									'type'        => 'boolean',
 									'description' => 'True when high RPM at meaningful volume (defensible).',
@@ -301,10 +318,10 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 									'description' => 'derived_rpm / cohort_median_rpm, or null when benchmark not computed.',
 								),
 							),
-							'required'   => array( 'page_key', 'cohort', 'post_id', 'content_blog_id', 'title', 'url', 'path', 'categories', 'format', 'route_family', 'published_date', 'views', 'revenue', 'derived_rpm', 'source_rpm', 'cpm', 'viewability', 'fill_rate', 'impressions_per_pageview', 'dollars_per_page', 'zero_views', 'benchmark_opportunity', 'benchmark_score' ),
+							'required'   => array( 'page_key', 'cohort', 'post_id', 'content_blog_id', 'title', 'url', 'path', 'categories', 'format', 'route_family', 'published_date', 'views', 'revenue', 'derived_rpm', 'source_rpm', 'cpm', 'viewability', 'fill_rate', 'impressions_per_pageview', 'dollars_per_page', 'zero_views', 'ad_policy', 'revenue_status', 'policy_conflict', 'benchmark_opportunity', 'benchmark_score' ),
 						),
 					),
-					'totals'  => array(
+					'totals'    => array(
 						'type'       => 'object',
 						'properties' => array(
 							'pages_before_limit' => array(
@@ -334,7 +351,7 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 						),
 						'required'   => array( 'pages_before_limit', 'pages_returned', 'cohort_pages', 'zero_views_pages', 'views', 'revenue' ),
 					),
-					'sample'  => array(
+					'sample'    => array(
 						'type'       => 'object',
 						'properties' => array(
 							'rows_in_window'           => array(
@@ -368,11 +385,11 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 						),
 						'required'   => array( 'rows_in_window', 'resolved_pages', 'unresolved_pages', 'after_min_views', 'truncated', 'benchmark_computed', 'sufficient_for_benchmark' ),
 					),
-					'caveat'  => array(
+					'caveat'    => array(
 						'type'        => 'string',
 						'description' => 'Stable analyst caveat.',
 					),
-					'error'   => array(
+					'error'     => array(
 						'type'        => 'string',
 						'description' => 'Error message when success is false.',
 					),
@@ -420,6 +437,9 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 	$order             = isset( $input['order'] ) ? (string) $input['order'] : 'desc';
 	$limit             = isset( $input['limit'] ) ? max( 0, (int) $input['limit'] ) : 50;
 	$include_post_meta = isset( $input['include_post_meta'] ) ? (bool) $input['include_post_meta'] : true;
+	$site_policy       = extrachill_analytics_revenue_get_ad_policy(
+		extrachill_analytics_revenue_ad_policy_context( $blog_id )
+	);
 
 	if ( ! in_array( $cohort, array( 'resolved', 'unresolved', 'all' ), true ) ) {
 		$cohort = 'resolved';
@@ -450,15 +470,16 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 	$auth = extrachill_analytics_revenue_authorize_blog_read( $blog_id );
 	if ( true !== $auth ) {
 		return array(
-			'success' => false,
-			'error'   => is_string( $auth ) ? $auth : 'Permission denied.',
-			'rows'    => 0,
-			'blog_id' => $blog_id,
-			'window'  => '',
-			'cohort'  => $cohort,
-			'sort_by' => $sort_by,
-			'order'   => $order,
-			'scope'   => array(
+			'success'   => false,
+			'error'     => is_string( $auth ) ? $auth : 'Permission denied.',
+			'rows'      => 0,
+			'blog_id'   => $blog_id,
+			'window'    => '',
+			'cohort'    => $cohort,
+			'sort_by'   => $sort_by,
+			'order'     => $order,
+			'ad_policy' => $site_policy,
+			'scope'     => array(
 				'requested_period' => $requested_period,
 				'effective_period' => '',
 				'effective_batch'  => '',
@@ -466,8 +487,8 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 				'selected_periods' => array(),
 				'selected_batches' => array(),
 			),
-			'pages'   => array(),
-			'totals'  => array(
+			'pages'     => array(),
+			'totals'    => array(
 				'pages_before_limit' => 0,
 				'pages_returned'     => 0,
 				'cohort_pages'       => 0,
@@ -475,7 +496,7 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 				'views'              => 0,
 				'revenue'            => 0.0,
 			),
-			'sample'  => array(
+			'sample'    => array(
 				'rows_in_window'           => 0,
 				'resolved_pages'           => 0,
 				'unresolved_pages'         => 0,
@@ -484,7 +505,7 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 				'benchmark_computed'       => false,
 				'sufficient_for_benchmark' => false,
 			),
-			'caveat'  => __( 'Permission denied.', 'extrachill-analytics' ),
+			'caveat'    => __( 'Permission denied.', 'extrachill-analytics' ),
 		);
 	}
 
@@ -550,18 +571,19 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 
 	if ( empty( $rows ) ) {
 		return array(
-			'success' => true,
-			'rows'    => 0,
-			'blog_id' => $blog_id,
-			'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end, $effective_period ),
-			'cohort'  => $cohort,
-			'sort_by' => $sort_by,
-			'order'   => $order,
-			'scope'   => $scope_block,
-			'pages'   => array(),
-			'totals'  => $empty_totals,
-			'sample'  => $empty_sample,
-			'caveat'  => $defaulted
+			'success'   => true,
+			'rows'      => 0,
+			'blog_id'   => $blog_id,
+			'window'    => extrachill_analytics_revenue_window_label( $period_start, $period_end, $effective_period ),
+			'cohort'    => $cohort,
+			'sort_by'   => $sort_by,
+			'order'     => $order,
+			'ad_policy' => $site_policy,
+			'scope'     => $scope_block,
+			'pages'     => array(),
+			'totals'    => $empty_totals,
+			'sample'    => $empty_sample,
+			'caveat'    => $defaulted
 				? __( 'No revenue snapshots for this blog. Import a Mediavine Pages CSV first: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' )
 				: __( 'No revenue snapshots match the requested scope for this blog. Check period/batch, or import: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' ),
 		);
@@ -574,6 +596,11 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 		$metadata        = extrachill_analytics_revenue_content_metadata( $content_blog_id, $post_id );
 		$is_content      = is_array( $metadata );
 		$source_url      = $row->url ? $row->url : $row->slug;
+		$route_family    = $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $source_url );
+		$post_type       = $is_content && isset( $metadata['post_type'] ) ? (string) $metadata['post_type'] : '';
+		$ad_policy       = extrachill_analytics_revenue_get_ad_policy(
+			extrachill_analytics_revenue_ad_policy_context( $content_blog_id, $source_url, $post_type, $route_family )
+		);
 		$records[]       = array(
 			'page_key'                 => $is_content ? 'p' . $content_blog_id . ':' . $post_id : 'u' . md5( (string) $row->slug ),
 			'is_content'               => $is_content,
@@ -581,7 +608,7 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 			'post_id'                  => $is_content ? $post_id : 0,
 			'format'                   => $is_content ? $metadata['format'] : '',
 			'categories'               => $is_content ? $metadata['categories'] : array(),
-			'route_family'             => $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $source_url ),
+			'route_family'             => $route_family,
 			'views'                    => (int) $row->views,
 			'revenue'                  => (float) $row->revenue,
 			'source_rpm'               => (float) $row->rpm,
@@ -593,6 +620,7 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 			'title'                    => $is_content && $include_post_meta ? $metadata['title'] : '',
 			'path'                     => $is_content && $include_post_meta ? $metadata['path'] : '',
 			'published_date'           => $is_content && $include_post_meta ? $metadata['published_date'] : '',
+			'ad_policy'                => $ad_policy,
 		);
 	}
 
@@ -608,18 +636,19 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 	);
 
 	return array(
-		'success' => true,
-		'rows'    => count( $rows ),
-		'blog_id' => $blog_id,
-		'window'  => extrachill_analytics_revenue_window_label( $period_start, $period_end, $effective_period ),
-		'cohort'  => $cohort,
-		'sort_by' => $sort_by,
-		'order'   => $order,
-		'scope'   => $scope_block,
-		'pages'   => $built['pages'],
-		'totals'  => $built['totals'],
-		'sample'  => $built['sample'],
-		'caveat'  => __( 'Pages cover the requested cohort. derived_rpm = revenue / (views/1000), recomputed here; source_rpm is the Mediavine-reported rpm column — they can disagree and are kept distinct (rank on either). Pages with revenue but zero views are flagged zero_views with derived_rpm = 0 (never a division error) and revenue preserved. benchmark_opportunity flags genuinely strong RPM at meaningful volume (>= 1.5x cohort median RPM AND >= cohort median views; requires >= 5 views-positive pages). URL-variant rows of one post collapse by page_key: volume is summed, while rate metrics (source_rpm, cpm, viewability, fill_rate, impressions_per_pageview) are simple-averaged because their true impression/request denominators are not stored — derived_rpm stays the correct aggregated RPM. With no explicit scope the query defaults to the freshest dated period (never silently combines all-time + monthly + duplicates). Revenue is Mediavine-imported (the only source of ad income); never estimated.', 'extrachill-analytics' ),
+		'success'   => true,
+		'rows'      => count( $rows ),
+		'blog_id'   => $blog_id,
+		'window'    => extrachill_analytics_revenue_window_label( $period_start, $period_end, $effective_period ),
+		'cohort'    => $cohort,
+		'sort_by'   => $sort_by,
+		'order'     => $order,
+		'ad_policy' => $site_policy,
+		'scope'     => $scope_block,
+		'pages'     => $built['pages'],
+		'totals'    => $built['totals'],
+		'sample'    => $built['sample'],
+		'caveat'    => __( 'Pages cover the requested cohort. Ad policy is owned by Extra Chill Network: blocked rows remain visible with revenue_status=not_applicable, and unknown means the policy integration is not instrumented. Only policy-confirmed applicable rows participate in benchmark_opportunity; imported revenue is never altered, and policy_conflict discloses contradictory source revenue. derived_rpm = revenue / (views/1000), recomputed here; source_rpm is the Mediavine-reported rpm column — they can disagree and are kept distinct (rank on either). Pages with revenue but zero views are flagged zero_views with derived_rpm = 0 (never a division error) and revenue preserved. URL-variant rows of one post collapse by page_key: volume is summed, while rate metrics are simple-averaged because their true denominators are not stored. With no explicit scope the query defaults to the freshest dated period.', 'extrachill-analytics' ),
 	);
 }
 
@@ -882,6 +911,9 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 				'title'              => isset( $rec['title'] ) ? (string) $rec['title'] : '',
 				'path'               => isset( $rec['path'] ) ? (string) $rec['path'] : '',
 				'published_date'     => isset( $rec['published_date'] ) ? (string) $rec['published_date'] : '',
+				'ad_policy'          => extrachill_analytics_revenue_normalize_ad_policy( isset( $rec['ad_policy'] ) ? $rec['ad_policy'] : null ),
+				'policy_statuses'    => array(),
+				'policy_conflict'    => false,
 			);
 		}
 
@@ -890,11 +922,15 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 		$a['views']   += $views;
 		$a['revenue'] += (float) ( isset( $rec['revenue'] ) ? $rec['revenue'] : 0.0 );
 
-		$a['source_rpm_values'][]  = (float) ( isset( $rec['source_rpm'] ) ? $rec['source_rpm'] : 0.0 );
-		$a['cpm_values'][]         = (float) ( isset( $rec['cpm'] ) ? $rec['cpm'] : 0.0 );
-		$a['viewability_values'][] = (float) ( isset( $rec['viewability'] ) ? $rec['viewability'] : 0.0 );
-		$a['fill_rate_values'][]   = (float) ( isset( $rec['fill_rate'] ) ? $rec['fill_rate'] : 0.0 );
-		$a['impressions_values'][] = (float) ( isset( $rec['impressions_per_pageview'] ) ? $rec['impressions_per_pageview'] : 0.0 );
+		$a['source_rpm_values'][]                      = (float) ( isset( $rec['source_rpm'] ) ? $rec['source_rpm'] : 0.0 );
+		$a['cpm_values'][]                             = (float) ( isset( $rec['cpm'] ) ? $rec['cpm'] : 0.0 );
+		$a['viewability_values'][]                     = (float) ( isset( $rec['viewability'] ) ? $rec['viewability'] : 0.0 );
+		$a['fill_rate_values'][]                       = (float) ( isset( $rec['fill_rate'] ) ? $rec['fill_rate'] : 0.0 );
+		$a['impressions_values'][]                     = (float) ( isset( $rec['impressions_per_pageview'] ) ? $rec['impressions_per_pageview'] : 0.0 );
+		$record_policy                                 = extrachill_analytics_revenue_normalize_ad_policy( isset( $rec['ad_policy'] ) ? $rec['ad_policy'] : null );
+		$record_policy_status                          = extrachill_analytics_revenue_policy_status( $record_policy );
+		$a['policy_statuses'][ $record_policy_status ] = isset( $a['policy_statuses'][ $record_policy_status ] ) ? $a['policy_statuses'][ $record_policy_status ] + 1 : 1;
+		$a['policy_conflict']                          = $a['policy_conflict'] || extrachill_analytics_revenue_policy_conflicts( $record_policy, isset( $rec['revenue'] ) ? $rec['revenue'] : 0.0 );
 		unset( $a );
 	}
 
@@ -928,8 +964,15 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 		$fill_rate   = extrachill_analytics_revenue_simple_average( $a['fill_rate_values'] );
 		$impressions = extrachill_analytics_revenue_simple_average( $a['impressions_values'] );
 
-		$zero_views  = $views <= 0;
-		$derived_rpm = $views > 0 ? round( $revenue / ( $views / 1000 ), 4 ) : 0.0;
+		$zero_views     = $views <= 0;
+		$derived_rpm    = $views > 0 ? round( $revenue / ( $views / 1000 ), 4 ) : 0.0;
+		$revenue_status = extrachill_analytics_revenue_aggregate_policy_status( $a['policy_statuses'] );
+		$ad_policy      = $a['ad_policy'];
+		if ( 'mixed' === $revenue_status ) {
+			$ad_policy           = extrachill_analytics_revenue_normalize_ad_policy( null );
+			$ad_policy['reason'] = 'mixed_policy';
+			$revenue_status      = 'unknown';
+		}
 
 		$pages[ $key ] = array(
 			'page_key'                 => $key,
@@ -953,6 +996,9 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 			'impressions_per_pageview' => round( $impressions, 4 ),
 			'dollars_per_page'         => round( $revenue, 4 ),
 			'zero_views'               => $zero_views,
+			'ad_policy'                => $ad_policy,
+			'revenue_status'           => $revenue_status,
+			'policy_conflict'          => (bool) $a['policy_conflict'],
 			'benchmark_opportunity'    => false,
 			'benchmark_score'          => null,
 		);
@@ -964,7 +1010,7 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 	$sufficient_for_benchmark = false;
 	$views_positive           = array();
 	foreach ( $pages as $p ) {
-		if ( $p['views'] > 0 ) {
+		if ( $p['views'] > 0 && 'applicable' === $p['revenue_status'] ) {
 			$views_positive[] = $p;
 		}
 	}
@@ -988,6 +1034,9 @@ function extrachill_analytics_revenue_build_pages( array $records, array $args )
 		$median_views             = extrachill_analytics_revenue_median( $views_values );
 
 		foreach ( $pages as $key => $p ) {
+			if ( 'applicable' !== $p['revenue_status'] ) {
+				continue;
+			}
 			if ( $p['views'] <= 0 || $median_rpm <= 0 ) {
 				$pages[ $key ]['benchmark_score'] = $p['views'] > 0 ? 0.0 : null;
 				continue;

--- a/inc/core/abilities/get-content-revenue.php
+++ b/inc/core/abilities/get-content-revenue.php
@@ -121,6 +121,9 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 	$include_alltime = ! empty( $input['include_alltime'] );
 	$blog_id         = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : get_current_blog_id();
 	$hostname        = ! empty( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com';
+	$site_policy     = extrachill_analytics_revenue_get_ad_policy(
+		extrachill_analytics_revenue_ad_policy_context( $blog_id )
+	);
 
 	if ( ! in_array( $group_by, array( 'format', 'category', 'both', 'timeseries' ), true ) ) {
 		$group_by = 'format';
@@ -131,7 +134,7 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 	// answers "what did we earn month-over-month" so the HCU cliff shows in
 	// dollars. Each monthly CSV the operator imports becomes one point.
 	if ( 'timeseries' === $group_by ) {
-		return extrachill_analytics_revenue_timeseries_response( $blog_id, $include_alltime );
+		return extrachill_analytics_revenue_timeseries_response( $blog_id, $include_alltime, $site_policy );
 	}
 
 	$rows = extrachill_analytics_revenue_get_rows(
@@ -146,25 +149,27 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 
 	if ( empty( $rows ) ) {
 		return array(
-			'success'    => true,
-			'rows'       => 0,
-			'window'     => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
-			'rollups'    => array(),
-			'totals'     => array(
+			'success'        => true,
+			'rows'           => 0,
+			'window'         => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
+			'ad_policy'      => $site_policy,
+			'revenue_status' => extrachill_analytics_revenue_policy_status( $site_policy ),
+			'rollups'        => array(),
+			'totals'         => array(
 				'pages'            => 0,
 				'views'            => 0,
 				'revenue'          => 0.0,
 				'rpm'              => 0.0,
 				'dollars_per_page' => 0.0,
 			),
-			'unresolved' => array(
+			'unresolved'     => array(
 				'pages'           => 0,
 				'views'           => 0,
 				'revenue'         => 0.0,
 				'rpm'             => 0.0,
 				'by_route_family' => array(),
 			),
-			'caveat'     => __( 'No revenue snapshots for this blog/window. Import a Mediavine Pages CSV first: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' ),
+			'caveat'         => __( 'No revenue snapshots for this blog/window. Import a Mediavine Pages CSV first: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' ),
 		);
 	}
 
@@ -179,8 +184,9 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 	foreach ( $rows as $row ) {
 		$post_id = (int) $row->post_id;
 
-		$views   = (int) $row->views;
-		$revenue = (float) $row->revenue;
+		$views      = (int) $row->views;
+		$revenue    = (float) $row->revenue;
+		$source_url = ! empty( $row->canonical_url ) ? $row->canonical_url : ( $row->url ? $row->url : $row->slug );
 
 		$content_blog_id = ! empty( $row->content_blog_id ) ? (int) $row->content_blog_id : $blog_id;
 		// Content remains eligible only when 'publish' === get_post_status( $post_id ).
@@ -194,11 +200,15 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 				return array(
 					'categories' => ( is_array( $terms ) && ! empty( $terms ) ) ? wp_list_pluck( $terms, 'slug' ) : array( 'uncategorized' ),
 					'format'     => extrachill_analytics_classify_format( $post_id ),
+					'post_type'  => (string) get_post_type( $post_id ),
 				);
 			}
 		) : null;
 
 		if ( is_array( $content ) ) {
+			$ad_policy = extrachill_analytics_revenue_get_ad_policy(
+				extrachill_analytics_revenue_ad_policy_context( $content_blog_id, $source_url, $content['post_type'] )
+			);
 			$records[] = array(
 				'is_content' => true,
 				'page_key'   => 'p' . $content_blog_id . ':' . $post_id,
@@ -206,17 +216,23 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 				'categories' => $content['categories'],
 				'views'      => $views,
 				'revenue'    => $revenue,
-				'url'        => ! empty( $row->canonical_url ) ? $row->canonical_url : ( $row->url ? $row->url : $row->slug ),
+				'url'        => $source_url,
+				'ad_policy'  => $ad_policy,
 			);
 		} else {
 			// Unresolved route (post_id 0, or stale/non-published ID): diagnostic
 			// cohort only — excluded from content totals and buckets.
-			$records[] = array(
+			$route_family = extrachill_analytics_revenue_classify_route_family( $source_url );
+			$ad_policy    = extrachill_analytics_revenue_get_ad_policy(
+				extrachill_analytics_revenue_ad_policy_context( $content_blog_id, $source_url, '', $route_family )
+			);
+			$records[]    = array(
 				'is_content' => false,
 				'page_key'   => 'u' . md5( (string) $row->slug ),
 				'views'      => $views,
 				'revenue'    => $revenue,
-				'url'        => $row->url ? $row->url : $row->slug,
+				'url'        => $source_url,
+				'ad_policy'  => $ad_policy,
 			);
 		}
 	}
@@ -224,15 +240,17 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 	$built = extrachill_analytics_revenue_build_rollups( $records, $group_by );
 
 	return array(
-		'success'    => true,
-		'rows'       => count( $rows ),
-		'blog_id'    => $blog_id,
-		'group_by'   => $group_by,
-		'window'     => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
-		'rollups'    => $built['rollups'],
-		'totals'     => $built['totals'],
-		'unresolved' => $built['unresolved'],
-		'caveat'     => __( 'Totals and rollups cover RESOLVED PUBLISHED CONTENT ONLY — unresolved routes (home, pagination, taxonomy archives, app/account routes, legacy .html ghosts) are excluded so published-content RPM is honest, and reported separately under `unresolved` with a by_route_family breakdown. $/page is the honest "worth producing" metric — RPM alone misleads (high RPM on tiny volume = pennies). Revenue is Mediavine-imported (the only source of ad income); never estimated. Note: the Mediavine Pages CSV carries one path per row and may omit hostnames, so cross-site paths (e.g. Festival Wire) can land under the import blog when the hostname is ambiguous — treat the unresolved cohort as coverage signal, not an attribution verdict.', 'extrachill-analytics' ),
+		'success'        => true,
+		'rows'           => count( $rows ),
+		'blog_id'        => $blog_id,
+		'group_by'       => $group_by,
+		'window'         => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),
+		'ad_policy'      => $site_policy,
+		'revenue_status' => extrachill_analytics_revenue_policy_status( $site_policy ),
+		'rollups'        => $built['rollups'],
+		'totals'         => $built['totals'],
+		'unresolved'     => $built['unresolved'],
+		'caveat'         => __( 'Totals and rollups cover RESOLVED PUBLISHED CONTENT ONLY; unresolved routes are reported separately. Ad policy is owned by Extra Chill Network. revenue_status marks aggregates as applicable, not_applicable, mixed, or unknown while imported revenue remains unchanged; policy_conflicts counts contradictory positive revenue on blocked rows. $/page is the honest "worth producing" metric — RPM alone misleads. The Mediavine Pages CSV may omit hostnames, so unresolved cross-site paths remain coverage signal, not an attribution verdict.', 'extrachill-analytics' ),
 	);
 }
 
@@ -244,18 +262,26 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
  * @param int    $views      Views to add.
  * @param float  $revenue    Revenue to add.
  * @param bool   $count_page Whether this contributes a new page to the count.
+ * @param string $policy_status Policy status for this row.
+ * @param bool   $policy_conflict Whether source revenue conflicts with policy.
  */
-function extrachill_analytics_revenue_accumulate( array &$bucket, $key, $views, $revenue, $count_page ) {
+function extrachill_analytics_revenue_accumulate( array &$bucket, $key, $views, $revenue, $count_page, $policy_status = 'unknown', $policy_conflict = false ) {
 	if ( ! isset( $bucket[ $key ] ) ) {
 		$bucket[ $key ] = array(
-			'pages'   => 0,
-			'views'   => 0,
-			'revenue' => 0.0,
+			'pages'            => 0,
+			'views'            => 0,
+			'revenue'          => 0.0,
+			'policy_statuses'  => array(),
+			'policy_conflicts' => 0,
 		);
 	}
 
-	$bucket[ $key ]['views']   += $views;
-	$bucket[ $key ]['revenue'] += $revenue;
+	$bucket[ $key ]['views']                            += $views;
+	$bucket[ $key ]['revenue']                          += $revenue;
+	$bucket[ $key ]['policy_statuses'][ $policy_status ] = isset( $bucket[ $key ]['policy_statuses'][ $policy_status ] ) ? $bucket[ $key ]['policy_statuses'][ $policy_status ] + 1 : 1;
+	if ( $policy_conflict ) {
+		++$bucket[ $key ]['policy_conflicts'];
+	}
 	if ( $count_page ) {
 		++$bucket[ $key ]['pages'];
 	}
@@ -285,6 +311,8 @@ function extrachill_analytics_revenue_finalize( array $bucket ) {
 			'revenue'          => round( $revenue, 2 ),
 			'rpm'              => $views > 0 ? round( $revenue / ( $views / 1000 ), 2 ) : 0.0,
 			'dollars_per_page' => $pages > 0 ? round( $revenue / $pages, 2 ) : 0.0,
+			'revenue_status'   => extrachill_analytics_revenue_aggregate_policy_status( isset( $agg['policy_statuses'] ) ? $agg['policy_statuses'] : array() ),
+			'policy_conflicts' => isset( $agg['policy_conflicts'] ) ? (int) $agg['policy_conflicts'] : 0,
 		);
 	}
 
@@ -391,21 +419,28 @@ function extrachill_analytics_revenue_build_rollups( array $records, $group_by )
 	$by_format   = array();
 	$by_category = array();
 
-	$content_pages   = 0;
-	$content_views   = 0;
-	$content_revenue = 0.0;
-	$seen_content    = array();
+	$content_pages            = 0;
+	$content_views            = 0;
+	$content_revenue          = 0.0;
+	$seen_content             = array();
+	$content_policy_statuses  = array();
+	$content_policy_conflicts = 0;
 
-	$unresolved_pages   = 0;
-	$unresolved_views   = 0;
-	$unresolved_revenue = 0.0;
-	$seen_unresolved    = array();
-	$unresolved_family  = array();
+	$unresolved_pages            = 0;
+	$unresolved_views            = 0;
+	$unresolved_revenue          = 0.0;
+	$seen_unresolved             = array();
+	$unresolved_family           = array();
+	$unresolved_policy_statuses  = array();
+	$unresolved_policy_conflicts = 0;
 
 	foreach ( $records as $rec ) {
-		$views   = (int) ( isset( $rec['views'] ) ? $rec['views'] : 0 );
-		$revenue = (float) ( isset( $rec['revenue'] ) ? $rec['revenue'] : 0.0 );
-		$key     = (string) ( isset( $rec['page_key'] ) ? $rec['page_key'] : '' );
+		$views           = (int) ( isset( $rec['views'] ) ? $rec['views'] : 0 );
+		$revenue         = (float) ( isset( $rec['revenue'] ) ? $rec['revenue'] : 0.0 );
+		$key             = (string) ( isset( $rec['page_key'] ) ? $rec['page_key'] : '' );
+		$policy          = extrachill_analytics_revenue_normalize_ad_policy( isset( $rec['ad_policy'] ) ? $rec['ad_policy'] : null );
+		$policy_status   = extrachill_analytics_revenue_policy_status( $policy );
+		$policy_conflict = extrachill_analytics_revenue_policy_conflicts( $policy, $revenue );
 
 		if ( empty( $rec['is_content'] ) ) {
 			// Unresolved diagnostic cohort — excluded from content totals/buckets.
@@ -413,24 +448,34 @@ function extrachill_analytics_revenue_build_rollups( array $records, $group_by )
 				$seen_unresolved[ $key ] = true;
 				++$unresolved_pages;
 			}
-			$unresolved_views   += $views;
-			$unresolved_revenue += $revenue;
+			$unresolved_views                            += $views;
+			$unresolved_revenue                          += $revenue;
+			$unresolved_policy_statuses[ $policy_status ] = isset( $unresolved_policy_statuses[ $policy_status ] ) ? $unresolved_policy_statuses[ $policy_status ] + 1 : 1;
+			if ( $policy_conflict ) {
+				++$unresolved_policy_conflicts;
+			}
 
 			$family = extrachill_analytics_revenue_classify_route_family( isset( $rec['url'] ) ? $rec['url'] : '' );
 			if ( ! isset( $unresolved_family[ $family ] ) ) {
 				$unresolved_family[ $family ] = array(
-					'pages'   => 0,
-					'views'   => 0,
-					'revenue' => 0.0,
-					'seen'    => array(),
+					'pages'            => 0,
+					'views'            => 0,
+					'revenue'          => 0.0,
+					'seen'             => array(),
+					'policy_statuses'  => array(),
+					'policy_conflicts' => 0,
 				);
 			}
 			if ( '' !== $key && empty( $unresolved_family[ $family ]['seen'][ $key ] ) ) {
 				$unresolved_family[ $family ]['seen'][ $key ] = true;
 				++$unresolved_family[ $family ]['pages'];
 			}
-			$unresolved_family[ $family ]['views']   += $views;
-			$unresolved_family[ $family ]['revenue'] += $revenue;
+			$unresolved_family[ $family ]['views']                            += $views;
+			$unresolved_family[ $family ]['revenue']                          += $revenue;
+			$unresolved_family[ $family ]['policy_statuses'][ $policy_status ] = isset( $unresolved_family[ $family ]['policy_statuses'][ $policy_status ] ) ? $unresolved_family[ $family ]['policy_statuses'][ $policy_status ] + 1 : 1;
+			if ( $policy_conflict ) {
+				++$unresolved_family[ $family ]['policy_conflicts'];
+			}
 			continue;
 		}
 
@@ -439,17 +484,21 @@ function extrachill_analytics_revenue_build_rollups( array $records, $group_by )
 		$seen_content[ $key ] = true;
 
 		$format = isset( $rec['format'] ) ? (string) $rec['format'] : 'uncategorized';
-		extrachill_analytics_revenue_accumulate( $by_format, $format, $views, $revenue, $count_page );
+		extrachill_analytics_revenue_accumulate( $by_format, $format, $views, $revenue, $count_page, $policy_status, $policy_conflict );
 
 		$categories = ( ! empty( $rec['categories'] ) && is_array( $rec['categories'] ) )
 			? array_map( 'strval', $rec['categories'] )
 			: array( 'uncategorized' );
 		foreach ( $categories as $cat ) {
-			extrachill_analytics_revenue_accumulate( $by_category, $cat, $views, $revenue, $count_page );
+			extrachill_analytics_revenue_accumulate( $by_category, $cat, $views, $revenue, $count_page, $policy_status, $policy_conflict );
 		}
 
-		$content_views   += $views;
-		$content_revenue += $revenue;
+		$content_views                            += $views;
+		$content_revenue                          += $revenue;
+		$content_policy_statuses[ $policy_status ] = isset( $content_policy_statuses[ $policy_status ] ) ? $content_policy_statuses[ $policy_status ] + 1 : 1;
+		if ( $policy_conflict ) {
+			++$content_policy_conflicts;
+		}
 		if ( $count_page ) {
 			++$content_pages;
 		}
@@ -469,11 +518,13 @@ function extrachill_analytics_revenue_build_rollups( array $records, $group_by )
 		$fviews        = (int) $agg['views'];
 		$frevenue      = (float) $agg['revenue'];
 		$family_rows[] = array(
-			'route_family' => $family,
-			'pages'        => $fpages,
-			'views'        => $fviews,
-			'revenue'      => round( $frevenue, 2 ),
-			'rpm'          => $fviews > 0 ? round( $frevenue / ( $fviews / 1000 ), 2 ) : 0.0,
+			'route_family'     => $family,
+			'pages'            => $fpages,
+			'views'            => $fviews,
+			'revenue'          => round( $frevenue, 2 ),
+			'rpm'              => $fviews > 0 ? round( $frevenue / ( $fviews / 1000 ), 2 ) : 0.0,
+			'revenue_status'   => extrachill_analytics_revenue_aggregate_policy_status( $agg['policy_statuses'] ),
+			'policy_conflicts' => (int) $agg['policy_conflicts'],
 		);
 	}
 	usort(
@@ -491,13 +542,17 @@ function extrachill_analytics_revenue_build_rollups( array $records, $group_by )
 			'revenue'          => round( $content_revenue, 2 ),
 			'rpm'              => $content_views > 0 ? round( $content_revenue / ( $content_views / 1000 ), 2 ) : 0.0,
 			'dollars_per_page' => $content_pages > 0 ? round( $content_revenue / $content_pages, 2 ) : 0.0,
+			'revenue_status'   => extrachill_analytics_revenue_aggregate_policy_status( $content_policy_statuses ),
+			'policy_conflicts' => $content_policy_conflicts,
 		),
 		'unresolved' => array(
-			'pages'           => $unresolved_pages,
-			'views'           => $unresolved_views,
-			'revenue'         => round( $unresolved_revenue, 2 ),
-			'rpm'             => $unresolved_views > 0 ? round( $unresolved_revenue / ( $unresolved_views / 1000 ), 2 ) : 0.0,
-			'by_route_family' => $family_rows,
+			'pages'            => $unresolved_pages,
+			'views'            => $unresolved_views,
+			'revenue'          => round( $unresolved_revenue, 2 ),
+			'rpm'              => $unresolved_views > 0 ? round( $unresolved_revenue / ( $unresolved_views / 1000 ), 2 ) : 0.0,
+			'revenue_status'   => extrachill_analytics_revenue_aggregate_policy_status( $unresolved_policy_statuses ),
+			'policy_conflicts' => $unresolved_policy_conflicts,
+			'by_route_family'  => $family_rows,
 		),
 	);
 }
@@ -530,12 +585,14 @@ function extrachill_analytics_revenue_window_label( $period_start, $period_end, 
  * — is readable in dollars. The flat "all-time" cumulative bucket is excluded by
  * default (it is a lifetime total, not a point on the arc).
  *
- * @param int  $blog_id         Blog ID.
- * @param bool $include_alltime Include the cumulative "all-time" bucket.
+ * @param int        $blog_id         Blog ID.
+ * @param bool       $include_alltime Include the cumulative "all-time" bucket.
+ * @param array|null $ad_policy       Current network-owned site policy.
  * @return array Ability response with a `series` array.
  */
-function extrachill_analytics_revenue_timeseries_response( $blog_id, $include_alltime ) {
-	$points = extrachill_analytics_revenue_get_timeseries(
+function extrachill_analytics_revenue_timeseries_response( $blog_id, $include_alltime, $ad_policy = null ) {
+	$ad_policy = extrachill_analytics_revenue_normalize_ad_policy( $ad_policy );
+	$points    = extrachill_analytics_revenue_get_timeseries(
 		array(
 			'blog_id'         => $blog_id,
 			'include_alltime' => $include_alltime,
@@ -584,21 +641,23 @@ function extrachill_analytics_revenue_timeseries_response( $blog_id, $include_al
 	}
 
 	return array(
-		'success'  => true,
-		'rows'     => count( $points ),
-		'blog_id'  => $blog_id,
-		'group_by' => 'timeseries',
-		'window'   => 'revenue arc (per-period, chronological)',
-		'series'   => $series,
-		'peak'     => array(
+		'success'        => true,
+		'rows'           => count( $points ),
+		'blog_id'        => $blog_id,
+		'group_by'       => 'timeseries',
+		'window'         => 'revenue arc (per-period, chronological)',
+		'ad_policy'      => $ad_policy,
+		'revenue_status' => extrachill_analytics_revenue_policy_status( $ad_policy ),
+		'series'         => $series,
+		'peak'           => array(
 			'period'  => $peak_label,
 			'revenue' => round( $peak_revenue, 2 ),
 		),
-		'totals'   => array(
+		'totals'         => array(
 			'periods' => count( $series ),
 			'views'   => $total_views,
 			'revenue' => round( $total_revenue, 2 ),
 		),
-		'caveat'   => __( 'The revenue ARC needs DATE-RANGED (monthly) Mediavine exports — import each with --period=YYYY-MM. The flat lifetime export is one cumulative "all-time" total per URL (no dates) and is excluded here by default; on its own it is time-blind and undercounts the 2022-2023 peak, whose revenue ran on old URL structures. Revenue is Mediavine-imported (the only source of ad income); never estimated.', 'extrachill-analytics' ),
+		'caveat'         => __( 'The revenue ARC needs DATE-RANGED (monthly) Mediavine exports — import each with --period=YYYY-MM. The flat lifetime export is one cumulative "all-time" total per URL (no dates) and is excluded here by default; on its own it is time-blind and undercounts the 2022-2023 peak, whose revenue ran on old URL structures. Revenue is Mediavine-imported (the only source of ad income); never estimated.', 'extrachill-analytics' ),
 	);
 }

--- a/inc/core/abilities/get-surface-stickiness.php
+++ b/inc/core/abilities/get-surface-stickiness.php
@@ -3,9 +3,9 @@
  * Get Surface Stickiness Ability
  *
  * Engagement instrument for the platform's NON-ARTICLE surfaces — community,
- * artist platform, and the events calendar. These surfaces earn $0 ad revenue
- * BY DESIGN (community has no ads; the artist platform is not monetized), so
- * the all-time revenue x-ray reads them as dead. They are not dead — they are
+ * artist platform, and the events calendar. Community and the artist platform
+ * are intentionally ad-free; Events is ad-enabled. Regardless of ad policy,
+ * the all-time revenue x-ray alone cannot measure their platform value. They are
  * the platform pivot. Their value is STICKINESS: do real people come back, go
  * deeper, and traverse between surfaces? This ability answers that question
  * with a deterministic, first-party read, and deliberately NEVER references ad
@@ -61,7 +61,7 @@ function extrachill_analytics_register_surface_stickiness_ability() {
 		'extrachill/get-surface-stickiness',
 		array(
 			'label'               => __( 'Get Surface Stickiness', 'extrachill-analytics' ),
-			'description'         => __( 'Returns a per-surface ENGAGEMENT (not revenue) scorecard for the platform pivot surfaces (community, artist, events): return rate, session depth, new-vs-returning, and windowed activity — each as a this-period-vs-prior trend — plus a network-wide cross-surface traversal figure. These surfaces earn $0 ad revenue by design and must be judged by stickiness. Unmeasurable cells return a not_instrumented coverage marker, never a zero.', 'extrachill-analytics' ),
+			'description'         => __( 'Returns a per-surface ENGAGEMENT scorecard for community, artist, and events, plus authoritative network-owned ad-policy context. Community and artist are intentionally ad-free; Events is ad-enabled. Unmeasurable cells return a not_instrumented marker, never a zero.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -165,14 +165,19 @@ function extrachill_analytics_ability_get_surface_stickiness( $input ) {
 	foreach ( extrachill_analytics_stickiness_surface_map() as $key => $surface ) {
 		$engagement = extrachill_analytics_surface_engagement_trend( $retention_ability, $retention_present, $surface['blog_id'], $days );
 		$activity   = extrachill_analytics_surface_activity_trend( $surface, $window_start, $prior_start, $days );
+		$ad_policy  = extrachill_analytics_revenue_get_ad_policy(
+			extrachill_analytics_revenue_ad_policy_context( $surface['blog_id'] )
+		);
 
 		$surfaces[ $key ] = array(
-			'surface'    => $key,
-			'label'      => $surface['label'],
-			'blog_id'    => $surface['blog_id'],
-			'host'       => $surface['host'],
-			'engagement' => $engagement,
-			'activity'   => $activity,
+			'surface'        => $key,
+			'label'          => $surface['label'],
+			'blog_id'        => $surface['blog_id'],
+			'host'           => $surface['host'],
+			'engagement'     => $engagement,
+			'activity'       => $activity,
+			'ad_policy'      => $ad_policy,
+			'revenue_status' => extrachill_analytics_revenue_policy_status( $ad_policy ),
 		);
 	}
 
@@ -194,7 +199,7 @@ function extrachill_analytics_ability_get_surface_stickiness( $input ) {
 		'retention_available' => $retention_present,
 		'as_of'               => $now_utc,
 		'lens'                => 'engagement',
-		'note'                => 'ENGAGEMENT lens, NOT revenue. These surfaces (community, artist, events) earn $0 ad revenue by design; judging them by ad revenue is the wrong instrument and always reads $0. ENGAGEMENT CORE = first-party return_rate / session_depth / new-vs-returning from extrachill/get-retention-stats, scoped per blog and reported as current-window-vs-prior-equal-window trend. ACTIVITY = deterministic COUNT(*) of each surface stickiness post type (topics / profiles / events) created per window. CROSS-SURFACE = network-wide visitors hitting >= 2 blogs on >= 2 days. A measured 0 means flat (honest + expected for these low-activity surfaces right now); not_instrumented is a coverage gap and must never be read as a zero.',
+		'note'                => 'ENGAGEMENT lens with network-owned ad-policy context. Community and Artist are intentionally ad-free; Events is ad-enabled and may carry attributed revenue. Analytics does not own or infer that policy. ENGAGEMENT CORE = first-party return_rate / session_depth / new-vs-returning, ACTIVITY = deterministic published-item counts, and CROSS-SURFACE = network-wide visitors hitting >= 2 blogs on >= 2 days. A measured 0 is real; not_instrumented is a coverage gap.',
 	);
 }
 

--- a/inc/core/revenue-ad-policy.php
+++ b/inc/core/revenue-ad-policy.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Revenue ad-policy integration.
+ *
+ * Analytics consumes the network-owned policy contract. It does not infer site
+ * eligibility from plugin activation or maintain its own site/route matrix.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalize a network ad-policy response for analytics output.
+ *
+ * @param mixed $policy Network policy response, or null when unavailable.
+ * @return array{site_enabled:?bool,serve_ads:?bool,reason:string}
+ */
+function extrachill_analytics_revenue_normalize_ad_policy( $policy ) {
+	if ( ! is_array( $policy ) || ! array_key_exists( 'site_enabled', $policy ) || ! array_key_exists( 'serve_ads', $policy ) ) {
+		return array(
+			'site_enabled' => null,
+			'serve_ads'    => null,
+			'reason'       => 'not_instrumented',
+		);
+	}
+
+	return array(
+		'site_enabled' => is_bool( $policy['site_enabled'] ) ? $policy['site_enabled'] : null,
+		'serve_ads'    => is_bool( $policy['serve_ads'] ) ? $policy['serve_ads'] : null,
+		'reason'       => isset( $policy['reason'] ) && '' !== (string) $policy['reason'] ? (string) $policy['reason'] : 'unknown',
+	);
+}
+
+/**
+ * Read the authoritative network ad policy, degrading to unknown when absent.
+ *
+ * @param array $context Site/request context understood by the network policy.
+ * @return array{site_enabled:?bool,serve_ads:?bool,reason:string}
+ */
+function extrachill_analytics_revenue_get_ad_policy( array $context = array() ) {
+	if ( ! function_exists( 'extrachill_get_ad_policy' ) ) {
+		return extrachill_analytics_revenue_normalize_ad_policy( null );
+	}
+
+	$policy = extrachill_get_ad_policy( $context );
+	if ( function_exists( 'is_wp_error' ) && is_wp_error( $policy ) ) {
+		$policy = null;
+	}
+
+	return extrachill_analytics_revenue_normalize_ad_policy( $policy );
+}
+
+/**
+ * Build anonymous route context without re-resolving persisted attribution.
+ *
+ * @param int    $blog_id     Owning blog ID.
+ * @param string $url         Persisted URL/path.
+ * @param string $post_type   Persisted content post type, when resolved.
+ * @param string $route_family Existing Analytics route classification.
+ * @return array<string,mixed>
+ */
+function extrachill_analytics_revenue_ad_policy_context( $blog_id, $url = '', $post_type = '', $route_family = '' ) {
+	$is_home = 'home' === $route_family;
+
+	return array(
+		'blog_id'              => (int) $blog_id,
+		'url'                  => (string) $url,
+		'post_type'            => (string) $post_type,
+		'is_front_page'        => $is_home,
+		'is_home'              => $is_home,
+		'is_page'              => 'page' === $post_type,
+		'is_search'            => false,
+		'is_archive'           => in_array( $route_family, array( 'pagination', 'taxonomy-archive' ), true ),
+		'is_singular'          => '' !== $post_type,
+		'is_post_type_archive' => false,
+		'is_lifetime_member'   => false,
+	);
+}
+
+/**
+ * Convert effective policy into the revenue-analysis applicability state.
+ *
+ * @param array $policy Normalized policy.
+ * @return string applicable|not_applicable|unknown
+ */
+function extrachill_analytics_revenue_policy_status( array $policy ) {
+	if ( true === $policy['serve_ads'] ) {
+		return 'applicable';
+	}
+	if ( false === $policy['serve_ads'] ) {
+		return 'not_applicable';
+	}
+	return 'unknown';
+}
+
+/**
+ * Whether imported revenue contradicts an intentional no-ads policy.
+ *
+ * @param array $policy  Normalized policy.
+ * @param float $revenue Imported source revenue.
+ * @return bool
+ */
+function extrachill_analytics_revenue_policy_conflicts( array $policy, $revenue ) {
+	return false === $policy['serve_ads'] && (float) $revenue > 0;
+}
+
+/**
+ * Summarize policy states represented by aggregate rows.
+ *
+ * @param array $statuses Policy status counts.
+ * @return string applicable|not_applicable|mixed|unknown
+ */
+function extrachill_analytics_revenue_aggregate_policy_status( array $statuses ) {
+	$present = array_keys(
+		array_filter(
+			$statuses,
+			static function ( $count ) {
+				return (int) $count > 0;
+			}
+		)
+	);
+
+	if ( 1 === count( $present ) ) {
+		return $present[0];
+	}
+	if ( count( $present ) > 1 ) {
+		return 'mixed';
+	}
+	return 'unknown';
+}

--- a/inc/core/revenue-content-attribution.php
+++ b/inc/core/revenue-content-attribution.php
@@ -193,6 +193,7 @@ function extrachill_analytics_revenue_content_metadata( $blog_id, $post_id ) {
 				'title'          => $post ? (string) $post->post_title : '',
 				'url'            => is_string( $permalink ) ? $permalink : '',
 				'path'           => is_string( $permalink ) ? wp_make_link_relative( $permalink ) : '',
+				'post_type'      => $post && isset( $post->post_type ) ? (string) $post->post_type : '',
 				'published_date' => $post ? (string) $post->post_date : '',
 				'categories'     => ( is_array( $terms ) && ! empty( $terms ) ) ? wp_list_pluck( $terms, 'slug' ) : array( 'uncategorized' ),
 				'format'         => extrachill_analytics_classify_format( $post_id ),

--- a/tests/GetContentRevenueDiagnosticsTest.php
+++ b/tests/GetContentRevenueDiagnosticsTest.php
@@ -11,6 +11,7 @@
 
 use PHPUnit\Framework\TestCase;
 
+require_once dirname( __DIR__ ) . '/inc/core/revenue-ad-policy.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue-diagnostics.php';
 
 /**
@@ -46,6 +47,11 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 				'fill_rate'                => 90.0,
 				'impressions_per_pageview' => 2.0,
 				'derived_rpm'              => 100.0,
+				'ad_policy'                => array(
+					'site_enabled' => true,
+					'serve_ads'    => true,
+					'reason'       => 'enabled',
+				),
 			),
 			$over
 		);
@@ -1048,7 +1054,7 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 	}
 
 	/**
-	 * A clean store → all pass, overall pass (12 checks now).
+	 * A clean store → all pass, overall pass.
 	 */
 	public function test_clean_store_overall_pass(): void {
 		$periods = array();
@@ -1087,10 +1093,58 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 		);
 
 		$this->assertSame( 'pass', $built['overall_status'] );
-		$this->assertSame( 12, $built['summary']['total'] );
-		$this->assertSame( 12, $built['summary']['pass'] );
+		$this->assertSame( 13, $built['summary']['total'] );
+		$this->assertSame( 13, $built['summary']['pass'] );
 		$this->assertSame( 0, $built['summary']['warning'] );
 		$this->assertSame( 0, $built['summary']['fail'] );
+	}
+
+	/**
+	 * Positive imported revenue on an intentionally blocked route warns only.
+	 */
+	public function test_contradictory_imported_revenue_warns_without_mutation(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'slug'       => '/',
+					'post_id'    => 0,
+					'is_content' => false,
+					'revenue'    => 12.5,
+					'ad_policy'  => array(
+						'site_enabled' => true,
+						'serve_ads'    => false,
+						'reason'       => 'route_blocked',
+					),
+				)
+			),
+		);
+
+		$check = extrachill_analytics_revenue_diag_ad_policy_consistency( $rows );
+
+		$this->assertSame( 'warning', $check['status'] );
+		$this->assertSame( 1, $check['totals']['conflict_rows'] );
+		$this->assertSame( 12.5, $check['totals']['conflict_revenue'] );
+		$this->assertSame( 12.5, $rows[0]['revenue'] );
+		$this->assertSame( 'route_blocked', $check['totals']['samples'][0]['reason'] );
+	}
+
+	/**
+	 * Missing upstream policy is an explicit coverage warning, never eligibility.
+	 */
+	public function test_unknown_policy_is_not_instrumented_warning(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'ad_policy' => extrachill_analytics_revenue_normalize_ad_policy( null ),
+				)
+			),
+		);
+
+		$check = extrachill_analytics_revenue_diag_ad_policy_consistency( $rows );
+
+		$this->assertSame( 'warning', $check['status'] );
+		$this->assertSame( 1, $check['totals']['unknown_rows'] );
+		$this->assertStringContainsString( 'unknown/not instrumented', $check['evidence'][0] );
 	}
 
 	/**

--- a/tests/GetContentRevenuePagesTest.php
+++ b/tests/GetContentRevenuePagesTest.php
@@ -11,6 +11,7 @@
 
 use PHPUnit\Framework\TestCase;
 
+require_once dirname( __DIR__ ) . '/inc/core/revenue-ad-policy.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue-pages.php';
 require_once dirname( __DIR__ ) . '/inc/core/content-format-classifier.php';
 
@@ -45,6 +46,11 @@ final class GetContentRevenuePagesTest extends TestCase {
 				'title'                    => 'A Song',
 				'path'                     => '/song/',
 				'published_date'           => '2024-01-01 00:00:00',
+				'ad_policy'                => array(
+					'site_enabled' => true,
+					'serve_ads'    => true,
+					'reason'       => 'enabled',
+				),
 			),
 			$over
 		);
@@ -76,6 +82,11 @@ final class GetContentRevenuePagesTest extends TestCase {
 				'title'                    => '',
 				'path'                     => '',
 				'published_date'           => '',
+				'ad_policy'                => array(
+					'site_enabled' => true,
+					'serve_ads'    => true,
+					'reason'       => 'enabled',
+				),
 			),
 			$over
 		);
@@ -691,6 +702,82 @@ final class GetContentRevenuePagesTest extends TestCase {
 		$this->assertNotNull( $by_key['p6']['benchmark_score'] );
 		// score = 300 / 35 ≈ 8.57.
 		$this->assertEqualsWithDelta( 8.5714, $by_key['p6']['benchmark_score'], 0.01 );
+	}
+
+	/**
+	 * Only policy-confirmed ad-serving pages participate in benchmarks.
+	 */
+	public function test_ad_free_and_unknown_surfaces_are_excluded_from_benchmark(): void {
+		$eligible = array(
+			array( 'p-main', 1, 'enabled', 10.0 ),
+			array( 'p-events', 7, 'enabled', 20.0 ),
+			array( 'p-wire', 11, 'enabled', 30.0 ),
+			array( 'p-main-2', 1, 'enabled', 40.0 ),
+			array( 'p-events-2', 7, 'enabled', 200.0 ),
+		);
+		$records  = array();
+		foreach ( $eligible as $item ) {
+			$records[] = $this->content(
+				array(
+					'page_key'        => $item[0],
+					'content_blog_id' => $item[1],
+					'views'           => 5000,
+					'revenue'         => $item[3] * 5,
+				)
+			);
+		}
+
+		$records[] = $this->content(
+			array(
+				'page_key'        => 'community',
+				'content_blog_id' => 2,
+				'views'           => 10000,
+				'revenue'         => 0.0,
+				'ad_policy'       => array(
+					'site_enabled' => false,
+					'serve_ads'    => false,
+					'reason'       => 'site_disabled',
+				),
+			)
+		);
+		$records[] = $this->unresolved(
+			array(
+				'page_key'  => 'main-home',
+				'views'     => 20000,
+				'revenue'   => 0.0,
+				'ad_policy' => array(
+					'site_enabled' => true,
+					'serve_ads'    => false,
+					'reason'       => 'route_blocked',
+				),
+			)
+		);
+		$records[] = $this->content(
+			array(
+				'page_key'  => 'unknown-policy',
+				'views'     => 10000,
+				'revenue'   => 10000.0,
+				'ad_policy' => extrachill_analytics_revenue_normalize_ad_policy( null ),
+			)
+		);
+
+		$built  = extrachill_analytics_revenue_build_pages( $records, array( 'cohort' => 'all' ) );
+		$by_key = array();
+		foreach ( $built['pages'] as $page ) {
+			$by_key[ $page['page_key'] ] = $page;
+		}
+
+		$this->assertTrue( $built['sample']['benchmark_computed'] );
+		$this->assertSame( 'not_applicable', $by_key['community']['revenue_status'] );
+		$this->assertSame( 'not_applicable', $by_key['main-home']['revenue_status'] );
+		$this->assertSame( 'unknown', $by_key['unknown-policy']['revenue_status'] );
+		$this->assertFalse( $by_key['community']['benchmark_opportunity'] );
+		$this->assertFalse( $by_key['main-home']['benchmark_opportunity'] );
+		$this->assertFalse( $by_key['unknown-policy']['benchmark_opportunity'] );
+		$this->assertNull( $by_key['unknown-policy']['benchmark_score'] );
+		$this->assertSame( 'applicable', $by_key['p-main']['revenue_status'] );
+		$this->assertSame( 'applicable', $by_key['p-events']['revenue_status'] );
+		$this->assertSame( 'applicable', $by_key['p-wire']['revenue_status'] );
 	}
 
 	/**

--- a/tests/GetContentRevenueRollupTest.php
+++ b/tests/GetContentRevenueRollupTest.php
@@ -11,6 +11,7 @@
 
 use PHPUnit\Framework\TestCase;
 
+require_once dirname( __DIR__ ) . '/inc/core/revenue-ad-policy.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue.php';
 
 /**
@@ -308,6 +309,35 @@ final class GetContentRevenueRollupTest extends TestCase {
 		$this->assertSame( $result['unresolved']['views'], $views );
 		$this->assertEquals( round( $result['unresolved']['revenue'], 2 ), round( $revenue, 2 ) );
 		$this->assertSame( $result['unresolved']['pages'], $family['home']['pages'] + $family['pagination']['pages'] + $family['taxonomy-archive']['pages'] + $family['legacy-html']['pages'] );
+	}
+
+	/**
+	 * Intentional no-ads traffic remains visible without reading as underperformance.
+	 */
+	public function test_blocked_home_revenue_is_not_applicable_but_preserved(): void {
+		$result = extrachill_analytics_revenue_build_rollups(
+			array(
+				array(
+					'is_content' => false,
+					'page_key'   => 'home',
+					'views'      => 5000,
+					'revenue'    => 2.5,
+					'url'        => '/',
+					'ad_policy'  => array(
+						'site_enabled' => true,
+						'serve_ads'    => false,
+						'reason'       => 'route_blocked',
+					),
+				),
+			),
+			'format'
+		);
+
+		$this->assertSame( 5000, $result['unresolved']['views'] );
+		$this->assertSame( 2.5, $result['unresolved']['revenue'] );
+		$this->assertSame( 'not_applicable', $result['unresolved']['revenue_status'] );
+		$this->assertSame( 1, $result['unresolved']['policy_conflicts'] );
+		$this->assertSame( 'not_applicable', $result['unresolved']['by_route_family'][0]['revenue_status'] );
 	}
 
 	/**

--- a/tests/RevenueAdPolicyTest.php
+++ b/tests/RevenueAdPolicyTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Tests for the network-owned ad-policy adapter.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/revenue-ad-policy.php';
+
+/**
+ * Verify policy normalization and context mapping.
+ */
+final class RevenueAdPolicyTest extends TestCase {
+
+	/** Missing integration stays explicitly unknown. */
+	public function test_unavailable_policy_is_unknown(): void {
+		$policy = extrachill_analytics_revenue_normalize_ad_policy( null );
+
+		$this->assertNull( $policy['site_enabled'] );
+		$this->assertNull( $policy['serve_ads'] );
+		$this->assertSame( 'not_instrumented', $policy['reason'] );
+		$this->assertSame( 'unknown', extrachill_analytics_revenue_policy_status( $policy ) );
+	}
+
+	/** Homepage and Page facts are passed as context, not policy inferred here. */
+	public function test_context_maps_known_route_facts_only(): void {
+		$home = extrachill_analytics_revenue_ad_policy_context( 1, 'https://extrachill.com/', '', 'home' );
+		$page = extrachill_analytics_revenue_ad_policy_context( 1, 'https://extrachill.com/about/', 'page', '' );
+
+		$this->assertTrue( $home['is_front_page'] );
+		$this->assertTrue( $home['is_home'] );
+		$this->assertTrue( $page['is_page'] );
+		$this->assertTrue( $page['is_singular'] );
+		$this->assertFalse( $page['is_front_page'] );
+	}
+
+	/** The adapter preserves all upstream policy outcomes without a site matrix. */
+	public function test_upstream_outcomes_are_preserved(): void {
+		foreach ( array( 'enabled', 'site_disabled', 'route_blocked', 'member_benefit', 'integration_unavailable' ) as $reason ) {
+			$serve_ads = 'enabled' === $reason;
+			$policy    = extrachill_analytics_revenue_normalize_ad_policy(
+				array(
+					'site_enabled' => ! in_array( $reason, array( 'site_disabled', 'integration_unavailable' ), true ),
+					'serve_ads'    => $serve_ads,
+					'reason'       => $reason,
+				)
+			);
+
+			$this->assertSame( $reason, $policy['reason'] );
+			$this->assertSame( $serve_ads ? 'applicable' : 'not_applicable', extrachill_analytics_revenue_policy_status( $policy ) );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Consume the network-owned `extrachill_get_ad_policy()` contract across revenue pages, rollups, diagnostics, and surface stickiness without duplicating the site matrix or inspecting integration activation.
- Keep traffic, engagement, and imported revenue visible while marking blocked rows `not_applicable`, unavailable policy `unknown`, and mixed aggregate policy explicitly.
- Exclude every non-applicable or unknown row from benchmark opportunities while retaining existing content attribution and avoiding read-time URL resolver fanout.

## Failure Corrected

Community and the blocked main homepage can no longer be treated as monetization opportunities. Policy-confirmed Main posts/archives, Events, and Wire remain benchmark-eligible. The stale stickiness prose now correctly states that Events is ad-enabled and may carry attributed revenue.

## Output Contract

Revenue and surface outputs now expose network policy fields under `ad_policy` (`site_enabled`, `serve_ads`, `reason`) plus `revenue_status` where performance applicability matters. Page rows also expose `policy_conflict`; aggregate rollups expose conflict counts.

- `applicable`: network policy confirms ads serve.
- `not_applicable`: ads are intentionally disabled or blocked; traffic and raw revenue remain visible but do not enter benchmark opportunities.
- `unknown`: the policy primitive is unavailable or returned an incomplete contract; Analytics does not infer eligibility.
- Policy conflicts: diagnostics warn with slug, views, revenue, and policy reason when positive imported revenue contradicts a blocked policy. Source revenue is never changed.

Analytics remains a consumer only. Extra Chill Network owns site, route, member-benefit, and integration policy in Extra-Chill/extrachill-network#125.

## Tests

- `composer test` - 206 tests, 734 assertions passing.
- Changed-file WordPress PHPCS - passing.
- `php -l` on all changed production PHP - passing.
- Repository-wide PHPCS still reports unrelated pre-existing baseline debt tracked in #155; no changed file has PHPCS findings.

Closes #154
