### PR TITLE
fix: scope revenue reports by canonical host

### DIFF
--- a/inc/core/abilities/get-content-revenue-pages.php
+++ b/inc/core/abilities/get-content-revenue-pages.php
@@ -97,7 +97,7 @@ function extrachill_analytics_register_content_revenue_pages_ability() {
 					),
 					'hostname'          => array(
 						'type'        => 'string',
-						'description' => __( 'Optional hostname for resolving relative slugs to posts. Empty = the target blog hostname.', 'extrachill-analytics' ),
+						'description' => __( 'Optional hostname scope. Resolved content matches its canonical owner host; unresolved rows require an absolute source URL with matching host. Empty = all hosts.', 'extrachill-analytics' ),
 						'default'     => '',
 					),
 					'cohort'            => array(
@@ -535,22 +535,6 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 		)
 	);
 
-	$selected_periods = array();
-	$selected_batches = array();
-	foreach ( $rows as $r ) {
-		$selected_periods[ (string) $r->period_label ] = true;
-		$selected_batches[ (string) $r->import_batch ] = true;
-	}
-
-	$scope_block = array(
-		'requested_period' => $requested_period,
-		'effective_period' => $effective_period,
-		'effective_batch'  => $effective_batch,
-		'defaulted'        => $defaulted,
-		'selected_periods' => array_keys( $selected_periods ),
-		'selected_batches' => array_keys( $selected_batches ),
-	);
-
 	$empty_totals = array(
 		'pages_before_limit' => 0,
 		'pages_returned'     => 0,
@@ -570,6 +554,14 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 	);
 
 	if ( empty( $rows ) ) {
+		$scope_block = array(
+			'requested_period' => $requested_period,
+			'effective_period' => $effective_period,
+			'effective_batch'  => $effective_batch,
+			'defaulted'        => $defaulted,
+			'selected_periods' => array(),
+			'selected_batches' => array(),
+		);
 		return array(
 			'success'   => true,
 			'rows'      => 0,
@@ -589,19 +581,30 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 		);
 	}
 
-	$records = array();
+	$records          = array();
+	$selected_periods = array();
+	$selected_batches = array();
 	foreach ( $rows as $row ) {
 		$post_id         = (int) $row->post_id;
 		$content_blog_id = ! empty( $row->content_blog_id ) ? (int) $row->content_blog_id : $blog_id;
 		$metadata        = extrachill_analytics_revenue_content_metadata( $content_blog_id, $post_id );
 		$is_content      = is_array( $metadata );
 		$source_url      = $row->url ? $row->url : $row->slug;
-		$route_family    = $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $source_url );
-		$post_type       = $is_content && isset( $metadata['post_type'] ) ? (string) $metadata['post_type'] : '';
-		$ad_policy       = extrachill_analytics_revenue_get_ad_policy(
+		$canonical_url   = $is_content
+			? ( ! empty( $row->canonical_url ) ? (string) $row->canonical_url : (string) $metadata['url'] )
+			: '';
+		if ( ! extrachill_analytics_revenue_row_matches_hostname( $hostname, $is_content, $canonical_url, $source_url ) ) {
+			continue;
+		}
+		$selected_periods[ (string) $row->period_label ] = true;
+		$selected_batches[ (string) $row->import_batch ] = true;
+
+		$route_family = $is_content ? '' : extrachill_analytics_revenue_classify_route_family( $source_url );
+		$post_type    = $is_content && isset( $metadata['post_type'] ) ? (string) $metadata['post_type'] : '';
+		$ad_policy    = extrachill_analytics_revenue_get_ad_policy(
 			extrachill_analytics_revenue_ad_policy_context( $content_blog_id, $source_url, $post_type, $route_family )
 		);
-		$records[]       = array(
+		$records[]    = array(
 			'page_key'                 => $is_content ? 'p' . $content_blog_id . ':' . $post_id : 'u' . md5( (string) $row->slug ),
 			'is_content'               => $is_content,
 			'content_blog_id'          => $is_content ? $content_blog_id : 0,
@@ -635,9 +638,18 @@ function extrachill_analytics_ability_get_content_revenue_pages( $input ) {
 		)
 	);
 
+	$scope_block = array(
+		'requested_period' => $requested_period,
+		'effective_period' => $effective_period,
+		'effective_batch'  => $effective_batch,
+		'defaulted'        => $defaulted,
+		'selected_periods' => array_keys( $selected_periods ),
+		'selected_batches' => array_keys( $selected_batches ),
+	);
+
 	return array(
 		'success'   => true,
-		'rows'      => count( $rows ),
+		'rows'      => count( $records ),
 		'blog_id'   => $blog_id,
 		'window'    => extrachill_analytics_revenue_window_label( $period_start, $period_end, $effective_period ),
 		'cohort'    => $cohort,

--- a/inc/core/abilities/get-content-revenue.php
+++ b/inc/core/abilities/get-content-revenue.php
@@ -81,8 +81,8 @@ function extrachill_analytics_register_content_revenue_ability() {
 					),
 					'hostname'        => array(
 						'type'        => 'string',
-						'description' => __( 'Hostname for resolving any still-unresolved slugs to posts (default: extrachill.com).', 'extrachill-analytics' ),
-						'default'     => 'extrachill.com',
+						'description' => __( 'Optional hostname scope. Resolved content matches its canonical owner host; unresolved rows require an absolute source URL with matching host. Empty = all hosts.', 'extrachill-analytics' ),
+						'default'     => '',
 					),
 				),
 			),
@@ -120,7 +120,7 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 	$import_batch    = isset( $input['import_batch'] ) ? (string) $input['import_batch'] : '';
 	$include_alltime = ! empty( $input['include_alltime'] );
 	$blog_id         = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : get_current_blog_id();
-	$hostname        = ! empty( $input['hostname'] ) ? (string) $input['hostname'] : 'extrachill.com';
+	$hostname        = isset( $input['hostname'] ) ? trim( (string) $input['hostname'] ) : '';
 	$site_policy     = extrachill_analytics_revenue_get_ad_policy(
 		extrachill_analytics_revenue_ad_policy_context( $blog_id )
 	);
@@ -193,7 +193,7 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 
 		$views      = (int) $row->views;
 		$revenue    = (float) $row->revenue;
-		$source_url = ! empty( $row->canonical_url ) ? $row->canonical_url : ( $row->url ? $row->url : $row->slug );
+		$source_url = $row->url ? $row->url : $row->slug;
 
 		$content_blog_id = ! empty( $row->content_blog_id ) ? (int) $row->content_blog_id : $blog_id;
 		// Content remains eligible only when 'publish' === get_post_status( $post_id ).
@@ -208,13 +208,21 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 					'categories' => ( is_array( $terms ) && ! empty( $terms ) ) ? wp_list_pluck( $terms, 'slug' ) : array( 'uncategorized' ),
 					'format'     => extrachill_analytics_classify_format( $post_id ),
 					'post_type'  => (string) get_post_type( $post_id ),
+					'url'        => (string) get_permalink( $post_id ),
 				);
 			}
 		) : null;
 
+		$canonical_url = is_array( $content )
+			? ( ! empty( $row->canonical_url ) ? (string) $row->canonical_url : $content['url'] )
+			: '';
+		if ( ! extrachill_analytics_revenue_row_matches_hostname( $hostname, is_array( $content ), $canonical_url, $source_url ) ) {
+			continue;
+		}
+
 		if ( is_array( $content ) ) {
 			$ad_policy = extrachill_analytics_revenue_get_ad_policy(
-				extrachill_analytics_revenue_ad_policy_context( $content_blog_id, $source_url, $content['post_type'] )
+				extrachill_analytics_revenue_ad_policy_context( $content_blog_id, $canonical_url, $content['post_type'] )
 			);
 			$records[] = array(
 				'is_content'      => true,
@@ -226,7 +234,7 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 				'format_eligible' => extrachill_analytics_is_editorial_format_eligible( $content_blog_id, $content['post_type'] ),
 				'views'           => $views,
 				'revenue'         => $revenue,
-				'url'             => $source_url,
+				'url'             => $canonical_url,
 				'ad_policy'       => $ad_policy,
 			);
 		} else {
@@ -251,7 +259,7 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 
 	return array(
 		'success'        => true,
-		'rows'           => count( $rows ),
+		'rows'           => count( $records ),
 		'blog_id'        => $blog_id,
 		'group_by'       => $group_by,
 		'window'         => extrachill_analytics_revenue_window_label( $period_start, $period_end, $period ),

--- a/inc/core/revenue-content-attribution.php
+++ b/inc/core/revenue-content-attribution.php
@@ -35,6 +35,88 @@ function extrachill_analytics_revenue_frontend_path( $value ) {
 }
 
 /**
+ * Normalize a hostname or URL for revenue host scoping.
+ *
+ * Scheme, port, case, a trailing DNS dot, and the common `www` alias do not
+ * change content ownership. A bare hostname is accepted for CLI ergonomics.
+ *
+ * @param string $value Hostname or URL.
+ * @return string Normalized hostname, or an empty string when invalid.
+ */
+function extrachill_analytics_revenue_normalize_hostname( $value ) {
+	$value = trim( (string) $value );
+	if ( '' === $value ) {
+		return '';
+	}
+
+	$url = preg_match( '#^https?://#i', $value ) || 0 === strpos( $value, '//' )
+		? $value
+		: 'https://' . $value;
+	if ( 0 === strpos( $url, '//' ) ) {
+		$url = 'https:' . $url;
+	}
+
+	$parts = wp_parse_url( $url );
+	if ( false === $parts || empty( $parts['host'] ) ) {
+		return '';
+	}
+
+	$host = rtrim( strtolower( (string) $parts['host'] ), '.' );
+	if ( 0 === strpos( $host, 'www.' ) ) {
+		$host = substr( $host, 4 );
+	}
+
+	return $host;
+}
+
+/**
+ * Extract trustworthy hostname evidence from an absolute source URL.
+ *
+ * Host-relative paths deliberately return an empty string. Their owner cannot
+ * be inferred from the path without recreating resolver fanout at read time.
+ *
+ * @param string $url Source or canonical URL.
+ * @return string Normalized hostname, or an empty string when unavailable.
+ */
+function extrachill_analytics_revenue_url_hostname( $url ) {
+	$url = trim( (string) $url );
+	if ( ! preg_match( '#^https?://#i', $url ) && 0 !== strpos( $url, '//' ) ) {
+		return '';
+	}
+
+	return extrachill_analytics_revenue_normalize_hostname( $url );
+}
+
+/**
+ * Determine whether one revenue row belongs to a requested hostname.
+ *
+ * Resolved content is scoped exclusively by its canonical owner URL. An
+ * unresolved row may match only from an absolute source URL; missing source
+ * host evidence fails closed. With no requested hostname, all rows match for
+ * backward compatibility.
+ *
+ * @param string $requested_hostname Requested hostname or URL.
+ * @param bool   $is_content          Whether the row resolved to published content.
+ * @param string $canonical_url       Canonical resolved owner URL.
+ * @param string $source_url          Original source URL/path.
+ * @return bool Whether the row is in scope.
+ */
+function extrachill_analytics_revenue_row_matches_hostname( $requested_hostname, $is_content, $canonical_url, $source_url ) {
+	$requested_hostname = trim( (string) $requested_hostname );
+	if ( '' === $requested_hostname ) {
+		return true;
+	}
+
+	$requested = extrachill_analytics_revenue_normalize_hostname( $requested_hostname );
+	if ( '' === $requested ) {
+		return false;
+	}
+
+	$evidence = $is_content ? $canonical_url : $source_url;
+	return extrachill_analytics_revenue_url_hostname( $evidence ) === $requested;
+}
+
+/**
  * Resolve unresolved content paths through the Network batch contract.
  *
  * This deliberately runs before the ingestion transaction. An incomplete scan

--- a/tests/GetContentRevenuePagesTest.php
+++ b/tests/GetContentRevenuePagesTest.php
@@ -12,6 +12,7 @@
 use PHPUnit\Framework\TestCase;
 
 require_once dirname( __DIR__ ) . '/inc/core/revenue-ad-policy.php';
+require_once dirname( __DIR__ ) . '/inc/core/revenue-content-attribution.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue-pages.php';
 require_once dirname( __DIR__ ) . '/inc/core/content-format-classifier.php';
 
@@ -90,6 +91,87 @@ final class GetContentRevenuePagesTest extends TestCase {
 			),
 			$over
 		);
+	}
+
+	/**
+	 * Host scope follows canonical ownership and fails closed without provenance.
+	 */
+	public function test_hostname_scope_uses_canonical_owner_and_source_evidence(): void {
+		$rows = array(
+			array(
+				'key'       => 'main',
+				'resolved'  => true,
+				'canonical' => 'https://extrachill.com/post/',
+				'source'    => '/post/',
+			),
+			array(
+				'key'       => 'community',
+				'resolved'  => true,
+				'canonical' => 'https://community.extrachill.com/?p=5254',
+				'source'    => '/?p=5254',
+			),
+			array(
+				'key'       => 'wire',
+				'resolved'  => true,
+				'canonical' => 'https://wire.extrachill.com/story/',
+				'source'    => '/story/',
+			),
+			array(
+				'key'       => 'events',
+				'resolved'  => true,
+				'canonical' => 'https://events.extrachill.com/show/',
+				'source'    => '/show/',
+			),
+			array(
+				'key'       => 'unresolved-main',
+				'resolved'  => false,
+				'canonical' => '',
+				'source'    => 'https://extrachill.com/ghost/',
+			),
+			array(
+				'key'       => 'unresolved-unknown',
+				'resolved'  => false,
+				'canonical' => '',
+				'source'    => '/ghost/',
+			),
+		);
+
+		$filter = static function ( $hostname ) use ( $rows ) {
+			return array_values(
+				array_map(
+					static function ( $row ) {
+						return $row['key'];
+					},
+					array_filter(
+						$rows,
+						static function ( $row ) use ( $hostname ) {
+							return extrachill_analytics_revenue_row_matches_hostname( $hostname, $row['resolved'], $row['canonical'], $row['source'] );
+						}
+					)
+				)
+			);
+		};
+
+		$this->assertSame( array( 'main', 'unresolved-main' ), $filter( 'extrachill.com' ) );
+		$this->assertSame( array( 'community' ), $filter( 'community.extrachill.com' ) );
+		$this->assertSame( array( 'wire' ), $filter( 'wire.extrachill.com' ) );
+		$this->assertSame( array( 'events' ), $filter( 'events.extrachill.com' ) );
+		$this->assertSame( array_column( $rows, 'key' ), $filter( '' ) );
+	}
+
+	/**
+	 * Host matching normalizes aliases, scheme, port, case, and trailing dots.
+	 */
+	public function test_hostname_scope_normalization(): void {
+		$this->assertTrue(
+			extrachill_analytics_revenue_row_matches_hostname(
+				'https://WWW.ExtraChill.com:443/path',
+				true,
+				'http://extrachill.com./canonical/',
+				'https://wire.extrachill.com/source/'
+			)
+		);
+		$this->assertFalse( extrachill_analytics_revenue_row_matches_hostname( 'extrachill.com', false, '', '/hostless/' ) );
 	}
 
 	/**
@@ -439,6 +521,7 @@ final class GetContentRevenuePagesTest extends TestCase {
 		$this->assertStringContainsString( "'selected_batches'", $source );
 		// Reuses shared substrate (no new SQL/table).
 		$this->assertStringContainsString( 'extrachill_analytics_revenue_get_rows', $source );
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_row_matches_hostname', $source );
 		$this->assertStringNotContainsString( 'CREATE TABLE', $source );
 	}
 

--- a/tests/GetContentRevenueRollupTest.php
+++ b/tests/GetContentRevenueRollupTest.php
@@ -12,6 +12,7 @@
 use PHPUnit\Framework\TestCase;
 
 require_once dirname( __DIR__ ) . '/inc/core/revenue-ad-policy.php';
+require_once dirname( __DIR__ ) . '/inc/core/revenue-content-attribution.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue.php';
 
 /**
@@ -411,6 +412,7 @@ final class GetContentRevenueRollupTest extends TestCase {
 		// The response exposes an explicit unresolved cohort.
 		$this->assertStringContainsString( "'unresolved'", $source );
 		$this->assertStringContainsString( "'by_route_family'", $source );
+		$this->assertStringContainsString( 'extrachill_analytics_revenue_row_matches_hostname', $source );
 		// The old conflation (unresolved rows bucketed as uncategorized/legacy-html
 		// content) is gone.
 		$this->assertStringNotContainsString( "preg_match( '/\\.html(?:[\\/?#]|$)/i', (string) \$row->url ) ? 'legacy-html' : 'uncategorized'", $source );


### PR DESCRIPTION
## Summary
- apply requested hostname scope to resolved rows using their persisted canonical owner URL, excluding Community/Wire rows from Main-only reports
- share identical host matching between page and rollup outputs, with deterministic case, scheme, port, trailing-dot, and `www` normalization
- keep unresolved rows explicitly unresolved and include them only when their original source URL provides trustworthy matching host evidence

## Root cause
The page and rollup abilities parsed `hostname`, but the store query and record-building loops never applied it. `blog_id` scoped the imported revenue snapshot, not the canonical owner discovered by the network resolver, so cross-site resolved rows remained in host-specific reports.

## Canonical vs source host semantics
Resolved content is scoped exclusively by its canonical owner URL (`canonical_url`, with the owning post permalink as the legacy fallback). The original source path/URL remains separate and revenue values are unchanged. Unresolved rows use only an absolute source URL as host evidence; host-relative paths are not inferred or sent back through the resolver at read time.

## Unresolved behavior
- absolute source URL with a matching host: included
- absolute source URL with another host: excluded
- missing/host-relative source evidence: excluded from hostname-scoped results and remains unresolved
- no hostname filter: existing unfiltered behavior is preserved

## Compatibility
No schema migration, re-ingestion, resolver fanout, policy change, or revenue mutation is required. Existing canonical ownership evidence is used directly. Calls that omit `hostname` continue to return all hosts.

## Tests
- `vendor/bin/phpunit` (`208 tests, 743 assertions`)
- `vendor/bin/phpcs --standard=WordPress inc/core/revenue-content-attribution.php inc/core/abilities/get-content-revenue.php inc/core/abilities/get-content-revenue-pages.php tests/GetContentRevenuePagesTest.php tests/GetContentRevenueRollupTest.php` (pass, no findings)
- `git diff --check` (pass)

Closes #157