### PR TITLE
fix: stitch outcomes on conversion routes

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -164,7 +164,7 @@ function extrachill_analytics_beacon_is_first_party() {
 	$suffix        = '.' . $cookie_domain;
 
 	return $source_host === $cookie_domain
-		|| ( strlen( $source_host ) > strlen( $suffix ) && $suffix === substr( $source_host, -strlen( $suffix ) ) );
+		|| ( strlen( $source_host ) > strlen( $suffix ) && substr( $source_host, -strlen( $suffix ) ) === $suffix );
 }
 
 /**
@@ -250,11 +250,59 @@ function extrachill_analytics_get_or_mint_visitor_id() {
  * then reads the memoized result instead of trying — and failing — to set the
  * cookie itself.
  *
- * Gated on the same conditions as the enqueue: singular, non-preview, and not
- * opted out via GPC/DNT.
+ * Unlike the singular-only pageview beacon, the cookie is primed on every
+ * first-party public template request. This lets outcomes from homepages,
+ * archives, and custom login/register pages reuse the same anonymous identity
+ * without minting from REST, admin, cron, CLI, preview, or custom-domain
+ * requests.
+ *
+ * @return bool True when the current request may prime visitor identity.
+ */
+function extrachill_analytics_should_prime_visitor_cookie() {
+	if (
+		extrachill_analytics_visitor_opted_out()
+		|| is_preview()
+		|| is_admin()
+		|| wp_doing_ajax()
+		|| wp_doing_cron()
+		|| ( defined( 'REST_REQUEST' ) && REST_REQUEST )
+		|| ( defined( 'WP_CLI' ) && WP_CLI )
+	) {
+		return false;
+	}
+
+	$request_method = isset( $_SERVER['REQUEST_METHOD'] )
+		? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) )
+		: '';
+	if ( ! in_array( $request_method, array( 'GET', 'HEAD' ), true ) ) {
+		return false;
+	}
+
+	$request_host  = isset( $_SERVER['HTTP_HOST'] )
+		? wp_parse_url( 'https://' . sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ), PHP_URL_HOST )
+		: '';
+	$cookie_domain = ltrim( extrachill_analytics_visitor_cookie_domain(), '.' );
+	if ( '' === $cookie_domain ) {
+		$cookie_domain = wp_parse_url( home_url( '/' ), PHP_URL_HOST );
+	}
+
+	if ( ! is_string( $request_host ) || '' === $request_host || ! is_string( $cookie_domain ) || '' === $cookie_domain ) {
+		return false;
+	}
+
+	$request_host  = strtolower( rtrim( $request_host, '.' ) );
+	$cookie_domain = strtolower( rtrim( $cookie_domain, '.' ) );
+	$suffix        = '.' . $cookie_domain;
+
+	return $request_host === $cookie_domain
+		|| ( strlen( $request_host ) > strlen( $suffix ) && substr( $request_host, -strlen( $suffix ) ) === $suffix );
+}
+
+/**
+ * Mint/read the visitor cookie early on eligible public template requests.
  */
 function extrachill_analytics_prime_visitor_cookie() {
-	if ( ! is_singular() || is_preview() ) {
+	if ( ! extrachill_analytics_should_prime_visitor_cookie() ) {
 		return;
 	}
 
@@ -266,7 +314,7 @@ add_action( 'template_redirect', 'extrachill_analytics_prime_visitor_cookie' );
 /**
  * Script handle for the shared, network-activated Chart.js v4 asset.
  *
- * extrachill-analytics is network-activated, so registering Chart.js once here
+ * Extra Chill Analytics is network-activated, so registering Chart.js once here
  * makes a single guaranteed-present copy available to every consumer on the
  * network — instead of each plugin re-bundling its own. Consumers (artist-
  * platform link-page analytics, the Mediavine revenue ARC, the Studio Network

--- a/tests/VisitorCookiePrimingTest.php
+++ b/tests/VisitorCookiePrimingTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Tests for the visitor-cookie priming request boundary.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verify anonymous identity is minted only on eligible frontend requests.
+ */
+final class VisitorCookiePrimingTest extends TestCase {
+	/**
+	 * Load the request-boundary helpers.
+	 */
+	public static function setUpBeforeClass(): void {
+		require_once dirname( __DIR__ ) . '/inc/core/assets.php';
+	}
+
+	/**
+	 * Set a normal first-party browser request before each test.
+	 */
+	protected function setUp(): void {
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_HOST']      = 'extrachill.com';
+	}
+
+	/**
+	 * Restore request fixtures after each test.
+	 */
+	protected function tearDown(): void {
+		unset(
+			$_SERVER['REQUEST_METHOD'],
+			$_SERVER['HTTP_HOST'],
+			$_SERVER['HTTP_SEC_GPC'],
+			$_SERVER['HTTP_DNT'],
+			$GLOBALS['extrachill_analytics_test_is_preview'],
+			$GLOBALS['extrachill_analytics_test_is_admin'],
+			$GLOBALS['extrachill_analytics_test_doing_ajax'],
+			$GLOBALS['extrachill_analytics_test_doing_cron']
+		);
+	}
+
+	/**
+	 * Singular pages remain eligible after widening the boundary.
+	 */
+	public function test_singular_frontend_request_is_eligible(): void {
+		$this->assertTrue( extrachill_analytics_should_prime_visitor_cookie() );
+	}
+
+	/**
+	 * The request boundary also covers network home, archive, and login routes.
+	 *
+	 * @dataProvider eligible_frontend_route_provider
+	 *
+	 * @param string $host   First-party network host.
+	 * @param string $method Safe browser request method.
+	 */
+	public function test_non_singular_and_login_frontend_requests_are_eligible( $host, $method ): void {
+		$_SERVER['HTTP_HOST']      = $host;
+		$_SERVER['REQUEST_METHOD'] = $method;
+
+		$this->assertTrue( extrachill_analytics_should_prime_visitor_cookie() );
+	}
+
+	/**
+	 * First-party public route fixtures.
+	 *
+	 * @return array<string,array{string,string}>
+	 */
+	public function eligible_frontend_route_provider() {
+		return array(
+			'network homepage' => array( 'extrachill.com', 'GET' ),
+			'archive'          => array( 'newsletter.extrachill.com', 'GET' ),
+			'login/register'   => array( 'community.extrachill.com', 'GET' ),
+			'head request'     => array( 'events.extrachill.com', 'HEAD' ),
+		);
+	}
+
+	/**
+	 * Preview and non-template runtimes cannot mint identity.
+	 *
+	 * @dataProvider ineligible_runtime_provider
+	 *
+	 * @param string $fixture Runtime fixture global.
+	 */
+	public function test_preview_admin_ajax_and_cron_requests_are_ineligible( $fixture ): void {
+		$GLOBALS[ $fixture ] = true;
+
+		$this->assertFalse( extrachill_analytics_should_prime_visitor_cookie() );
+	}
+
+	/**
+	 * Runtime fixture globals.
+	 *
+	 * @return array<string,array{string}>
+	 */
+	public function ineligible_runtime_provider() {
+		return array(
+			'preview' => array( 'extrachill_analytics_test_is_preview' ),
+			'admin'   => array( 'extrachill_analytics_test_is_admin' ),
+			'ajax'    => array( 'extrachill_analytics_test_doing_ajax' ),
+			'cron'    => array( 'extrachill_analytics_test_doing_cron' ),
+		);
+	}
+
+	/**
+	 * REST and CLI guards remain explicit in the request boundary.
+	 */
+	public function test_rest_and_cli_requests_are_explicitly_ineligible(): void {
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/assets.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local source fixture.
+
+		$this->assertStringContainsString( "defined( 'REST_REQUEST' ) && REST_REQUEST", $source );
+		$this->assertStringContainsString( "defined( 'WP_CLI' ) && WP_CLI", $source );
+	}
+
+	/**
+	 * Unsafe methods and custom-domain requests cannot mint the network cookie.
+	 */
+	public function test_post_and_third_party_requests_are_ineligible(): void {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$this->assertFalse( extrachill_analytics_should_prime_visitor_cookie() );
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_HOST']      = 'artist.example';
+		$this->assertFalse( extrachill_analytics_should_prime_visitor_cookie() );
+	}
+
+	/**
+	 * GPC and DNT prevent priming on otherwise eligible requests.
+	 *
+	 * @dataProvider privacy_header_provider
+	 *
+	 * @param string $header Privacy request header.
+	 */
+	public function test_privacy_opt_out_requests_are_ineligible( $header ): void {
+		$_SERVER[ $header ] = '1';
+
+		$this->assertFalse( extrachill_analytics_should_prime_visitor_cookie() );
+	}
+
+	/**
+	 * Supported privacy headers.
+	 *
+	 * @return array<string,array{string}>
+	 */
+	public function privacy_header_provider() {
+		return array(
+			'global privacy control' => array( 'HTTP_SEC_GPC' ),
+			'do not track'           => array( 'HTTP_DNT' ),
+		);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -184,6 +184,46 @@ if ( ! function_exists( 'sanitize_text_field' ) ) {
 		return is_scalar( $str ) ? (string) $str : '';
 	}
 }
+if ( ! function_exists( 'is_preview' ) ) {
+	/**
+	 * Return the preview-request fixture state.
+	 *
+	 * @return bool Whether the request is a preview.
+	 */
+	function is_preview() {
+		return ! empty( $GLOBALS['extrachill_analytics_test_is_preview'] );
+	}
+}
+if ( ! function_exists( 'is_admin' ) ) {
+	/**
+	 * Return the admin-request fixture state.
+	 *
+	 * @return bool Whether the request is administrative.
+	 */
+	function is_admin() {
+		return ! empty( $GLOBALS['extrachill_analytics_test_is_admin'] );
+	}
+}
+if ( ! function_exists( 'wp_doing_ajax' ) ) {
+	/**
+	 * Return the AJAX-request fixture state.
+	 *
+	 * @return bool Whether WordPress is handling AJAX.
+	 */
+	function wp_doing_ajax() {
+		return ! empty( $GLOBALS['extrachill_analytics_test_doing_ajax'] );
+	}
+}
+if ( ! function_exists( 'wp_doing_cron' ) ) {
+	/**
+	 * Return the cron-request fixture state.
+	 *
+	 * @return bool Whether WordPress is handling cron.
+	 */
+	function wp_doing_cron() {
+		return ! empty( $GLOBALS['extrachill_analytics_test_doing_cron'] );
+	}
+}
 if ( ! function_exists( 'get_current_blog_id' ) ) {
 	/**
 	 * Return the current blog fixture ID.


### PR DESCRIPTION
## Summary
- prime the existing `ec_vid` identity on eligible first-party public template requests, including singular pages, network home/archive views, and custom login/register pages
- preserve the singular-only pageview beacon while allowing existing newsletter and registration outcome emitters to read the cookie on their later REST/admin-post submissions
- add focused request-boundary coverage for eligible routes and privacy/runtime/host exclusions

## Eligible request boundary
Cookie priming runs from `template_redirect` only for first-party network-host `GET` or `HEAD` requests. It rejects previews, admin and AJAX requests, REST, cron, CLI, unsafe methods, missing or foreign/custom hosts, and GPC/DNT opt-outs.

## Privacy and bot safeguards
- reuses the existing random UUID v4 cookie, network-root scope, UUID validation, Secure/HttpOnly/SameSite attributes, and read-only event fallback
- keeps GPC and DNT as hard opt-outs before minting
- keeps custom-domain and third-party requests anonymous through cookie-domain host validation
- leaves the canonical request/UA bot classifier and singular pageview beacon unchanged

## Tests
- `vendor/bin/phpunit` (259 tests, 925 assertions)
- `vendor/bin/phpcs --standard=WordPress inc/core/assets.php tests/bootstrap.php tests/VisitorCookiePrimingTest.php`
- PHP syntax checks for all modified PHP files
- `npm run build`
- `git diff --check`

Homeboy review was attempted but resource policy refused to run on the hot host (load average 125.5 across 8 CPUs) and no eligible Lab runner was available. The local PHPUnit, PHPCS, syntax, build, and diff checks above completed successfully.

## Residual limits
Identity remains unavailable when visitors opt out, reject cookies, arrive through excluded/non-template request contexts, or use third-party/custom domains. Existing historical outcomes are not backfilled; coverage improves for new eligible visits after deployment.

Closes #180