### PR TITLE
fix: isolate editorial revenue format coverage

### DIFF
--- a/inc/core/abilities/get-content-revenue-diagnostics.php
+++ b/inc/core/abilities/get-content-revenue-diagnostics.php
@@ -247,74 +247,80 @@ function extrachill_analytics_revenue_diagnostic_totals_schema() {
 	);
 
 	return array(
-		'periods'             => array( 'type' => 'integer' ),
-		'rows'                => array( 'type' => 'integer' ),
-		'has_dated'           => array( 'type' => 'boolean' ),
-		'latest_period'       => array( 'type' => 'string' ),
-		'latest_period_end'   => array( 'type' => 'string' ),
-		'data_age_days'       => array( 'type' => array( 'integer', 'null' ) ),
-		'dated_periods'       => array( 'type' => 'integer' ),
-		'missing_periods'     => array( 'type' => 'integer' ),
-		'missing'             => array(
+		'periods'                  => array( 'type' => 'integer' ),
+		'rows'                     => array( 'type' => 'integer' ),
+		'has_dated'                => array( 'type' => 'boolean' ),
+		'latest_period'            => array( 'type' => 'string' ),
+		'latest_period_end'        => array( 'type' => 'string' ),
+		'data_age_days'            => array( 'type' => array( 'integer', 'null' ) ),
+		'dated_periods'            => array( 'type' => 'integer' ),
+		'missing_periods'          => array( 'type' => 'integer' ),
+		'missing'                  => array(
 			'type'  => 'array',
 			'items' => array( 'type' => 'string' ),
 		),
-		'period_labels'       => array( 'type' => 'integer' ),
-		'duplicate_labels'    => array( 'type' => 'integer' ),
-		'duplicates'          => array(
+		'period_labels'            => array( 'type' => 'integer' ),
+		'duplicate_labels'         => array( 'type' => 'integer' ),
+		'duplicates'               => array(
 			'type'                 => 'object',
 			'additionalProperties' => array(
 				'type'  => 'array',
 				'items' => array( 'type' => 'string' ),
 			),
 		),
-		'row_sum'             => $aggregate,
-		'independent'         => $aggregate,
-		'reconciled'          => array( 'type' => 'boolean' ),
-		'raw_rows'            => array( 'type' => 'integer' ),
-		'distinct_pages'      => array( 'type' => 'integer' ),
-		'resolved_pages'      => array( 'type' => 'integer' ),
-		'unresolved_pages'    => array( 'type' => 'integer' ),
-		'stale_post_id_rows'  => array( 'type' => 'integer' ),
-		'partition_complete'  => array( 'type' => 'boolean' ),
-		'content_rows'        => array( 'type' => 'integer' ),
-		'unresolved_rows'     => array( 'type' => 'integer' ),
-		'partition_views'     => array( 'type' => 'integer' ),
-		'partition_revenue'   => array( 'type' => 'number' ),
-		'total_pages'         => array( 'type' => 'integer' ),
-		'resolved_views'      => array( 'type' => 'integer' ),
-		'unresolved_views'    => array( 'type' => 'integer' ),
-		'unresolved_ratio'    => array( 'type' => 'number' ),
-		'by_route_family'     => array(
+		'row_sum'                  => $aggregate,
+		'independent'              => $aggregate,
+		'reconciled'               => array( 'type' => 'boolean' ),
+		'raw_rows'                 => array( 'type' => 'integer' ),
+		'distinct_pages'           => array( 'type' => 'integer' ),
+		'resolved_pages'           => array( 'type' => 'integer' ),
+		'unresolved_pages'         => array( 'type' => 'integer' ),
+		'stale_post_id_rows'       => array( 'type' => 'integer' ),
+		'partition_complete'       => array( 'type' => 'boolean' ),
+		'content_rows'             => array( 'type' => 'integer' ),
+		'unresolved_rows'          => array( 'type' => 'integer' ),
+		'partition_views'          => array( 'type' => 'integer' ),
+		'partition_revenue'        => array( 'type' => 'number' ),
+		'total_pages'              => array( 'type' => 'integer' ),
+		'resolved_views'           => array( 'type' => 'integer' ),
+		'unresolved_views'         => array( 'type' => 'integer' ),
+		'unresolved_ratio'         => array( 'type' => 'number' ),
+		'by_route_family'          => array(
 			'type'                 => 'object',
 			'additionalProperties' => array( 'type' => 'integer' ),
 		),
-		'uncategorized_pages' => array( 'type' => 'integer' ),
-		'uncategorized_ratio' => array( 'type' => 'number' ),
-		'by_format'           => array(
+		'uncategorized_pages'      => array( 'type' => 'integer' ),
+		'uncategorized_ratio'      => array( 'type' => 'number' ),
+		'eligible_editorial_pages' => array( 'type' => 'integer' ),
+		'non_editorial_pages'      => array( 'type' => 'integer' ),
+		'by_non_editorial'         => array(
 			'type'                 => 'object',
 			'additionalProperties' => array( 'type' => 'integer' ),
 		),
-		'revenue'             => array( 'type' => 'number' ),
-		'samples'             => array(
+		'by_format'                => array(
+			'type'                 => 'object',
+			'additionalProperties' => array( 'type' => 'integer' ),
+		),
+		'revenue'                  => array( 'type' => 'number' ),
+		'samples'                  => array(
 			'type'  => 'array',
 			'items' => $sample,
 		),
-		'views'               => array( 'type' => 'integer' ),
-		'ratio'               => array( 'type' => 'number' ),
-		'checked'             => array( 'type' => 'integer' ),
-		'high_variance'       => array( 'type' => 'integer' ),
-		'high_rate_rows'      => array( 'type' => 'integer' ),
-		'high_rate_samples'   => array(
+		'views'                    => array( 'type' => 'integer' ),
+		'ratio'                    => array( 'type' => 'number' ),
+		'checked'                  => array( 'type' => 'integer' ),
+		'high_variance'            => array( 'type' => 'integer' ),
+		'high_rate_rows'           => array( 'type' => 'integer' ),
+		'high_rate_samples'        => array(
 			'type'  => 'array',
 			'items' => $sample,
 		),
-		'missing_batch'       => array( 'type' => 'integer' ),
-		'missing_period'      => array( 'type' => 'integer' ),
-		'instrumented_rows'   => array( 'type' => 'integer' ),
-		'unknown_rows'        => array( 'type' => 'integer' ),
-		'conflict_rows'       => array( 'type' => 'integer' ),
-		'conflict_revenue'    => array( 'type' => 'number' ),
+		'missing_batch'            => array( 'type' => 'integer' ),
+		'missing_period'           => array( 'type' => 'integer' ),
+		'instrumented_rows'        => array( 'type' => 'integer' ),
+		'unknown_rows'             => array( 'type' => 'integer' ),
+		'conflict_rows'            => array( 'type' => 'integer' ),
+		'conflict_revenue'         => array( 'type' => 'number' ),
 	);
 }
 
@@ -422,6 +428,8 @@ function extrachill_analytics_ability_get_content_revenue_diagnostics( $input ) 
 			'is_content'               => $is_content,
 			'route_family'             => $route_family,
 			'format'                   => $is_content ? $metadata['format'] : '',
+			'post_type'                => $post_type,
+			'format_eligible'          => $is_content && extrachill_analytics_is_editorial_format_eligible( $content_blog_id, $post_type ),
 			'views'                    => $views,
 			'revenue'                  => $revenue,
 			'source_rpm'               => (float) $row->rpm,
@@ -1069,8 +1077,8 @@ function extrachill_analytics_revenue_diag_resolution_coverage( array $rows ) {
 }
 
 /**
- * Content-format coverage: resolved posts that classified as 'uncategorized',
- * counted on DEDUPED pages (not raw rows).
+ * Content-format coverage for eligible main-site editorial posts, counted on
+ * DEDUPED pages (not raw rows). Other resolved content is reported separately.
  *
  * A high uncategorized ratio means the format classifier has no mapping for
  * many posts — a taxonomy gap, not corruption. Unresolved routes are excluded
@@ -1080,8 +1088,12 @@ function extrachill_analytics_revenue_diag_resolution_coverage( array $rows ) {
  * @return array Check.
  */
 function extrachill_analytics_revenue_diag_format_coverage( array $rows ) {
-	$by_format     = array();
-	$uncategorized = 0;
+	$by_format           = array();
+	$by_non_editorial    = array();
+	$seen                = array();
+	$uncategorized       = 0;
+	$resolved_total      = 0;
+	$non_editorial_total = 0;
 
 	foreach ( $rows as $r ) {
 		if ( empty( $r['is_content'] ) ) {
@@ -1089,10 +1101,18 @@ function extrachill_analytics_revenue_diag_format_coverage( array $rows ) {
 		}
 		// Dedupe by owning content identity — one vote per resolved page.
 		$key = 'p' . (int) ( $r['content_blog_id'] ?? 0 ) . ':' . (int) $r['post_id'];
-		if ( isset( $by_format['_seen'][ $key ] ) ) {
+		if ( isset( $seen[ $key ] ) ) {
 			continue;
 		}
-		$by_format['_seen'][ $key ] = true;
+		$seen[ $key ] = true;
+		++$resolved_total;
+
+		if ( isset( $r['format_eligible'] ) && ! $r['format_eligible'] ) {
+			$type                      = 'blog-' . (int) ( $r['content_blog_id'] ?? 0 ) . ':' . ( ! empty( $r['post_type'] ) ? (string) $r['post_type'] : 'unknown' );
+			$by_non_editorial[ $type ] = isset( $by_non_editorial[ $type ] ) ? $by_non_editorial[ $type ] + 1 : 1;
+			++$non_editorial_total;
+			continue;
+		}
 
 		$format = isset( $r['format'] ) ? (string) $r['format'] : 'uncategorized';
 		if ( '' === $format ) {
@@ -1106,34 +1126,37 @@ function extrachill_analytics_revenue_diag_format_coverage( array $rows ) {
 			++$uncategorized;
 		}
 	}
-	unset( $by_format['_seen'] );
-
-	$resolved_total = 0;
+	$eligible_total = 0;
 	foreach ( $by_format as $count ) {
-		$resolved_total += $count;
+		$eligible_total += $count;
 	}
 
-	$ratio = $resolved_total > 0 ? $uncategorized / $resolved_total : 0.0;
+	$ratio = $eligible_total > 0 ? $uncategorized / $eligible_total : 0.0;
 	// Warn above 30% — a lot of distinct resolved pages fall outside every bucket.
-	$status     = ( $resolved_total > 0 && $ratio > 0.30 ) ? 'warning' : 'pass';
+	$status     = ( $eligible_total > 0 && $ratio > 0.30 ) ? 'warning' : 'pass';
 	$evidence   = array();
-	$evidence[] = "{$uncategorized} of {$resolved_total} distinct resolved page(s) classified as 'uncategorized'.";
+	$evidence[] = "{$uncategorized} of {$eligible_total} eligible editorial page(s) classified as 'uncategorized'.";
+	$evidence[] = "{$non_editorial_total} resolved non-editorial page(s) excluded from format coverage and reported by owning blog/post type.";
 	if ( 'warning' === $status ) {
-		$evidence[] = 'Over 30% of resolved pages match no content-format bucket — a taxonomy-mapping gap. Add their category slugs to extrachill_analytics_format_category_map().';
+		$evidence[] = 'Over 30% of eligible editorial pages match no content-format bucket — audit their taxonomy before adding stable category mappings.';
 	} else {
 		$evidence[] = 'Format classifier covers the majority of resolved pages.';
 	}
 	arsort( $by_format );
+	arsort( $by_non_editorial );
 
 	return array(
 		'check'    => 'format_coverage',
 		'status'   => $status,
 		'evidence' => $evidence,
 		'totals'   => array(
-			'resolved_pages'      => $resolved_total,
-			'uncategorized_pages' => $uncategorized,
-			'uncategorized_ratio' => round( $ratio, 4 ),
-			'by_format'           => $by_format,
+			'resolved_pages'           => $resolved_total,
+			'eligible_editorial_pages' => $eligible_total,
+			'non_editorial_pages'      => $non_editorial_total,
+			'uncategorized_pages'      => $uncategorized,
+			'uncategorized_ratio'      => round( $ratio, 4 ),
+			'by_format'                => $by_format,
+			'by_non_editorial'         => $by_non_editorial,
 		),
 	);
 }

--- a/inc/core/abilities/get-content-revenue.php
+++ b/inc/core/abilities/get-content-revenue.php
@@ -39,7 +39,7 @@ function extrachill_analytics_register_content_revenue_ability() {
 		'extrachill/get-content-revenue',
 		array(
 			'label'               => __( 'Get Content Revenue Lens', 'extrachill-analytics' ),
-			'description'         => __( 'Join imported Mediavine per-URL ad revenue to WordPress content metadata (category, content format, age) and roll it up by category, by content format, or as a TIME-SERIES revenue arc. Content totals and rollups cover RESOLVED PUBLISHED POSTS ONLY — unresolved routes (home, pagination, taxonomy archives, app/account routes, legacy .html ghosts) are excluded from content metrics so published-content RPM is honest, and reported separately under `unresolved` with a by_route_family breakdown. group_by=timeseries sums revenue/views per time bucket chronologically (month-over-month, the HCU cliff in dollars) — the first-class capability, since each monthly Mediavine export is one point on the arc. group_by=format/category/both reports pages, views, revenue, RPM, and $/page (revenue/pages) — $/page is the honest "worth producing" metric because RPM alone misleads (high RPM on tiny volume = pennies); scope these to one bucket with period=YYYY-MM. Revenue is exactly what was imported from the Mediavine Pages CSV (Mediavine has no per-page revenue API, only ad-config); this ability never estimates ad income. NOTE: the flat lifetime export is time-blind (no date column, one cumulative total per URL) and undercounts the 2022-2023 peak — import date-ranged monthly CSVs for the real arc.', 'extrachill-analytics' ),
+			'description'         => __( 'Join imported Mediavine per-URL ad revenue to WordPress content metadata (category, content format, age) and roll main-site editorial posts up by category, by content format, or as a TIME-SERIES revenue arc. Resolved non-editorial sites and post types are reported separately under `non_editorial`; unresolved routes are reported under `unresolved`. group_by=timeseries sums revenue/views per time bucket chronologically (month-over-month, the HCU cliff in dollars) — the first-class capability, since each monthly Mediavine export is one point on the arc. group_by=format/category/both reports pages, views, revenue, RPM, and $/page (revenue/pages) — $/page is the honest "worth producing" metric because RPM alone misleads (high RPM on tiny volume = pennies); scope these to one bucket with period=YYYY-MM. Revenue is exactly what was imported from the Mediavine Pages CSV (Mediavine has no per-page revenue API, only ad-config); this ability never estimates ad income. NOTE: the flat lifetime export is time-blind (no date column, one cumulative total per URL) and undercounts the 2022-2023 peak — import date-ranged monthly CSVs for the real arc.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -169,6 +169,13 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 				'rpm'             => 0.0,
 				'by_route_family' => array(),
 			),
+			'non_editorial'  => array(
+				'pages'           => 0,
+				'views'           => 0,
+				'revenue'         => 0.0,
+				'rpm'             => 0.0,
+				'by_content_type' => array(),
+			),
 			'caveat'         => __( 'No revenue snapshots for this blog/window. Import a Mediavine Pages CSV first: wp extrachill analytics revenue import <csv>.', 'extrachill-analytics' ),
 		);
 	}
@@ -210,14 +217,17 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 				extrachill_analytics_revenue_ad_policy_context( $content_blog_id, $source_url, $content['post_type'] )
 			);
 			$records[] = array(
-				'is_content' => true,
-				'page_key'   => 'p' . $content_blog_id . ':' . $post_id,
-				'format'     => $content['format'],
-				'categories' => $content['categories'],
-				'views'      => $views,
-				'revenue'    => $revenue,
-				'url'        => $source_url,
-				'ad_policy'  => $ad_policy,
+				'is_content'      => true,
+				'page_key'        => 'p' . $content_blog_id . ':' . $post_id,
+				'format'          => $content['format'],
+				'categories'      => $content['categories'],
+				'content_blog_id' => $content_blog_id,
+				'post_type'       => $content['post_type'],
+				'format_eligible' => extrachill_analytics_is_editorial_format_eligible( $content_blog_id, $content['post_type'] ),
+				'views'           => $views,
+				'revenue'         => $revenue,
+				'url'             => $source_url,
+				'ad_policy'       => $ad_policy,
 			);
 		} else {
 			// Unresolved route (post_id 0, or stale/non-published ID): diagnostic
@@ -250,7 +260,8 @@ function extrachill_analytics_ability_get_content_revenue( $input ) {
 		'rollups'        => $built['rollups'],
 		'totals'         => $built['totals'],
 		'unresolved'     => $built['unresolved'],
-		'caveat'         => __( 'Totals and rollups cover RESOLVED PUBLISHED CONTENT ONLY; unresolved routes are reported separately. Ad policy is owned by Extra Chill Network. revenue_status marks aggregates as applicable, not_applicable, mixed, or unknown while imported revenue remains unchanged; policy_conflicts counts contradictory positive revenue on blocked rows. $/page is the honest "worth producing" metric — RPM alone misleads. The Mediavine Pages CSV may omit hostnames, so unresolved cross-site paths remain coverage signal, not an attribution verdict.', 'extrachill-analytics' ),
+		'non_editorial'  => $built['non_editorial'],
+		'caveat'         => __( 'Totals and category/format rollups cover main-site editorial posts only. Resolved content from other sites or post types is reported separately under non_editorial; unresolved routes are reported under unresolved. Ad policy is owned by Extra Chill Network. revenue_status marks aggregates as applicable, not_applicable, mixed, or unknown while imported revenue remains unchanged; policy_conflicts counts contradictory positive revenue on blocked rows. $/page is the honest "worth producing" metric — RPM alone misleads. The Mediavine Pages CSV may omit hostnames, so unresolved cross-site paths remain coverage signal, not an attribution verdict.', 'extrachill-analytics' ),
 	);
 }
 
@@ -386,11 +397,11 @@ function extrachill_analytics_revenue_classify_route_family( $url ) {
  * resolution (post lookup, publish-status gate, term lookup) and hands the
  * resulting records here.
  *
- * CONTRACT (issue #130):
- *   - `totals` and `rollups` contain RESOLVED PUBLISHED CONTENT ONLY. Unresolved
- *     routes never inflate content pages/views/revenue or leak into category/
- *     format buckets. This keeps published-content RPM honest ($23.37, not the
- *     contaminated $13.98 the combined rollup reported).
+ * CONTRACT (issues #130 and #159):
+ *   - `totals` and `rollups` contain eligible main-site editorial posts only.
+ *     Resolved non-editorial sites/types remain visible under `non_editorial`.
+ *   - Unresolved routes never inflate content pages/views/revenue or leak into
+ *     category/format buckets. This keeps published-content RPM honest.
  *   - `unresolved` is an explicit diagnostic cohort — same metrics, plus a
  *     `by_route_family` breakdown — so non-content routes (/, /page/2/,
  *     /location/..., app routes, legacy .html ghosts) stay visible without being
@@ -410,21 +421,29 @@ function extrachill_analytics_revenue_classify_route_family( $url ) {
  * @param array  $records  Pre-classified revenue records.
  * @param string $group_by 'format', 'category', 'both', or 'timeseries'.
  * @return array {
- *     @type array $rollups    by_format and/or by_category (content only).
- *     @type array $totals     Content-only pages/views/revenue/rpm/dollars_per_page.
- *     @type array $unresolved Diagnostic cohort + by_route_family breakdown.
+ *     @type array $rollups       by_format and/or by_category (editorial only).
+ *     @type array $totals        Editorial-only pages/views/revenue/rpm/dollars_per_page.
+ *     @type array $non_editorial Resolved non-editorial cohort + content types.
+ *     @type array $unresolved    Diagnostic cohort + by_route_family breakdown.
  * }
  */
 function extrachill_analytics_revenue_build_rollups( array $records, $group_by ) {
 	$by_format   = array();
 	$by_category = array();
 
-	$content_pages            = 0;
-	$content_views            = 0;
-	$content_revenue          = 0.0;
-	$seen_content             = array();
-	$content_policy_statuses  = array();
-	$content_policy_conflicts = 0;
+	$content_pages                  = 0;
+	$content_views                  = 0;
+	$content_revenue                = 0.0;
+	$seen_content                   = array();
+	$content_policy_statuses        = array();
+	$content_policy_conflicts       = 0;
+	$non_editorial_pages            = 0;
+	$non_editorial_views            = 0;
+	$non_editorial_revenue          = 0.0;
+	$seen_non_editorial             = array();
+	$non_editorial_types            = array();
+	$non_editorial_policy_statuses  = array();
+	$non_editorial_policy_conflicts = 0;
 
 	$unresolved_pages            = 0;
 	$unresolved_views            = 0;
@@ -475,6 +494,23 @@ function extrachill_analytics_revenue_build_rollups( array $records, $group_by )
 			$unresolved_family[ $family ]['policy_statuses'][ $policy_status ] = isset( $unresolved_family[ $family ]['policy_statuses'][ $policy_status ] ) ? $unresolved_family[ $family ]['policy_statuses'][ $policy_status ] + 1 : 1;
 			if ( $policy_conflict ) {
 				++$unresolved_family[ $family ]['policy_conflicts'];
+			}
+			continue;
+		}
+
+		if ( isset( $rec['format_eligible'] ) && ! $rec['format_eligible'] ) {
+			$count_page                 = '' !== $key && empty( $seen_non_editorial[ $key ] );
+			$seen_non_editorial[ $key ] = true;
+			$type                       = 'blog-' . (int) ( isset( $rec['content_blog_id'] ) ? $rec['content_blog_id'] : 0 ) . ':' . ( isset( $rec['post_type'] ) && '' !== $rec['post_type'] ? (string) $rec['post_type'] : 'unknown' );
+			extrachill_analytics_revenue_accumulate( $non_editorial_types, $type, $views, $revenue, $count_page, $policy_status, $policy_conflict );
+			$non_editorial_views                            += $views;
+			$non_editorial_revenue                          += $revenue;
+			$non_editorial_policy_statuses[ $policy_status ] = isset( $non_editorial_policy_statuses[ $policy_status ] ) ? $non_editorial_policy_statuses[ $policy_status ] + 1 : 1;
+			if ( $policy_conflict ) {
+				++$non_editorial_policy_conflicts;
+			}
+			if ( $count_page ) {
+				++$non_editorial_pages;
 			}
 			continue;
 		}
@@ -535,8 +571,8 @@ function extrachill_analytics_revenue_build_rollups( array $records, $group_by )
 	);
 
 	return array(
-		'rollups'    => $rollups,
-		'totals'     => array(
+		'rollups'       => $rollups,
+		'totals'        => array(
 			'pages'            => $content_pages,
 			'views'            => $content_views,
 			'revenue'          => round( $content_revenue, 2 ),
@@ -545,7 +581,7 @@ function extrachill_analytics_revenue_build_rollups( array $records, $group_by )
 			'revenue_status'   => extrachill_analytics_revenue_aggregate_policy_status( $content_policy_statuses ),
 			'policy_conflicts' => $content_policy_conflicts,
 		),
-		'unresolved' => array(
+		'unresolved'    => array(
 			'pages'            => $unresolved_pages,
 			'views'            => $unresolved_views,
 			'revenue'          => round( $unresolved_revenue, 2 ),
@@ -553,6 +589,15 @@ function extrachill_analytics_revenue_build_rollups( array $records, $group_by )
 			'revenue_status'   => extrachill_analytics_revenue_aggregate_policy_status( $unresolved_policy_statuses ),
 			'policy_conflicts' => $unresolved_policy_conflicts,
 			'by_route_family'  => $family_rows,
+		),
+		'non_editorial' => array(
+			'pages'            => $non_editorial_pages,
+			'views'            => $non_editorial_views,
+			'revenue'          => round( $non_editorial_revenue, 2 ),
+			'rpm'              => $non_editorial_views > 0 ? round( $non_editorial_revenue / ( $non_editorial_views / 1000 ), 2 ) : 0.0,
+			'revenue_status'   => extrachill_analytics_revenue_aggregate_policy_status( $non_editorial_policy_statuses ),
+			'policy_conflicts' => $non_editorial_policy_conflicts,
+			'by_content_type'  => extrachill_analytics_revenue_finalize( $non_editorial_types ),
 		),
 	);
 }

--- a/inc/core/content-format-classifier.php
+++ b/inc/core/content-format-classifier.php
@@ -55,7 +55,7 @@ function extrachill_analytics_format_category_map() {
 		// Explainers / how-tos / guides.
 		'explainer'        => array( 'explainers', 'explainer', 'guides', 'how-to', 'how-tos', 'music-theory', 'education' ),
 		// News / festival-wire reactive coverage.
-		'news'             => array( 'news', 'festival-wire', 'festivals', 'live-music', 'shows', 'concerts', 'reviews' ),
+		'news'             => array( 'news', 'music-news', 'premieres', 'festival-wire', 'festivals', 'live-music', 'live-music-reviews', 'shows', 'concerts', 'reviews' ),
 	);
 
 	/**
@@ -64,6 +64,21 @@ function extrachill_analytics_format_category_map() {
 	 * @param array $map Format => list of category slugs (precedence top-down).
 	 */
 	return apply_filters( 'extrachill_analytics_format_category_map', $map );
+}
+
+/**
+ * Determine whether resolved content belongs in editorial-format comparisons.
+ *
+ * Extra Chill's editorial taxonomy belongs to posts on the network main site.
+ * Other sites and post types remain resolved content, but are not comparable
+ * editorial formats and must be reported separately.
+ *
+ * @param int    $blog_id   Owning blog ID.
+ * @param string $post_type Owning post type.
+ * @return bool
+ */
+function extrachill_analytics_is_editorial_format_eligible( $blog_id, $post_type ) {
+	return 1 === (int) $blog_id && 'post' === (string) $post_type;
 }
 
 /**

--- a/tests/ContentFormatClassifierTest.php
+++ b/tests/ContentFormatClassifierTest.php
@@ -8,6 +8,7 @@
 use PHPUnit\Framework\TestCase;
 
 require_once dirname( __DIR__ ) . '/inc/core/content-format-classifier.php';
+require_once dirname( __DIR__ ) . '/inc/core/revenue-ad-policy.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-content-revenue.php';
 
 /**
@@ -52,6 +53,42 @@ final class ContentFormatClassifierTest extends TestCase {
 
 		$this->assertSame( 'guitar-history', extrachill_analytics_classify_format( 145 ) );
 		$this->assertSame( 'music-history', extrachill_analytics_classify_format( 146 ) );
+	}
+
+	/**
+	 * Every stable editorial taxonomy family resolves to its intended format.
+	 */
+	public function test_stable_editorial_taxonomy_families(): void {
+		$fixtures = array(
+			'song-meanings'      => 'song-meaning',
+			'famous-guitars'     => 'guitar-history',
+			'music-history'      => 'music-history',
+			'charleston-music'   => 'charleston-local',
+			'interviews'         => 'interview',
+			'trivia'             => 'trivia',
+			'lists'              => 'listicle',
+			'music-theory'       => 'explainer',
+			'music-news'         => 'news',
+			'premieres'          => 'news',
+			'live-music-reviews' => 'news',
+		);
+		$id       = 200;
+
+		foreach ( $fixtures as $category => $expected ) {
+			$this->fixture_post( $id, array( $category ) );
+			$this->assertSame( $expected, extrachill_analytics_classify_format( $id ), $category );
+			++$id;
+		}
+	}
+
+	/**
+	 * Editorial eligibility follows owning site and post type, never URL shape.
+	 */
+	public function test_editorial_format_eligibility_is_explicit(): void {
+		$this->assertTrue( extrachill_analytics_is_editorial_format_eligible( 1, 'post' ) );
+		$this->assertFalse( extrachill_analytics_is_editorial_format_eligible( 1, 'page' ) );
+		$this->assertFalse( extrachill_analytics_is_editorial_format_eligible( 7, 'data_machine_events' ) );
+		$this->assertFalse( extrachill_analytics_is_editorial_format_eligible( 11, 'festival_wire' ) );
 	}
 
 	/**

--- a/tests/GetContentRevenueDiagnosticsTest.php
+++ b/tests/GetContentRevenueDiagnosticsTest.php
@@ -679,7 +679,67 @@ final class GetContentRevenueDiagnosticsTest extends TestCase {
 		$this->assertSame( 'warning', $fmt['status'] );
 		// 5 distinct resolved pages (the post-3 variant collapsed), 3 uncategorized.
 		$this->assertSame( 5, $fmt['totals']['resolved_pages'] );
+		$this->assertSame( 5, $fmt['totals']['eligible_editorial_pages'] );
 		$this->assertSame( 3, $fmt['totals']['uncategorized_pages'] );
+	}
+
+	/**
+	 * Format coverage excludes resolved non-editorial entities from its denominator.
+	 */
+	public function test_format_coverage_reports_non_editorial_content_separately(): void {
+		$rows = array(
+			$this->row(
+				array(
+					'content_blog_id' => 1,
+					'post_id'         => 10,
+					'format'          => 'news',
+					'post_type'       => 'post',
+					'format_eligible' => true,
+				)
+			),
+			$this->row(
+				array(
+					'content_blog_id' => 1,
+					'post_id'         => 11,
+					'format'          => 'uncategorized',
+					'post_type'       => 'post',
+					'format_eligible' => true,
+				)
+			),
+			$this->row(
+				array(
+					'content_blog_id' => 7,
+					'post_id'         => 12,
+					'format'          => 'uncategorized',
+					'post_type'       => 'data_machine_events',
+					'format_eligible' => false,
+				)
+			),
+			$this->row(
+				array(
+					'content_blog_id' => 11,
+					'post_id'         => 13,
+					'format'          => 'uncategorized',
+					'post_type'       => 'festival_wire',
+					'format_eligible' => false,
+				)
+			),
+		);
+
+		$fmt = extrachill_analytics_revenue_diag_format_coverage( $rows );
+
+		$this->assertSame( 4, $fmt['totals']['resolved_pages'] );
+		$this->assertSame( 2, $fmt['totals']['eligible_editorial_pages'] );
+		$this->assertSame( 2, $fmt['totals']['non_editorial_pages'] );
+		$this->assertSame( 1, $fmt['totals']['uncategorized_pages'] );
+		$this->assertSame( 0.5, $fmt['totals']['uncategorized_ratio'] );
+		$this->assertSame(
+			array(
+				'blog-7:data_machine_events' => 1,
+				'blog-11:festival_wire'      => 1,
+			),
+			$fmt['totals']['by_non_editorial']
+		);
 	}
 
 	/**

--- a/tests/GetContentRevenueRollupTest.php
+++ b/tests/GetContentRevenueRollupTest.php
@@ -175,6 +175,62 @@ final class GetContentRevenueRollupTest extends TestCase {
 	}
 
 	/**
+	 * Resolved cross-site entities stay visible without contaminating editorial peers.
+	 */
+	public function test_non_editorial_content_is_excluded_from_editorial_rollups(): void {
+		$records = array(
+			array(
+				'is_content'      => true,
+				'format_eligible' => true,
+				'page_key'        => 'p1:10',
+				'content_blog_id' => 1,
+				'post_type'       => 'post',
+				'format'          => 'news',
+				'categories'      => array( 'music-news' ),
+				'views'           => 1000,
+				'revenue'         => 20.0,
+			),
+			array(
+				'is_content'      => true,
+				'format_eligible' => false,
+				'page_key'        => 'p7:10',
+				'content_blog_id' => 7,
+				'post_type'       => 'data_machine_events',
+				'format'          => 'uncategorized',
+				'categories'      => array( 'uncategorized' ),
+				'views'           => 5000,
+				'revenue'         => 5.0,
+			),
+			array(
+				'is_content'      => true,
+				'format_eligible' => false,
+				'page_key'        => 'p11:10',
+				'content_blog_id' => 11,
+				'post_type'       => 'festival_wire',
+				'format'          => 'listicle',
+				'categories'      => array( 'uncategorized' ),
+				'views'           => 2000,
+				'revenue'         => 25.0,
+			),
+		);
+
+		$result = extrachill_analytics_revenue_build_rollups( $records, 'both' );
+
+		$this->assertSame( 1, $result['totals']['pages'] );
+		$this->assertSame( 1000, $result['totals']['views'] );
+		$this->assertSame( 20.0, $result['totals']['revenue'] );
+		$this->assertSame( array( 'news' ), $this->pluck( $result['rollups']['by_format'], 'bucket' ) );
+		$this->assertSame( array( 'music-news' ), $this->pluck( $result['rollups']['by_category'], 'bucket' ) );
+		$this->assertSame( 2, $result['non_editorial']['pages'] );
+		$this->assertSame( 7000, $result['non_editorial']['views'] );
+		$this->assertSame( 30.0, $result['non_editorial']['revenue'] );
+		$this->assertEqualsCanonicalizing(
+			array( 'blog-7:data_machine_events', 'blog-11:festival_wire' ),
+			$this->pluck( $result['non_editorial']['by_content_type'], 'bucket' )
+		);
+	}
+
+	/**
 	 * Duplicate URL variants of the same post/page count once for pages while
 	 * revenue and views still sum (the existing de-dupe contract, preserved).
 	 */
@@ -350,8 +406,8 @@ final class GetContentRevenueRollupTest extends TestCase {
 		// A row is content only when its post is currently published.
 		$this->assertStringContainsString( "'publish' === get_post_status( \$post_id )", $source );
 		// Unresolved routes are marked is_content => false and excluded.
-		$this->assertStringContainsString( "'is_content' => false", $source );
-		$this->assertStringContainsString( "'is_content' => true", $source );
+		$this->assertMatchesRegularExpression( "/'is_content'\s*=>\s*false/", $source );
+		$this->assertMatchesRegularExpression( "/'is_content'\s*=>\s*true/", $source );
 		// The response exposes an explicit unresolved cohort.
 		$this->assertStringContainsString( "'unresolved'", $source );
 		$this->assertStringContainsString( "'by_route_family'", $source );


### PR DESCRIPTION
## Summary
- scope format coverage and category/format revenue rollups to main-site editorial `post` content
- report resolved non-editorial content separately by authoritative owning blog and post type, without URL/hostname guesses or source-revenue changes
- map the established `music-news`, `premieres`, and `live-music-reviews` taxonomy families to the existing `news` format

## Inventory Findings
Trailing-year fixture: `2025-07-01` through `2026-06-30`.

| Owning content | Category / type | Pages | Views | Revenue |
| --- | --- | ---: | ---: | ---: |
| Events (blog 7) | `data_machine_events` | 846 | 4,870 | $25.93 |
| Wire (blog 11) | `festival_wire` | 732 | 20,368 | $257.93 |
| Community (blog 2) | topics/forums/replies/pages | 64 | 7,357 | $0.40 |
| Artist (blog 4) | artist profiles/pages | 10 | 230 | $0.00 |
| Newsletter (blog 9) | `newsletter` | 3 | 61 | $0.00 |
| Docs (blog 10) | `ec_doc` | 1 | 9 | $0.00 |
| Shop (blog 3) | page | 1 | 5 | $0.00 |
| Main non-post entities | pages/attachments | 11 | 1,539 | $0.35 |
| Main editorial posts | `music-news` | 101 | 372 | $4.80 |
| Main editorial posts | `premieres` | 15 | 186 | $2.31 |
| Main editorial posts | other stable/unmapped categories | 160 | 12,145 | $211.86 |

The original 1,947-page uncategorized cohort consisted of 1,686 non-editorial records plus 276 main-site editorial posts. The category rollup's 1,686-page / 36,414-view / $306.40 `uncategorized` bucket was exactly the resolved non-editorial cohort, not missing editorial taxonomy.

## Coverage
- reported baseline: 1,947 / 2,534 resolved pages uncategorized (76.8%)
- corrected editorial baseline before new mappings: 276 / 848 eligible editorial posts (32.6%)
- after stable mappings: 160 / 848 eligible editorial posts (18.9%)
- retained separately: 1,686 resolved non-editorial pages, 36,414 views, $306.40 revenue
- unresolved routes remain unchanged in their existing cohort

## Excluded Content Classes
- Events records and site pages
- Wire `festival_wire` records
- Community topics, forums, replies, and pages
- Artist profiles and pages
- Newsletter, Docs, and Shop entities
- main-site pages and attachments

These records remain resolved and fully reported under `non_editorial.by_content_type`; they are only excluded from editorial category/format peers. True unmapped main-site editorial posts retain the explicit `uncategorized` format fallback.

## Rollup And Compatibility
- no schema migration or persisted-attribution rewrite
- no imported views or revenue are altered
- `totals` and category/format rollups now explicitly represent eligible editorial posts
- resolved non-editorial metrics move to the additive `non_editorial` cohort with ad-policy status and conflict reporting preserved
- unresolved-route behavior and time-series behavior are unchanged

## Tests
- `vendor/bin/phpunit`: **210 tests, 765 assertions, passing**
- changed-file `vendor/bin/phpcs --standard=WordPress ...`: **0 errors, 0 warnings**
- `git diff --check`: **passing**

Closes #159