### PR TITLE
fix: expose conversion article identity

### DIFF
--- a/inc/core/abilities/get-conversion-map.php
+++ b/inc/core/abilities/get-conversion-map.php
@@ -430,11 +430,11 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 		}
 	);
 	$article_rank = array_slice( $article_rank, 0, $top_articles );
-	// Resolve titles/permalinks only for the surviving top rows (blog 1 context).
+	// Resolve identity only for the surviving top rows (blog 1 context).
 	foreach ( $article_rank as &$ar ) {
-		$post        = extrachill_analytics_get_blog_post( $entry_blog_id, (int) $ar['post_id'] );
-		$ar['title'] = $post ? $post->post_title : '(unknown)';
-		$ar['slug']  = $post ? $post->post_name : '';
+		$post     = extrachill_analytics_get_blog_post( $entry_blog_id, (int) $ar['post_id'] );
+		$identity = extrachill_analytics_conversion_article_identity( $entry_blog_id, $post );
+		$ar       = array_merge( $ar, $identity );
 	}
 	unset( $ar );
 
@@ -474,6 +474,47 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 		'since'                       => $since,
 		'as_of'                       => $now_utc,
 		'note'                        => 'First-party, bot-filtered editorial-to-platform funnel. entry_sessions is a legacy field name: it counts one first eligible, mature entry journey per visitor, not every entry session. Eligible entries start on a published blog-1 post. Same-session reach is a tracked post-backed events/community/artist destination within that session; return reach is one in a later session. Homepages, archives, directories, forum indexes, search, and other non-singular routes are outside this report. The query reads one inactivity-gap before the lower boundary to avoid session truncation, and excludes late entries until they have the configured return observation period. NULL-visitor rows (GPC/DNT opt-out) cannot be sessionized and are excluded.',
+	);
+}
+
+/**
+ * Resolve stable identity for an article output row.
+ *
+ * @param int          $blog_id Entry blog ID.
+ * @param WP_Post|null $post    Entry article post.
+ * @return array{title:string,slug:string,url:string,path:string} Article identity.
+ */
+function extrachill_analytics_conversion_article_identity( $blog_id, $post ) {
+	if ( ! $post instanceof WP_Post ) {
+		return array(
+			'title' => '(unknown)',
+			'slug'  => '',
+			'url'   => '',
+			'path'  => '',
+		);
+	}
+
+	$switched = false;
+	if ( is_multisite() && get_current_blog_id() !== (int) $blog_id ) {
+		switch_to_blog( (int) $blog_id );
+		$switched = true;
+	}
+
+	$url  = (string) get_permalink( $post );
+	$path = (string) wp_parse_url( $url, PHP_URL_PATH );
+	if ( '' !== $path ) {
+		$path = '/' . ltrim( $path, '/' );
+	}
+
+	if ( $switched ) {
+		restore_current_blog();
+	}
+
+	return array(
+		'title' => (string) $post->post_title,
+		'slug'  => (string) $post->post_name,
+		'url'   => $url,
+		'path'  => $path,
 	);
 }
 

--- a/tests/ConversionMapScopeTest.php
+++ b/tests/ConversionMapScopeTest.php
@@ -156,6 +156,42 @@ final class ConversionMapScopeTest extends TestCase {
 	}
 
 	/**
+	 * Machine consumers receive complete canonical article identity and typed metrics.
+	 */
+	public function test_article_identity_and_metrics_are_machine_readable(): void {
+		$post             = new WP_Post();
+		$post->ID         = 173;
+		$post->post_title = 'Mama Say Mama Sa Mama Coosa: The Story Behind an Iconic Michael Jackson Lyric';
+		$post->post_name  = 'mama-say-mama-sa-mama-coosa';
+
+		$GLOBALS['extrachill_analytics_test_permalinks'][173] = 'https://extrachill.com/mama-say-mama-sa-mama-coosa/';
+
+		$identity = extrachill_analytics_conversion_article_identity( 1, $post );
+		$metrics  = extrachill_analytics_conversion_rate_row(
+			array_merge(
+				extrachill_analytics_conversion_zero_bucket(),
+				array(
+					'entry_sessions'     => 4,
+					'reached_any'        => 2,
+					'reached_any_same'   => 1,
+					'reached_any_return' => 1,
+					'returned'           => 3,
+				)
+			),
+			array( 'post_id' => 173 )
+		);
+
+		$this->assertSame( $post->post_title, $identity['title'] );
+		$this->assertSame( 'https://extrachill.com/mama-say-mama-sa-mama-coosa/', $identity['url'] );
+		$this->assertSame( '/mama-say-mama-sa-mama-coosa/', $identity['path'] );
+		$this->assertSame( 173, $metrics['post_id'] );
+		$this->assertIsInt( $metrics['entry_sessions'] );
+		$this->assertIsInt( $metrics['reached_any'] );
+		$this->assertIsFloat( $metrics['reached_any_rate'] );
+		$this->assertSame( 0.5, $metrics['reached_any_rate'] );
+	}
+
+	/**
 	 * The contract documents buffered lower-boundary sessionization and mature
 	 * journey denominator semantics instead of implying every entry session.
 	 */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -252,6 +252,19 @@ if ( ! function_exists( 'wp_parse_url' ) ) {
 		return parse_url( (string) $url, $component ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 	}
 }
+if ( ! function_exists( 'get_permalink' ) ) {
+	/**
+	 * Return a canonical permalink for a post fixture.
+	 *
+	 * @param WP_Post|int $post Post fixture or ID.
+	 * @return string Canonical fixture URL.
+	 */
+	function get_permalink( $post ) {
+		$post_id    = $post instanceof WP_Post ? (int) $post->ID : (int) $post;
+		$permalinks = isset( $GLOBALS['extrachill_analytics_test_permalinks'] ) ? $GLOBALS['extrachill_analytics_test_permalinks'] : array();
+		return isset( $permalinks[ $post_id ] ) ? (string) $permalinks[ $post_id ] : '';
+	}
+}
 if ( ! function_exists( 'url_to_postid' ) ) {
 	/**
 	 * Capture resolver URLs and resolve against both test fixture maps.


### PR DESCRIPTION
## Summary
- enrich ranked conversion article rows with canonical URL and normalized path while retaining the existing post ID, full title, and slug
- keep conversion counts and rates typed at the ability boundary
- add focused coverage for stable article identity and numeric metrics

## Root cause
Stable `post_id`, the full untruncated title, and typed counts/rates already existed in `extrachill/get-conversion-map`. The ability lacked canonical `url` and `path`, while the CLI presentation adapter dropped `post_id`, truncated `title`, and converted metrics to display strings. This PR fixes the ability-owned identity gap; the coordinated Extra-Chill/extrachill-cli#99 fix preserves those fields and types in JSON/CSV.

## Machine contract
Article identity supplied by the ability:
- `post_id` integer
- `title` full string
- `slug` full string
- `url` canonical permalink string
- `path` canonical site-relative path string

Metrics remain numeric, including `entry_sessions`, `reached_any`, `reached_any_rate`, `reached_any_same_count`, `reached_any_return_count`, `returned_count`, nested same-session/return rates, and `returned_rate`.

The coordinated CLI machine rows expose these exact flattened fields: `post_id`, `title`, `url`, `path`, `entry_sessions`, `reached_any`, `reached_any_rate`, `reached_any_same_count`, `same_session_rate`, `reached_any_return_count`, `return_rate`, `returned_count`, `returned_rate`.

## Compatibility
Human table formatting is not owned by this repository and is unchanged. The coordinated CLI fix retains the existing compact title, formatted count, percentage values, and column order for table output.

## Tests
- `vendor/bin/phpunit --filter ConversionMapScopeTest` - 5 tests, 20 assertions passed
- `vendor/bin/phpunit` - 237 tests, 883 assertions passed
- `vendor/bin/phpcs --standard=WordPress inc/core/abilities/get-conversion-map.php tests/bootstrap.php tests/ConversionMapScopeTest.php` - passed with no findings
- PHP syntax checks passed for all changed PHP files

Closes #173