### PR TITLE
feat: expose event source context detail

### DIFF
--- a/inc/core/abilities/get-analytics-summary.php
+++ b/inc/core/abilities/get-analytics-summary.php
@@ -19,7 +19,7 @@ function extrachill_analytics_register_summary_ability() {
 		'extrachill/get-analytics-summary',
 		array(
 			'label'               => __( 'Get Analytics Summary', 'extrachill-analytics' ),
-			'description'         => __( 'Returns event counts grouped by type with optional date filtering.', 'extrachill-analytics' ),
+			'description'         => __( 'Returns event counts grouped by type, plus date, source, and context detail when one event type is requested.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -43,7 +43,7 @@ function extrachill_analytics_register_summary_ability() {
 			),
 			'output_schema'       => array(
 				'type'        => 'object',
-				'description' => __( 'Summary with event_types array and total count.', 'extrachill-analytics' ),
+				'description' => __( 'Summary with event_types and total count. An event_type filter also adds by_date, by_source, and by_context arrays.', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_summary',
 			'permission_callback' => 'extrachill_analytics_can_read_reports',
@@ -130,7 +130,7 @@ function extrachill_analytics_ability_get_summary( $input ) {
 		$total += $count;
 	}
 
-	return array(
+	$summary = array(
 		'event_types' => $event_types,
 		'total'       => $total,
 		'days'        => $days,
@@ -143,4 +143,40 @@ function extrachill_analytics_ability_get_summary( $input ) {
 		'since'       => $since,
 		'as_of'       => $now_utc,
 	);
+
+	// Preserve the compact all-event response while exposing the existing
+	// aggregation detail when the caller requests one event type.
+	if ( ! empty( $event_type ) && function_exists( 'extrachill_get_analytics_event_stats' ) ) {
+		$detail = extrachill_get_analytics_event_stats( $event_type, $days, $blog_id );
+
+		$summary['by_date']    = array_map(
+			static function ( $row ) {
+				return array(
+					'date'  => (string) $row->date,
+					'count' => (int) $row->count,
+				);
+			},
+			(array) $detail['by_date']
+		);
+		$summary['by_source']  = array_map(
+			static function ( $row ) {
+				return array(
+					'source_url' => (string) $row->source_url,
+					'count'      => (int) $row->count,
+				);
+			},
+			(array) $detail['by_source']
+		);
+		$summary['by_context'] = array_map(
+			static function ( $row ) {
+				return array(
+					'context' => (string) $row->context,
+					'count'   => (int) $row->count,
+				);
+			},
+			(array) $detail['by_context']
+		);
+	}
+
+	return $summary;
 }

--- a/inc/core/events.php
+++ b/inc/core/events.php
@@ -358,7 +358,7 @@ function extrachill_get_analytics_event_stats( $event_type, $days = 30, $blog_id
 			FROM {$table_name} 
 			WHERE {$where_clause} AND source_url != '' 
 			GROUP BY source_url 
-			ORDER BY count DESC 
+			ORDER BY count DESC, source_url ASC
 			LIMIT 20",
 			$values
 		)
@@ -371,7 +371,8 @@ function extrachill_get_analytics_event_stats( $event_type, $days = 30, $blog_id
 			FROM {$table_name} 
 			WHERE {$where_clause} AND JSON_EXTRACT(event_data, '$.context') IS NOT NULL 
 			GROUP BY context 
-			ORDER BY count DESC",
+			ORDER BY count DESC, context ASC
+			LIMIT 20",
 			$values
 		)
 	);

--- a/tests/GetAnalyticsSummaryTest.php
+++ b/tests/GetAnalyticsSummaryTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Regression tests for analytics summary event detail (issue #177).
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-analytics-summary.php';
+
+/**
+ * Verify event detail is exposed only for explicitly filtered summaries.
+ */
+final class GetAnalyticsSummaryTest extends TestCase {
+	/**
+	 * Install fresh database and detail fixtures for each test.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['wpdb'] = new class() {
+			/**
+			 * Queries executed by the report.
+			 *
+			 * @var string[]
+			 */
+			public $queries = array();
+
+			/**
+			 * Return the query unchanged.
+			 *
+			 * @param string $query SQL query.
+			 * @param mixed  ...$args Prepared values.
+			 * @return string
+			 */
+			public function prepare( $query, ...$args ) {
+				unset( $args );
+				return $query;
+			}
+
+			/**
+			 * Return the summary row fixture.
+			 *
+			 * @param string $query SQL query.
+			 * @return array<object>
+			 */
+			public function get_results( $query ) {
+				$this->queries[] = $query;
+				return array(
+					(object) array(
+						'event_type' => 'newsletter_signup',
+						'count'      => '3',
+					),
+				);
+			}
+		};
+
+		$GLOBALS['extrachill_analytics_event_stats_fixture'] = array(
+			'total'      => 3,
+			'by_date'    => array(
+				(object) array(
+					'date'  => '2026-07-16',
+					'count' => '3',
+				),
+			),
+			'by_source'  => array(
+				(object) array(
+					'source_url' => 'https://extrachill.com/newsletter/',
+					'count'      => '2',
+				),
+			),
+			'by_context' => array(
+				(object) array(
+					'context' => 'footer',
+					'count'   => '2',
+				),
+			),
+		);
+	}
+
+	/**
+	 * An explicit event type exposes typed rows from the existing aggregation.
+	 */
+	public function test_explicit_event_type_exposes_typed_detail_rows(): void {
+		$summary = extrachill_analytics_ability_get_summary(
+			array(
+				'days'       => 28,
+				'event_type' => 'newsletter_signup',
+			)
+		);
+
+		$this->assertSame( 3, $summary['total'] );
+		$this->assertSame(
+			array(
+				array(
+					'date'  => '2026-07-16',
+					'count' => 3,
+				),
+			),
+			$summary['by_date']
+		);
+		$this->assertSame(
+			array(
+				array(
+					'source_url' => 'https://extrachill.com/newsletter/',
+					'count'      => 2,
+				),
+			),
+			$summary['by_source']
+		);
+		$this->assertSame(
+			array(
+				array(
+					'context' => 'footer',
+					'count'   => 2,
+				),
+			),
+			$summary['by_context']
+		);
+	}
+
+	/**
+	 * The all-event contract remains compact and does not run detail queries.
+	 */
+	public function test_all_event_summary_contract_is_unchanged(): void {
+		$summary = extrachill_analytics_ability_get_summary( array( 'days' => 28 ) );
+
+		$this->assertArrayNotHasKey( 'by_date', $summary );
+		$this->assertArrayNotHasKey( 'by_source', $summary );
+		$this->assertArrayNotHasKey( 'by_context', $summary );
+		$this->assertCount( 1, $GLOBALS['wpdb']->queries );
+	}
+
+	/**
+	 * Source and context rankings are deterministic and bounded in SQL.
+	 */
+	public function test_source_and_context_queries_are_stable_and_bounded(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local production source.
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/events.php' );
+
+		$this->assertNotFalse( $source );
+		$this->assertStringContainsString( 'ORDER BY count DESC, source_url ASC', $source );
+		$this->assertStringContainsString( 'ORDER BY count DESC, context ASC', $source );
+		$this->assertSame( 2, substr_count( $source, 'LIMIT 20' ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -74,6 +74,16 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) );
 	}
 }
+if ( ! function_exists( 'extrachill_analytics_events_table' ) ) {
+	/**
+	 * Return the fixture analytics events table name.
+	 *
+	 * @return string
+	 */
+	function extrachill_analytics_events_table() {
+		return 'wp_extrachill_analytics_events';
+	}
+}
 if ( ! function_exists( 'extrachill_get_analytics_events' ) ) {
 	/**
 	 * Return a paginated outbound-report fixture when configured by a test.
@@ -89,6 +99,26 @@ if ( ! function_exists( 'extrachill_get_analytics_events' ) ) {
 			: array();
 
 		return array_slice( $rows, $offset, $limit );
+	}
+}
+if ( ! function_exists( 'extrachill_get_analytics_event_stats' ) ) {
+	/**
+	 * Return event-detail fixtures configured by summary ability tests.
+	 *
+	 * @param string $event_type Event type (unused in the stub).
+	 * @param int    $days       Lookback days (unused in the stub).
+	 * @param int    $blog_id    Blog ID (unused in the stub).
+	 * @return array<string,mixed> Event detail fixture.
+	 */
+	function extrachill_get_analytics_event_stats( $event_type, $days = 30, $blog_id = 0 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return isset( $GLOBALS['extrachill_analytics_event_stats_fixture'] )
+			? $GLOBALS['extrachill_analytics_event_stats_fixture']
+			: array(
+				'total'      => 0,
+				'by_date'    => array(),
+				'by_source'  => array(),
+				'by_context' => array(),
+			);
 	}
 }
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {


### PR DESCRIPTION
## Summary
- expose `by_date`, `by_source`, and `by_context` on `extrachill/get-analytics-summary` when an explicit `event_type` is requested
- normalize detail rows to response arrays with integer counts while preserving the existing all-event summary shape
- make source/context rankings deterministic and cap both at 20 rows

## Compatibility
- all-event summary responses retain their existing keys and avoid the additional detail aggregation
- detailed output reuses `extrachill_get_analytics_event_stats()` and existing storage; no new instrumentation or parallel aggregation was added

## Tests
- `vendor/bin/phpunit tests/GetAnalyticsSummaryTest.php` (3 tests, 12 assertions)
- `vendor/bin/phpunit` (240 tests, 895 assertions)
- PHP syntax checks for all changed PHP files
- changed-file PHPCS: 0 errors; existing direct-database/caching warnings remain in the aggregation code
- `homeboy review extrachill-analytics` was attempted but refused by Homeboy resource policy because the host was hot (load 128.8/8 CPUs) and no eligible Lab runner was available

## Residual limitations
- source and context detail intentionally returns only the top 20 rows; date detail continues to follow the requested day window, including all available dates when `days=0`

Closes #177