### PR TITLE
fix: calculate mature exact-week retention cohorts

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -59,6 +59,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/track-page-vi
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-link-page-analytics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-bridge-ctr.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-outbound-clicks.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/retention-cohorts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-retention-stats.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-growth.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-demand-drill.php';

--- a/inc/core/abilities/get-retention-stats.php
+++ b/inc/core/abilities/get-retention-stats.php
@@ -147,55 +147,72 @@ function extrachill_analytics_ability_get_retention_stats( $input ) {
 	$return_rate        = $total_visitors > 0 ? round( $returning_visitors / $total_visitors, 4 ) : 0.0;
 
 	// ---------------------------------------------------------------------
-	// (b) Cohort retention: of visitors first-seen in week N, what % return in
-	// a later week (N+1, N+2, ...). "Week" is the ISO week of the visitor's
-	// first-ever pageview within the window. We compute, per cohort, the
-	// share still active 1 and 2 weeks later.
+	// (b) Cohort retention: acquisition is the first observed pageview in the
+	// available history (within the requested blog scope). W1 and W2 are the
+	// first and second complete ISO weeks after that acquisition week.
 	// ---------------------------------------------------------------------
 	$cohort_since = gmdate( 'Y-m-d H:i:s', strtotime( "-{$cohort_weeks} weeks" ) );
 
-	$cohort_where  = array( 'event_type = %s', "visitor_id IS NOT NULL AND visitor_id != ''", 'created_at >= %s' );
-	$cohort_values = array( $event_type, $cohort_since );
+	$cohort_where  = array( 'event_type = %s', "visitor_id IS NOT NULL AND visitor_id != ''", 'created_at < %s' );
+	$cohort_values = array( $event_type, $now_utc );
 	if ( $blog_id > 0 ) {
 		$cohort_where[]  = 'blog_id = %d';
 		$cohort_values[] = $blog_id;
 	}
 	$cohort_where_clause = implode( ' AND ', $cohort_where );
 
-	// Per visitor: their first-seen week, and the full set of weeks they were active.
+	// The first derived table reads all available pageview history to establish
+	// acquisition before restricting the requested cohort range. The activity
+	// join is bounded to W1/W2 and uses the existing (visitor_id, created_at)
+	// index for each acquired visitor.
 	$cohort_sql = "SELECT
-			first_week,
+			cohort_week_start,
 			COUNT(*) AS cohort_size,
-			SUM(CASE WHEN max_week >= first_week + 1 THEN 1 ELSE 0 END) AS returned_w1,
-			SUM(CASE WHEN max_week >= first_week + 2 THEN 1 ELSE 0 END) AS returned_w2
+			SUM(active_w1) AS returned_w1,
+			SUM(active_w2) AS returned_w2
 		FROM (
 			SELECT
-				visitor_id,
-				MIN(YEARWEEK(created_at, 3)) AS first_week,
-				MAX(YEARWEEK(created_at, 3)) AS max_week
-			FROM {$table}
-			WHERE {$cohort_where_clause}
-			GROUP BY visitor_id
-		) AS v
-		GROUP BY first_week
-		ORDER BY first_week ASC";
+				acquisition.visitor_id,
+				acquisition.cohort_week_start,
+				MAX(CASE WHEN activity.created_at >= DATE_ADD(acquisition.cohort_week_start, INTERVAL 7 DAY) AND activity.created_at < DATE_ADD(acquisition.cohort_week_start, INTERVAL 14 DAY) THEN 1 ELSE 0 END) AS active_w1,
+				MAX(CASE WHEN activity.created_at >= DATE_ADD(acquisition.cohort_week_start, INTERVAL 14 DAY) AND activity.created_at < DATE_ADD(acquisition.cohort_week_start, INTERVAL 21 DAY) THEN 1 ELSE 0 END) AS active_w2
+			FROM (
+				SELECT
+					visitor_id,
+					DATE_SUB( DATE( MIN(created_at) ), INTERVAL WEEKDAY( MIN(created_at) ) DAY ) AS cohort_week_start
+				FROM {$table}
+				WHERE {$cohort_where_clause}
+				GROUP BY visitor_id
+				HAVING MIN(created_at) >= %s
+			) AS acquisition
+			LEFT JOIN {$table} AS activity
+				ON activity.visitor_id = acquisition.visitor_id
+				AND activity.event_type = %s
+				AND activity.visitor_id IS NOT NULL
+				AND activity.created_at < %s
+				AND activity.created_at >= DATE_ADD(acquisition.cohort_week_start, INTERVAL 7 DAY)
+				AND activity.created_at < DATE_ADD(acquisition.cohort_week_start, INTERVAL 21 DAY)";
+
+	if ( $blog_id > 0 ) {
+		$cohort_sql .= ' AND activity.blog_id = %d';
+	}
+
+	$cohort_sql .= '
+			GROUP BY acquisition.visitor_id, acquisition.cohort_week_start
+		) AS per_visitor
+		GROUP BY cohort_week_start
+		ORDER BY cohort_week_start ASC';
+
+	$cohort_query_values = array_merge( $cohort_values, array( $cohort_since, $event_type, $now_utc ) );
+	if ( $blog_id > 0 ) {
+		$cohort_query_values[] = $blog_id;
+	}
 
 	// phpcs:disable WordPress.DB.PreparedSQL -- $cohort_sql interpolates only a code-defined table name and a placeholder where_clause bound via prepare().
-	$cohort_rows = $wpdb->get_results( $wpdb->prepare( $cohort_sql, $cohort_values ) );
+	$cohort_rows = $wpdb->get_results( $wpdb->prepare( $cohort_sql, $cohort_query_values ) );
 	// phpcs:enable WordPress.DB.PreparedSQL
 
-	$cohort_retention = array();
-	foreach ( (array) $cohort_rows as $row ) {
-		$size               = (int) $row->cohort_size;
-		$cohort_retention[] = array(
-			'cohort_week'  => (string) $row->first_week,
-			'cohort_size'  => $size,
-			'returned_w1'  => (int) $row->returned_w1,
-			'returned_w2'  => (int) $row->returned_w2,
-			'retention_w1' => $size > 0 ? round( (int) $row->returned_w1 / $size, 4 ) : 0.0,
-			'retention_w2' => $size > 0 ? round( (int) $row->returned_w2 / $size, 4 ) : 0.0,
-		);
-	}
+	$cohort_retention = extrachill_analytics_build_cohort_retention( $cohort_rows, $now_utc );
 
 	// ---------------------------------------------------------------------
 	// (c) Cross-site return: visitors who hit >= 2 distinct blog_ids on
@@ -304,7 +321,7 @@ function extrachill_analytics_ability_get_retention_stats( $input ) {
 		'cohort_retention'  => array(
 			'cohorts'    => $cohort_retention,
 			'weeks'      => $cohort_weeks,
-			'definition' => 'Per weekly first-seen cohort (ISO YEARWEEK), share still active 1 and 2 weeks later.',
+			'definition' => 'Acquisition is each visitor\'s first observed pageview in the available event history, scoped by blog_id when set. W1 is activity during the first complete ISO week after acquisition; W2 is activity during the second. A horizon is reported only after its full week has elapsed; incomplete horizons are null and must not be treated as zero retention. This cohort history is distinct from the rolling-window return_rate metric.',
 		),
 		'cross_site_return' => array(
 			'total_visitors'      => $xsite_total,

--- a/inc/core/retention-cohorts.php
+++ b/inc/core/retention-cohorts.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Retention cohort response helpers.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Apply observation-horizon semantics to exact-week cohort aggregates.
+ *
+ * @param array<object> $rows Cohort query rows.
+ * @param string        $as_of UTC observation cutoff.
+ * @return array<int,array<string,int|float|string|bool|null>> Cohort response rows.
+ */
+function extrachill_analytics_build_cohort_retention( $rows, $as_of ) {
+	$cohorts = array();
+	$as_of   = strtotime( $as_of . ' UTC' );
+
+	foreach ( (array) $rows as $row ) {
+		$week_start  = (string) $row->cohort_week_start;
+		$week_time   = strtotime( $week_start . ' UTC' );
+		$size        = (int) $row->cohort_size;
+		$w1_mature   = false !== $week_time && $as_of >= $week_time + ( 14 * DAY_IN_SECONDS );
+		$w2_mature   = false !== $week_time && $as_of >= $week_time + ( 21 * DAY_IN_SECONDS );
+		$returned_w1 = (int) $row->returned_w1;
+		$returned_w2 = (int) $row->returned_w2;
+
+		$cohorts[] = array(
+			// cohort_week remains for consumers that previously used YEARWEEK labels.
+			'cohort_week'       => false !== $week_time ? gmdate( 'oW', $week_time ) : $week_start,
+			'cohort_week_start' => $week_start,
+			'cohort_size'       => $size,
+			'w1_mature'         => $w1_mature,
+			'w2_mature'         => $w2_mature,
+			'returned_w1'       => $w1_mature ? $returned_w1 : null,
+			'returned_w2'       => $w2_mature ? $returned_w2 : null,
+			'retention_w1'      => $w1_mature && $size > 0 ? round( $returned_w1 / $size, 4 ) : null,
+			'retention_w2'      => $w2_mature && $size > 0 ? round( $returned_w2 / $size, 4 ) : null,
+		);
+	}
+
+	return $cohorts;
+}

--- a/tests/RetentionCohortsTest.php
+++ b/tests/RetentionCohortsTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Tests for mature exact-week retention cohort responses.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verify cohort output does not conflate late activity or censored horizons.
+ */
+final class RetentionCohortsTest extends TestCase {
+	/**
+	 * Exact W1 activity is retained while a no-return cohort remains zero.
+	 */
+	public function test_exact_w1_and_no_return_cohorts(): void {
+		$cohorts = $this->build( array( $this->row( '2026-01-05', 2, 1, 0 ) ) );
+
+		$this->assertSame( 1, $cohorts[0]['returned_w1'] );
+		$this->assertSame( 0, $cohorts[0]['returned_w2'] );
+		$this->assertSame( 0.5, $cohorts[0]['retention_w1'] );
+		$this->assertSame( 0.0, $cohorts[0]['retention_w2'] );
+	}
+
+	/**
+	 * Exact W2 activity is separate from W1 activity.
+	 */
+	public function test_exact_w2_activity_is_reported_independently(): void {
+		$cohorts = $this->build( array( $this->row( '2026-01-05', 1, 0, 1 ) ) );
+
+		$this->assertSame( 0, $cohorts[0]['returned_w1'] );
+		$this->assertSame( 1, $cohorts[0]['returned_w2'] );
+		$this->assertSame( 0.0, $cohorts[0]['retention_w1'] );
+		$this->assertSame( 1.0, $cohorts[0]['retention_w2'] );
+	}
+
+	/**
+	 * A later-only return must not be promoted into either exact-week result.
+	 */
+	public function test_late_only_return_is_not_counted_as_w1_or_w2(): void {
+		$cohorts = $this->build( array( $this->row( '2026-01-05', 1, 0, 0 ) ) );
+
+		$this->assertSame( 0, $cohorts[0]['returned_w1'] );
+		$this->assertSame( 0, $cohorts[0]['returned_w2'] );
+
+		$source = $this->get_retention_source();
+		$this->assertStringContainsString( 'activity.created_at >= DATE_ADD(acquisition.cohort_week_start, INTERVAL 7 DAY)', $source );
+		$this->assertStringContainsString( 'activity.created_at >= DATE_ADD(acquisition.cohort_week_start, INTERVAL 14 DAY)', $source );
+		$this->assertStringNotContainsString( 'max_week >= first_week', $source );
+	}
+
+	/**
+	 * Acquisition is selected from all history before cohort lookback filtering.
+	 */
+	public function test_pre_window_history_is_used_for_acquisition(): void {
+		$source = $this->get_retention_source();
+
+		$this->assertStringContainsString( 'WHERE {$cohort_where_clause}', $source );
+		$this->assertStringContainsString( 'HAVING MIN(created_at) >= %s', $source );
+		$this->assertStringContainsString( 'DATE_SUB( DATE( MIN(created_at) )', $source );
+		$this->assertStringContainsString( '$cohort_values = array( $event_type, $now_utc );', $source );
+		$this->assertStringNotContainsString( '$cohort_values = array( $event_type, $cohort_since );', $source );
+	}
+
+	/**
+	 * Recent cohorts expose censoring rather than artificial zero retention.
+	 */
+	public function test_immature_cohorts_are_explicitly_censored(): void {
+		$cohorts = $this->build( array( $this->row( '2026-01-19', 1, 0, 0 ) ), '2026-01-30 00:00:00' );
+
+		$this->assertFalse( $cohorts[0]['w1_mature'] );
+		$this->assertFalse( $cohorts[0]['w2_mature'] );
+		$this->assertNull( $cohorts[0]['returned_w1'] );
+		$this->assertNull( $cohorts[0]['returned_w2'] );
+		$this->assertNull( $cohorts[0]['retention_w1'] );
+		$this->assertNull( $cohorts[0]['retention_w2'] );
+		$this->assertSame( '2026-01-19', $cohorts[0]['cohort_week_start'] );
+		$this->assertSame( '202604', $cohorts[0]['cohort_week'] );
+	}
+
+	/**
+	 * Build a cohort response against a fixed observation cutoff.
+	 *
+	 * @param array<object> $rows Rows returned by the aggregate query.
+	 * @param string        $as_of UTC observation cutoff.
+	 * @return array<int,array<string,int|float|string|bool|null>>
+	 */
+	private function build( $rows, $as_of = '2026-02-01 00:00:00' ) {
+		return extrachill_analytics_build_cohort_retention( $rows, $as_of );
+	}
+
+	/**
+	 * Create an aggregate-query row fixture.
+	 *
+	 * @param string $week_start ISO week start.
+	 * @param int    $size Cohort size.
+	 * @param int    $w1 Exact W1 returns.
+	 * @param int    $w2 Exact W2 returns.
+	 * @return object
+	 */
+	private function row( $week_start, $size, $w1, $w2 ) {
+		return (object) array(
+			'cohort_week_start' => $week_start,
+			'cohort_size'       => $size,
+			'returned_w1'       => $w1,
+			'returned_w2'       => $w2,
+		);
+	}
+
+	/**
+	 * Read the production ability source for query-contract assertions.
+	 *
+	 * @return string
+	 */
+	private function get_retention_source() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local test fixture.
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/abilities/get-retention-stats.php' );
+
+		$this->assertNotFalse( $source );
+
+		return $source;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -366,3 +366,4 @@ if ( ! function_exists( 'get_the_terms' ) ) {
 require_once dirname( __DIR__ ) . '/inc/core/php-error-log.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-php-error-summary.php';
 require_once dirname( __DIR__ ) . '/inc/core/security-classifier.php';
+require_once dirname( __DIR__ ) . '/inc/core/retention-cohorts.php';


### PR DESCRIPTION
## Summary
- Calculate cohort acquisition from each visitor's first observed scoped pageview, then count activity only in exact W1 and W2 ISO-week windows.
- Mark each observation horizon as mature and return null retention/count values for censored cohorts; add an ISO week-start date while retaining the existing cohort label.
- Keep rolling-window return rate semantics unchanged and add focused cohort regression coverage.

## Metric Definitions
Before: a visitor's maximum active `YEARWEEK` was compared with their first week inside the lookback, so a week-4-only return counted as both W1 and W2; recent cohorts appeared as zero retention.

After: W1 is activity in `[cohort_week_start + 7d, +14d)` and W2 is activity in `[+14d, +21d)`. Acquisition is the first observed pageview in available history, optionally scoped to `blog_id`. The rolling `return_rate` remains the share active on at least two UTC days within its requested window.

## Query And Maturity
The acquisition subquery scans scoped pageview history to find each visitor's first event, applies the cohort lookback after that aggregation, and joins bounded W1/W2 activity using the existing `(visitor_id, created_at)` index. No schema migration is needed.

A cohort is W1-mature after its first complete post-acquisition week ends (`week_start + 14 days`) and W2-mature after its second ends (`week_start + 21 days`). Incomplete horizons return `null`, not a zero denominator/result. Historical precision is bounded by the first event retained in the analytics table; no backfill is possible for events predating it.

## Tests And Verification
- Added cases for exact W1, exact W2, late-only activity, pre-window acquisition history, no return, and immature cohorts.
- `composer test` passes: 211 tests, 762 assertions.
- PHP syntax checks pass.
- Changed-file PHPCS reports no errors; existing direct-query cache warnings remain in the retention ability.
- `homeboy review ... --changed-since origin/main`: audit and lint passed with zero findings; sandbox test setup failed before discovery because its PHPUnit harness was not initialized. Local PHPUnit passed.

Closes #163