### PR TITLE
Fix CLI failures polluting production error health

### DIFF
--- a/inc/core/php-error-log.php
+++ b/inc/core/php-error-log.php
@@ -241,7 +241,7 @@ function extrachill_analytics_parse_log_timestamp( $line ) {
  */
 function extrachill_analytics_normalize_php_error( $raw ) {
 	// Take only the first physical line for the headline message; the rest is the
-	// stack trace which we use only for the "thrown in file:line" of fatals.
+	// stack trace used for fatal locations and execution-context classification.
 	$first_line = strtok( $raw, "\n" );
 	if ( false === $first_line ) {
 		$first_line = $raw;
@@ -292,7 +292,8 @@ function extrachill_analytics_normalize_php_error( $raw ) {
 	// near-real-time alarm ignore that noise so it never pages on, e.g., a
 	// "Cannot redeclare" raised by a worktree copy of an already-loaded plugin.
 	// An empty/unresolvable origin classifies as production (fail open).
-	$from_production = extrachill_analytics_is_production_error_path( $file );
+	$from_production = extrachill_analytics_is_production_error_path( $file )
+		&& ! extrachill_analytics_has_cli_eval_stack( $raw );
 
 	// Build the normalized message used for the signature: strip the trailing
 	// "in <path> on line N", drop request-specific numerics, addresses, and IDs.
@@ -384,6 +385,31 @@ function extrachill_analytics_is_production_error_path( $file ) {
 	}
 
 	return false;
+}
+
+/**
+ * Detect a WP-CLI eval or eval-file frame in an error stack trace.
+ *
+ * These commands can directly include production files while running ad hoc
+ * diagnostics. The thrown file therefore looks like live application code even
+ * though the failing execution path cannot occur in a web request.
+ *
+ * Only explicit stack frames are matched so unknown contexts continue to fail
+ * open as production errors.
+ *
+ * @param string $raw Raw, possibly multi-line log entry.
+ * @return bool True when the stack came through WP-CLI eval or eval-file.
+ */
+function extrachill_analytics_has_cli_eval_stack( $raw ) {
+	$stack = strstr( (string) $raw, "\n" );
+	if ( false === $stack ) {
+		return false;
+	}
+
+	return 1 === preg_match(
+		'/^#\d+\s+phar:\/\/.*\/wp-cli\/eval-command\/src\/Eval(?:File)?_Command\.php(?:\(\d+\))?/mi',
+		$stack
+	);
 }
 
 /**

--- a/tests/PhpErrorLogParserTest.php
+++ b/tests/PhpErrorLogParserTest.php
@@ -121,5 +121,45 @@ final class PhpErrorLogParserTest extends TestCase {
 			@unlink( $log['path'] ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		}
 	}
+
+	/**
+	 * A CLI eval can throw from a production file without representing a web
+	 * request failure.
+	 */
+	public function test_cli_eval_stack_marks_production_file_as_non_production(): void {
+		$file = WP_CONTENT_DIR . '/plugins/extrachill-blog/inc/home/templates/hero.php';
+		$raw  = '[15-Jul-2026 01:20:31 UTC] PHP Fatal error: Uncaught Error: Missing helper in ' . $file . " on line 26\n";
+		$raw .= "Stack trace:\n";
+		$raw .= "#0 phar:///usr/local/bin/wp/vendor/wp-cli/eval-command/src/Eval_Command.php(39) : eval()'d code(1): include()\n";
+		$raw .= '#1 phar:///usr/local/bin/wp/vendor/wp-cli/eval-command/src/Eval_Command.php(39): eval()';
+
+		$entry = extrachill_analytics_normalize_php_error( $raw );
+
+		$this->assertIsArray( $entry );
+		$this->assertFalse( $entry['from_production'] );
+
+		$eval_file_entry = extrachill_analytics_normalize_php_error(
+			str_replace( 'Eval_Command.php', 'EvalFile_Command.php', $raw )
+		);
+
+		$this->assertIsArray( $eval_file_entry );
+		$this->assertFalse( $eval_file_entry['from_production'] );
+	}
+
+	/**
+	 * A normal stack whose thrown file is under wp-content remains production.
+	 */
+	public function test_normal_stack_keeps_production_file_classification(): void {
+		$file = WP_CONTENT_DIR . '/plugins/example/render.php';
+		$raw  = '[15-Jul-2026 01:20:31 UTC] PHP Fatal error: Uncaught Error: Broken render in ' . $file . " on line 12\n";
+		$raw .= "Stack trace:\n";
+		$raw .= '#0 ' . WP_CONTENT_DIR . "/themes/example/front-page.php(8): include()\n";
+		$raw .= '#1 {main}';
+
+		$entry = extrachill_analytics_normalize_php_error( $raw );
+
+		$this->assertIsArray( $entry );
+		$this->assertTrue( $entry['from_production'] );
+	}
 }
 // phpcs:enable WordPress.WP.AlternativeFunctions


### PR DESCRIPTION
## Summary
- detect explicit WP-CLI eval and eval-file frames in folded PHP error stacks
- classify those diagnostic failures as non-production even when they throw from a live plugin file
- retain fail-open behavior for unknown and normal production contexts

## Testing
- PHPUnit: 220 tests, 798 assertions
- PHP syntax checks passed for both changed files
- git diff --check passed
- Homeboy review was attempted but refused by host resource policy at load average 71.7; it was not force-overridden

Closes #170