### PR TITLE
fix: resolve analytics visitors from request cookies

### DIFF
--- a/assets/js/outbound-tracking.js
+++ b/assets/js/outbound-tracking.js
@@ -31,10 +31,6 @@
 			dest_host: destHost,
 		};
 
-		if ( config.visitorId ) {
-			payload.visitor_id = config.visitorId;
-		}
-
 		var data = JSON.stringify( payload );
 
 		if ( navigator.sendBeacon ) {

--- a/assets/js/view-tracking.js
+++ b/assets/js/view-tracking.js
@@ -6,13 +6,6 @@
 
 	var payload = { post_id: config.postId };
 
-	// Echo the server-minted first-party visitor id when present. Empty/absent
-	// when the visitor opted out via GPC/DNT — the pageview is still recorded,
-	// just without an id.
-	if ( config.visitorId ) {
-		payload.visitor_id = config.visitorId;
-	}
-
 	// Capture the TRUE referrer client-side. This beacon fires after page load,
 	// so the request's own HTTP Referer header is this article page itself —
 	// document.referrer is the only place the page the reader navigated FROM is

--- a/inc/core/abilities/track-page-view.php
+++ b/inc/core/abilities/track-page-view.php
@@ -29,11 +29,6 @@ function extrachill_analytics_register_track_page_view_ability(): void {
 						'type'        => 'integer',
 						'description' => __( 'The post ID to record a view for.', 'extrachill-analytics' ),
 					),
-					'visitor_id' => array(
-						'type'        => 'string',
-						'description' => __( 'Optional anonymous first-party visitor UUID v4. Stored on the pageview event only if well-formed; never PII. Empty when the visitor opted out (GPC/DNT).', 'extrachill-analytics' ),
-						'default'     => '',
-					),
 					'referrer'   => array(
 						'type'        => 'string',
 						'description' => __( 'Optional raw client-side referrer (document.referrer). Normalized server-side to a host-only `referrer_host` (no query strings, no PII) on the pageview event. Empty for direct traffic.', 'extrachill-analytics' ),
@@ -76,7 +71,6 @@ function extrachill_analytics_register_track_page_view_ability(): void {
  */
 function extrachill_analytics_ability_track_page_view( array $input ) {
 	$post_id    = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
-	$visitor_id = isset( $input['visitor_id'] ) ? (string) $input['visitor_id'] : '';
 	$referrer   = isset( $input['referrer'] ) ? (string) $input['referrer'] : '';
 
 	if ( $post_id <= 0 ) {
@@ -93,6 +87,31 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 			__( 'View tracking function not available.', 'extrachill-analytics' ),
 			array( 'status' => 500 )
 		);
+	}
+
+	// Resolve identity from this request's first-party cookie, never from the
+	// request body. A render-time UUID would be persisted in anonymous full-page
+	// cache HTML and replayed by every visitor receiving that cache entry. The
+	// REST response can safely mint the HttpOnly cookie for a first cached visit
+	// because response headers have not been sent yet. GPC/DNT returns an empty
+	// value and keeps the pageview anonymous.
+	$visitor_id = '';
+	$is_first_party_beacon = function_exists( 'extrachill_analytics_beacon_is_first_party' )
+		&& extrachill_analytics_beacon_is_first_party();
+
+	// Do not stitch a custom-domain request even if a browser permits its
+	// third-party cookie. Cross-site beacons have no durable first-party
+	// identity guarantee and intentionally remain anonymous.
+	if ( $is_first_party_beacon && function_exists( 'extrachill_analytics_read_visitor_id' ) ) {
+		$visitor_id = extrachill_analytics_read_visitor_id();
+	}
+
+	if (
+		$is_first_party_beacon
+		&& '' === $visitor_id
+		&& function_exists( 'extrachill_analytics_get_or_mint_visitor_id' )
+	) {
+		$visitor_id = extrachill_analytics_get_or_mint_visitor_id();
 	}
 
 	// All-time view increment (post meta) — retained for theme back-compat.

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -132,6 +132,42 @@ function extrachill_analytics_read_visitor_id() {
 }
 
 /**
+ * Check whether a browser beacon originated on the cookie's first-party site.
+ *
+ * Custom-domain link pages can beacon to an Extra Chill subdomain, but browsers
+ * may reject that response's cookie as third-party. Such requests must remain
+ * anonymous instead of minting a new, non-persistent UUID on every pageview.
+ *
+ * @return bool True when the request origin belongs to the cookie domain.
+ */
+function extrachill_analytics_beacon_is_first_party() {
+	$source = '';
+
+	if ( isset( $_SERVER['HTTP_ORIGIN'] ) ) {
+		$source = sanitize_text_field( wp_unslash( $_SERVER['HTTP_ORIGIN'] ) );
+	} elseif ( isset( $_SERVER['HTTP_REFERER'] ) ) {
+		$source = sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) );
+	}
+
+	$source_host   = wp_parse_url( $source, PHP_URL_HOST );
+	$cookie_domain = ltrim( extrachill_analytics_visitor_cookie_domain(), '.' );
+	if ( '' === $cookie_domain ) {
+		$cookie_domain = wp_parse_url( home_url( '/' ), PHP_URL_HOST );
+	}
+
+	if ( ! is_string( $source_host ) || '' === $source_host || ! is_string( $cookie_domain ) || '' === $cookie_domain ) {
+		return false;
+	}
+
+	$source_host   = strtolower( rtrim( $source_host, '.' ) );
+	$cookie_domain = strtolower( rtrim( $cookie_domain, '.' ) );
+	$suffix        = '.' . $cookie_domain;
+
+	return $source_host === $cookie_domain
+		|| ( strlen( $source_host ) > strlen( $suffix ) && $suffix === substr( $source_host, -strlen( $suffix ) ) );
+}
+
+/**
  * Read the existing first-party visitor id, or mint a new one server-side.
  *
  * The cookie value is a random UUID v4 only — never an IP, email, or
@@ -143,9 +179,9 @@ function extrachill_analytics_read_visitor_id() {
  * an empty string and set no cookie.
  *
  * Must be called before output starts (headers not yet sent) so setcookie()
- * works — the deferred beacon cannot reliably set a cookie itself. The result
- * is memoized per-request so callers after output has started (e.g. the
- * footer enqueue) read the already-resolved id without re-minting.
+ * works. This is safe from both template_redirect and the pageview REST beacon,
+ * whose response headers have not been sent yet. The result is memoized per
+ * request so later callers read the already-resolved id without re-minting.
  *
  * @return string The visitor UUID, or empty string if opted out / cannot mint.
  */
@@ -297,11 +333,6 @@ function extrachill_analytics_enqueue_view_tracking() {
 		return;
 	}
 
-	// Read the visitor id already resolved on template_redirect (before output
-	// started, so its cookie was actually set). Empty string when the visitor
-	// opted out (GPC/DNT). Memoization guarantees no re-mint here.
-	$visitor_id = extrachill_analytics_get_or_mint_visitor_id();
-
 	wp_enqueue_script(
 		'extrachill-view-tracking',
 		EXTRACHILL_ANALYTICS_PLUGIN_URL . 'assets/js/view-tracking.js',
@@ -317,9 +348,8 @@ function extrachill_analytics_enqueue_view_tracking() {
 		'extrachill-view-tracking',
 		'ecViewTracking',
 		array(
-			'postId'    => get_the_ID(),
-			'endpoint'  => rest_url( 'extrachill/v1/analytics/view' ),
-			'visitorId' => $visitor_id,
+			'postId'   => get_the_ID(),
+			'endpoint' => rest_url( 'extrachill/v1/analytics/view' ),
 		)
 	);
 }
@@ -336,10 +366,8 @@ add_action( 'wp_enqueue_scripts', 'extrachill_analytics_enqueue_view_tracking' )
  *
  * Because the beacon fires only from a real, JS-executing browser, the data is
  * bot-filtered by construction — the same guarantee the bridge_click /
- * pageview beacons rely on. The visitor_id echoed here is the already-resolved
- * `ec_vid` (present on singular pages where it was minted; empty on other
- * surfaces or under GPC/DNT opt-out — in which case the click is still recorded
- * anonymously with a NULL visitor_id, exactly like the rest of the system).
+ * pageview beacons rely on. Visitor identity is omitted from cacheable HTML and
+ * resolved by the browser-facing write adapter when a stable cookie exists.
  *
  * The network-host list is the canonical multisite map so an INTERNAL hop
  * (extrachill.com → community.extrachill.com, already covered by the conversion
@@ -354,13 +382,6 @@ function extrachill_analytics_enqueue_outbound_tracking() {
 	if ( ! file_exists( $js_path ) ) {
 		return;
 	}
-
-	// Read-only: never mint here (this runs on non-singular pages too, after
-	// output may have started). Empty when no cookie / opted out — the click is
-	// then recorded anonymously, consistent with the rest of the system.
-	$visitor_id = function_exists( 'extrachill_analytics_read_visitor_id' )
-		? extrachill_analytics_read_visitor_id()
-		: '';
 
 	// Canonical Extra Chill network hosts — a click to any of these is an
 	// internal hop, not an outbound exit. Falls back to the current site host
@@ -391,7 +412,6 @@ function extrachill_analytics_enqueue_outbound_tracking() {
 		'ecOutboundTracking',
 		array(
 			'endpoint'     => rest_url( 'extrachill/v1/analytics/click' ),
-			'visitorId'    => $visitor_id,
 			'networkHosts' => $network_hosts,
 		)
 	);

--- a/tests/VisitorIdentityCacheSafetyTest.php
+++ b/tests/VisitorIdentityCacheSafetyTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Tests for cache-safe browser analytics identity.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Prevent visitor-specific UUIDs from returning to cacheable page markup.
+ */
+final class VisitorIdentityCacheSafetyTest extends TestCase {
+	/**
+	 * Load the visitor identity helpers under the lightweight test bootstrap.
+	 */
+	public static function setUpBeforeClass(): void {
+		require_once dirname( __DIR__ ) . '/inc/core/assets.php';
+	}
+
+	/**
+	 * Restore request globals after each origin fixture.
+	 */
+	protected function tearDown(): void {
+		unset( $_SERVER['HTTP_ORIGIN'], $_SERVER['HTTP_REFERER'] );
+	}
+
+	/**
+	 * Frontend configuration must contain no render-time visitor UUID.
+	 */
+	public function test_frontend_assets_do_not_localize_visitor_identity(): void {
+		$assets   = $this->read_source( 'inc/core/assets.php' );
+		$pageview = $this->read_source( 'assets/js/view-tracking.js' );
+		$outbound = $this->read_source( 'assets/js/outbound-tracking.js' );
+
+		$this->assertStringNotContainsString( "'visitorId'", $assets );
+		$this->assertStringNotContainsString( 'config.visitorId', $pageview );
+		$this->assertStringNotContainsString( 'config.visitorId', $outbound );
+		$this->assertStringNotContainsString( 'payload.visitor_id', $pageview );
+		$this->assertStringNotContainsString( 'payload.visitor_id', $outbound );
+	}
+
+	/**
+	 * Browser beacon abilities must resolve identity from the request cookie.
+	 */
+	public function test_browser_beacons_resolve_request_identity(): void {
+		$pageview = $this->read_source( 'inc/core/abilities/track-page-view.php' );
+		$events   = $this->read_source( 'inc/core/abilities.php' );
+
+		$this->assertStringContainsString(
+			'extrachill_analytics_get_or_mint_visitor_id()',
+			$pageview
+		);
+		$this->assertStringNotContainsString( "\$input['visitor_id']", $pageview );
+		$this->assertStringNotContainsString( "'outbound_click' === \$event_type", $events );
+		$this->assertStringContainsString(
+			'$is_first_party_beacon && function_exists( \'extrachill_analytics_read_visitor_id\' )',
+			$pageview
+		);
+		$this->assertStringContainsString(
+			"wp_parse_url( home_url( '/' ), PHP_URL_HOST )",
+			$this->read_source( 'inc/core/assets.php' )
+		);
+	}
+
+	/**
+	 * Identity is limited to the cookie's first-party site, not a custom domain.
+	 */
+	public function test_beacon_origin_must_match_the_first_party_cookie_domain(): void {
+		$_SERVER['HTTP_ORIGIN'] = 'https://events.extrachill.com';
+		$this->assertTrue( extrachill_analytics_beacon_is_first_party() );
+
+		$_SERVER['HTTP_ORIGIN'] = 'https://artist.example';
+		$this->assertFalse( extrachill_analytics_beacon_is_first_party() );
+	}
+
+	/**
+	 * Read a production source file.
+	 *
+	 * @param string $relative_path Repository-relative path.
+	 * @return string
+	 */
+	private function read_source( $relative_path ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local source fixtures.
+		$source = file_get_contents( dirname( __DIR__ ) . '/' . $relative_path );
+
+		$this->assertNotFalse( $source );
+
+		return $source;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -234,11 +234,12 @@ if ( ! function_exists( 'wp_parse_url' ) ) {
 	/**
 	 * Stub for wp_parse_url().
 	 *
-	 * @param string $url The URL to parse.
-	 * @return array<string,mixed> Parse components.
+	 * @param string   $url URL to parse.
+	 * @param int|null $component Optional PHP_URL_* component.
+	 * @return array<string,mixed>|string|int|null|false Parse result.
 	 */
-	function wp_parse_url( $url ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
-		return parse_url( (string) $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+	function wp_parse_url( $url, $component = -1 ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+		return parse_url( (string) $url, $component ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 	}
 }
 if ( ! function_exists( 'url_to_postid' ) ) {


### PR DESCRIPTION
## Summary
- Removes render-time visitor UUIDs from pageview and outbound tracking configurations, preventing anonymous full-page cache entries from replaying the cache-populator's identity to unrelated readers.
- Resolves pageview identity solely from the receiving request's first-party `ec_vid` cookie. A first-party beacon with no cookie can mint one in its response; cross-site/custom-domain beacons remain anonymous even when a browser happens to send a third-party cookie.
- Keeps GPC/DNT requests anonymous while continuing to record aggregate pageview volume. Outbound identity remains the responsibility of the Extra Chill API adapter in Extra-Chill/extrachill-api#111 and #112; this generic analytics layer does not special-case routes, vendors, or event callers.

## Impact
Cacheable HTML previously embedded a valid UUID. The full-page cache could replay that UUID to every visitor receiving one cached page, collapsing distinct readers into one identity; a single reader could also acquire different identities across cached pages. This corrupts retention, cohort, cross-site return, and conversion/sessionization reporting.

## Verification
- `php -l inc/core/assets.php && php -l inc/core/abilities/track-page-view.php && php -l tests/VisitorIdentityCacheSafetyTest.php && php -l tests/bootstrap.php`
- `node --check assets/js/view-tracking.js && node --check assets/js/outbound-tracking.js`
- Focused PHP check for first-party subdomain acceptance, custom-domain rejection, and GPC cookie suppression
- `git diff --check`
- `composer test`, `composer lint:php`, and `npm run lint:js` could not run because `vendor/bin/phpunit`, `vendor/bin/phpcs`, and `wp-scripts` are not installed in this worktree.
- `homeboy review extrachill-analytics test` was safely declined because this host is overloaded and no eligible Lab runner is configured.

Closes #165