### PR TITLE
Fix non-singular route journey measurement

### DIFF
--- a/assets/js/view-tracking.js
+++ b/assets/js/view-tracking.js
@@ -1,10 +1,21 @@
 ( function () {
-	var config = window.ecViewTracking;
-	if ( ! config || ! config.postId || ! config.endpoint ) {
+	const config = window.ecViewTracking;
+	if (
+		! config ||
+		! config.sourcePath ||
+		! config.routeFamily ||
+		! config.endpoint
+	) {
 		return;
 	}
 
-	var payload = { post_id: config.postId };
+	const input = {
+		source_path: config.sourcePath,
+		route_family: config.routeFamily,
+	};
+	if ( config.postId ) {
+		input.post_id = config.postId;
+	}
 
 	// Capture the TRUE referrer client-side. This beacon fires after page load,
 	// so the request's own HTTP Referer header is this article page itself —
@@ -13,13 +24,13 @@
 	// query strings, no PII) and drops direct/same-host referrers. Empty for
 	// direct traffic.
 	if ( document.referrer ) {
-		payload.referrer = document.referrer;
+		input.referrer = document.referrer;
 	}
 
-	var data = JSON.stringify( payload );
+	const data = JSON.stringify( { input } );
 
-	if ( navigator.sendBeacon ) {
-		navigator.sendBeacon(
+	if ( window.navigator.sendBeacon ) {
+		window.navigator.sendBeacon(
 			config.endpoint,
 			new Blob( [ data ], { type: 'application/json' } )
 		);

--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -33,6 +33,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/security-classifier.php
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/visitor-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/search-source-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/referrer-host-classifier.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/route-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/content-format-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/outbound-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/mediavine-csv-import.php';

--- a/inc/core/abilities/get-conversion-map.php
+++ b/inc/core/abilities/get-conversion-map.php
@@ -5,7 +5,7 @@
  * THE first-party cross-surface conversion instrument. Answers the central
  * rebuild question deterministically and per-entry-page: *when an anonymous
  * visitor starts an eligible journey on an editorial article (blog 1), do they
- * ever reach a tracked, post-backed destination on the events, community, or
+ * ever reach a tracked destination on the events, community, or
  * artist platform in the same session or on a return visit?*
  *
  * The rebuild thesis is that song-meaning / music-history articles are
@@ -28,11 +28,10 @@
  *   visitor_id (opted-out via GPC/DNT, or pre-cookie) cannot be attributed to a
  *   session and are excluded by construction.
  *
- * SCOPE: pageviews are currently collected through the post-view endpoint,
- * which requires a positive post ID. The map therefore measures singular,
- * post-backed destinations only. Platform homepages, archives, directories,
- * forum indexes, and search routes are intentionally excluded rather than
- * silently represented as zero conversion.
+ * SCOPE: entry semantics remain editorial and post-backed. Destination reach
+ * includes every eligible pageview collected on a platform blog, including
+ * route-level homepage, archive, search, auth, and directory views added by
+ * issue #182. Historical periods remain singular-only before that deployment.
  *
  * SESSIONIZATION: a "session" is a run of a visitor's pageviews with no gap
  * larger than the inactivity timeout (default 30 minutes — the GA-standard
@@ -80,7 +79,7 @@ function extrachill_analytics_register_conversion_map_ability() {
 		'extrachill/get-conversion-map',
 		array(
 			'label'               => __( 'Get Conversion Map', 'extrachill-analytics' ),
-			'description'         => __( 'First-party, bot-filtered editorial-to-platform conversion map: for visitors whose first eligible journey starts on a published blog-1 post, the share that reach a tracked, post-backed destination on events/community/artist same-session or on a return visit. Platform homepages, archives, directories, forum indexes, and search routes are not measured. Ranked per entry article and category.', 'extrachill-analytics' ),
+			'description'         => __( 'First-party, bot-filtered editorial-to-platform conversion map: for visitors whose first eligible journey starts on a published blog-1 post, the share that reach an eligible collected route on events/community/artist same-session or on a return visit. Ranked per entry article and category.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -617,11 +616,11 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 		'session_gap_mins'            => $session_gap_mins,
 		'return_observation_days'     => $return_observation_days,
 		'denominator'                 => 'One first eligible, mature editorial-entry journey per visitor. An eligible entry is a session starting in the reporting window on a published blog-1 post; late entries without the configured return observation period are excluded.',
-		'measured_destination_routes' => 'Singular, post-backed pageviews on events, community, and artist only. Homepages, archives, directories, forum indexes, search, and other non-singular routes are excluded because the current post-view endpoint does not collect them.',
+		'measured_destination_routes' => 'Eligible collected pageviews on events, community, and artist, including post-backed singular views and route-level homepage, archive, search, auth, and directory views. Entry journeys remain published blog-1 posts only. Historical periods before issue #182 deployment remain singular-only.',
 		'period'                      => gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' ),
 		'since'                       => $since,
 		'as_of'                       => $now_utc,
-		'note'                        => 'First-party, bot-filtered editorial-to-platform funnel. entry_sessions is a legacy field name: it counts one first eligible, mature entry journey per visitor, not every entry session. Eligible entries start on a published blog-1 post. Same-session reach is a tracked post-backed events/community/artist destination within that session; return reach is one in a later session. Newsletter and registration outcomes are successful server-side events and are reported through separate direct-source and visitor-journey lenses. Automatic registration newsletter subscriptions are excluded. Missing source or visitor identity remains explicit coverage, never an inferred zero. Homepages, archives, directories, forum indexes, search, and other non-singular routes are outside the pageview destination report. The query reads one inactivity-gap before the lower boundary to avoid session truncation, and excludes late entries until they have the configured return observation period. NULL-visitor pageviews (GPC/DNT opt-out) cannot be sessionized and are excluded.',
+		'note'                        => 'First-party, bot-filtered editorial-to-platform funnel. entry_sessions is a legacy field name: it counts one first eligible, mature entry journey per visitor, not every entry session. Eligible entries start on a published blog-1 post; route views never become editorial entries. Same-session and return reach include eligible collected events/community/artist routes. Newsletter and registration outcomes are successful server-side events and are reported through separate direct-source and visitor-journey lenses. Automatic registration newsletter subscriptions are excluded. Missing source or visitor identity remains explicit coverage, never an inferred zero. Route-level destination collection is additive from issue #182 onward, so historical periods remain singular-only. The query reads one inactivity-gap before the lower boundary to avoid session truncation, and excludes late entries until they have the configured return observation period. NULL-visitor pageviews (GPC/DNT opt-out) cannot be sessionized and are excluded.',
 	);
 }
 
@@ -999,8 +998,7 @@ function extrachill_analytics_conversion_is_mature_entry_session( $event, $entry
  * @return bool Whether the event is a measured platform destination.
  */
 function extrachill_analytics_conversion_is_measured_platform_event( $event, $platform_id_to_key ) {
-	return (int) ( $event['post_id'] ?? 0 ) > 0
-		&& isset( $platform_id_to_key[ (int) ( $event['blog_id'] ?? 0 ) ] );
+	return isset( $platform_id_to_key[ (int) ( $event['blog_id'] ?? 0 ) ] );
 }
 
 /**

--- a/inc/core/abilities/get-retention-stats.php
+++ b/inc/core/abilities/get-retention-stats.php
@@ -311,40 +311,74 @@ function extrachill_analytics_ability_get_retention_stats( $input ) {
 		);
 	}
 
+	// Collection coverage is explicit because route-level rows begin only after
+	// issue #182 ships. Historical rows remain valid post-backed observations;
+	// they must not be silently presented as whole-platform route coverage.
+	$coverage_where  = array( 'event_type = %s', 'created_at >= %s' );
+	$coverage_values = array( $event_type, $since );
+	if ( $end_days_ago > 0 ) {
+		$coverage_where[]  = 'created_at < %s';
+		$coverage_values[] = $window_end;
+	}
+	if ( $blog_id > 0 ) {
+		$coverage_where[]  = 'blog_id = %d';
+		$coverage_values[] = $blog_id;
+	}
+	$coverage_where_clause = implode( ' AND ', $coverage_where );
+	$coverage_sql          = "SELECT
+			COUNT(*) AS total_pageviews,
+			SUM(CASE WHEN CAST(JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.post_id')) AS UNSIGNED) > 0 THEN 1 ELSE 0 END) AS post_backed_pageviews,
+			SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.view_kind')) = 'route' THEN 1 ELSE 0 END) AS route_pageviews,
+			SUM(CASE WHEN (JSON_EXTRACT(event_data, '$.post_id') IS NULL OR CAST(JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.post_id')) AS UNSIGNED) = 0)
+				AND JSON_EXTRACT(event_data, '$.view_kind') IS NULL THEN 1 ELSE 0 END) AS historical_unclassified_pageviews
+		FROM {$table}
+		WHERE {$coverage_where_clause}";
+
+	// phpcs:disable WordPress.DB.PreparedSQL -- Code-defined table and placeholder clause; values are bound below.
+	$coverage_row = $wpdb->get_row( $wpdb->prepare( $coverage_sql, $coverage_values ) );
+	// phpcs:enable WordPress.DB.PreparedSQL
+
 	return array(
-		'return_rate'       => array(
+		'return_rate'         => array(
 			'total_visitors'     => $total_visitors,
 			'returning_visitors' => $returning_visitors,
 			'rate'               => $return_rate,
 			'definition'         => 'Share of visitors active on >= 2 distinct UTC days within the window.',
 		),
-		'cohort_retention'  => array(
+		'cohort_retention'    => array(
 			'cohorts'    => $cohort_retention,
 			'weeks'      => $cohort_weeks,
 			'definition' => 'Acquisition is each visitor\'s first observed pageview in the available event history, scoped by blog_id when set. W1 is activity during the first complete ISO week after acquisition; W2 is activity during the second. A horizon is reported only after its full week has elapsed; incomplete horizons are null and must not be treated as zero retention. This cohort history is distinct from the rolling-window return_rate metric.',
 		),
-		'cross_site_return' => array(
+		'cross_site_return'   => array(
 			'total_visitors'      => $xsite_total,
 			'cross_site_visitors' => $xsite_visitors,
 			'rate'                => $cross_site_rate,
 			'definition'          => 'Share of visitors who hit >= 2 distinct blog_ids on >= 2 distinct UTC days (network-wide; ignores blog_id filter).',
 		),
-		'session_depth'     => array(
+		'session_depth'       => array(
 			'avg_pageviews_per_visitor_day' => $avg_depth,
 			'max_pageviews_per_visitor_day' => $max_depth,
 			'definition'                    => 'Average (and max) pageview events per visitor per active UTC day.',
 		),
-		'by_referrer_host'  => array(
+		'by_referrer_host'    => array(
 			'hosts'      => $by_referrer_host,
 			'definition' => 'Top cross-surface referrer hosts (host-only, no query strings/PII) that sent readers to a pageview in the window — AI-citation (chatgpt.com / perplexity.ai), social, search engines, and cross-subdomain landings. Counts ALL pageviews carrying a referrer_host (not just identified visitors); direct + same-host traffic omit the field, and rows predating issue #90 do not appear.',
 		),
-		'days'              => $days,
-		'end_days_ago'      => $end_days_ago,
-		'blog_id'           => $blog_id,
-		'period'            => gmdate( 'Y-m-d', strtotime( $since ) ) . ' to ' . gmdate( 'Y-m-d', strtotime( $window_end ) ),
-		'since'             => $since,
-		'until'             => $window_end,
-		'as_of'             => $now_utc,
-		'note'              => 'Deterministic + bot-filtered: pageview rows are written server-side only for non-bot, JS-executing browsers; visitor_id is an anonymous first-party UUID v4 (no PII). Opted-out (GPC/DNT) rows have NULL visitor_id and are excluded from per-visitor metrics.',
+		'collection_coverage' => array(
+			'total_pageviews'                   => $coverage_row ? (int) $coverage_row->total_pageviews : 0,
+			'post_backed_pageviews'             => $coverage_row ? (int) $coverage_row->post_backed_pageviews : 0,
+			'route_pageviews'                   => $coverage_row ? (int) $coverage_row->route_pageviews : 0,
+			'historical_unclassified_pageviews' => $coverage_row ? (int) $coverage_row->historical_unclassified_pageviews : 0,
+			'definition'                        => 'Post-backed includes singular pageviews carrying post_id. Route includes new non-singular rows explicitly stamped view_kind=route. Historical unclassified rows lack both signals and predate the route-view contract; periods spanning deployment combine singular-only historical collection with broader current collection.',
+		),
+		'days'                => $days,
+		'end_days_ago'        => $end_days_ago,
+		'blog_id'             => $blog_id,
+		'period'              => gmdate( 'Y-m-d', strtotime( $since ) ) . ' to ' . gmdate( 'Y-m-d', strtotime( $window_end ) ),
+		'since'               => $since,
+		'until'               => $window_end,
+		'as_of'               => $now_utc,
+		'note'                => 'Deterministic + bot-filtered: pageview rows are written server-side only for non-bot, JS-executing browsers; visitor_id is an anonymous first-party UUID v4 (no PII). Opted-out (GPC/DNT) rows have NULL visitor_id and are excluded from per-visitor metrics. Route-level collection is additive from issue #182 onward; use collection_coverage before comparing periods that cross deployment.',
 	);
 }

--- a/inc/core/abilities/track-page-view.php
+++ b/inc/core/abilities/track-page-view.php
@@ -2,13 +2,14 @@
 /**
  * Track Page View Ability
  *
- * Write-side ability that increments post view counts.
+ * Write-side ability that records post-backed and route-level pageviews.
  * High-frequency hot-path — keeps logic minimal.
  *
  * @package ExtraChill\Analytics
  * @since 0.8.0
  */
-declare(strict_types=1);
+
+declare( strict_types=1 );
 
 defined( 'ABSPATH' ) || exit;
 
@@ -20,22 +21,36 @@ function extrachill_analytics_register_track_page_view_ability(): void {
 		'extrachill/track-page-view',
 		array(
 			'label'               => __( 'Track Page View', 'extrachill-analytics' ),
-			'description'         => __( 'Increment the view counter for a post. High-frequency endpoint called async after page load.', 'extrachill-analytics' ),
+			'description'         => __( 'Record a pageview for an eligible public route and increment legacy counters for valid post-backed views.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'post_id'    => array(
+					'post_id'      => array(
 						'type'        => 'integer',
-						'description' => __( 'The post ID to record a view for.', 'extrachill-analytics' ),
+						'description' => __( 'Optional post ID for a singular post-backed view.', 'extrachill-analytics' ),
+						'minimum'     => 1,
 					),
-					'referrer'   => array(
+					'source_path'  => array(
+						'type'        => 'string',
+						'description' => __( 'Normalized query-free browser route path.', 'extrachill-analytics' ),
+						'maxLength'   => 512,
+					),
+					'route_family' => array(
+						'type'        => 'string',
+						'description' => __( 'Bounded browser route family.', 'extrachill-analytics' ),
+						'enum'        => extrachill_analytics_route_families(),
+					),
+					'referrer'     => array(
 						'type'        => 'string',
 						'description' => __( 'Optional raw client-side referrer (document.referrer). Normalized server-side to a host-only `referrer_host` (no query strings, no PII) on the pageview event. Empty for direct traffic.', 'extrachill-analytics' ),
 						'default'     => '',
 					),
 				),
-				'required'   => array( 'post_id' ),
+				'anyOf'      => array(
+					array( 'required' => array( 'post_id' ) ),
+					array( 'required' => array( 'source_path', 'route_family' ) ),
+				),
 			),
 			'output_schema'       => array(
 				'type'        => 'object',
@@ -70,18 +85,31 @@ function extrachill_analytics_register_track_page_view_ability(): void {
  * @return array{recorded: bool}|WP_Error Confirmation or error.
  */
 function extrachill_analytics_ability_track_page_view( array $input ) {
-	$post_id    = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
-	$referrer   = isset( $input['referrer'] ) ? (string) $input['referrer'] : '';
+	$post_id      = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
+	$referrer     = isset( $input['referrer'] ) ? (string) $input['referrer'] : '';
+	$source_path  = isset( $input['source_path'] ) ? extrachill_analytics_normalize_route_path( $input['source_path'] ) : '';
+	$route_family = isset( $input['route_family'] ) ? sanitize_key( $input['route_family'] ) : '';
 
-	if ( $post_id <= 0 ) {
+	// The deployed Extra Chill API adapter still calls this ability directly
+	// with post_id/referrer. Keep that valid while browser writes move to Core's
+	// Abilities REST runner and carry the complete route contract.
+	if ( $post_id > 0 && '' === $source_path ) {
+		$permalink   = get_permalink( $post_id );
+		$source_path = is_string( $permalink ) ? extrachill_analytics_normalize_route_path( $permalink ) : '';
+	}
+	if ( $post_id > 0 && '' === $route_family ) {
+		$route_family = 'singular';
+	}
+
+	if ( '' === $source_path || ! in_array( $route_family, extrachill_analytics_route_families(), true ) ) {
 		return new \WP_Error(
-			'invalid_post_id',
-			__( 'A valid post_id is required.', 'extrachill-analytics' ),
+			'invalid_route',
+			__( 'A normalized source_path and valid route_family are required.', 'extrachill-analytics' ),
 			array( 'status' => 400 )
 		);
 	}
 
-	if ( ! function_exists( 'ec_track_post_views' ) ) {
+	if ( $post_id > 0 && ! function_exists( 'ec_track_post_views' ) ) {
 		return new \WP_Error(
 			'function_missing',
 			__( 'View tracking function not available.', 'extrachill-analytics' ),
@@ -95,9 +123,16 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 	// REST response can safely mint the HttpOnly cookie for a first cached visit
 	// because response headers have not been sent yet. GPC/DNT returns an empty
 	// value and keeps the pageview anonymous.
-	$visitor_id = '';
+	$visitor_id            = '';
 	$is_first_party_beacon = function_exists( 'extrachill_analytics_beacon_is_first_party' )
 		&& extrachill_analytics_beacon_is_first_party();
+	if ( $post_id <= 0 && ! $is_first_party_beacon ) {
+		return new \WP_Error(
+			'invalid_route_origin',
+			__( 'Route-level views must originate on the first-party network.', 'extrachill-analytics' ),
+			array( 'status' => 403 )
+		);
+	}
 
 	// Do not stitch a custom-domain request even if a browser permits its
 	// third-party cookie. Cross-site beacons have no durable first-party
@@ -114,8 +149,10 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 		$visitor_id = extrachill_analytics_get_or_mint_visitor_id();
 	}
 
-	// All-time view increment (post meta) — retained for theme back-compat.
-	ec_track_post_views( $post_id );
+	// All-time view increment (post meta) is retained only for post-backed views.
+	if ( $post_id > 0 ) {
+		ec_track_post_views( $post_id );
+	}
 
 	// Write a deterministic pageview event row so per-visitor retention can be
 	// queried. visitor_id is persisted only when it is a valid UUID v4; an empty
@@ -138,8 +175,14 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 		&& 'browser' !== extrachill_analytics_classify_user_agent( $user_agent );
 
 	if ( ! $is_bot && function_exists( 'extrachill_track_analytics_event' ) ) {
-		$permalink  = get_permalink( $post_id );
-		$event_data = array( 'post_id' => $post_id );
+		$permalink  = $post_id > 0 ? get_permalink( $post_id ) : home_url( $source_path );
+		$event_data = array(
+			'route_family' => $route_family,
+			'view_kind'    => $post_id > 0 ? 'post' : 'route',
+		);
+		if ( $post_id > 0 ) {
+			$event_data['post_id'] = $post_id;
+		}
 
 		// Stamp a NORMALIZED, host-only referrer provenance on the pageview so
 		// AI-citation (chatgpt.com / perplexity.ai / gemini.google.com), social,
@@ -180,7 +223,7 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 	}
 
 	// Link pages also fire the 90-day daily-table action.
-	if ( get_post_type( $post_id ) === 'artist_link_page' ) {
+	if ( $post_id > 0 && get_post_type( $post_id ) === 'artist_link_page' ) {
 		do_action( 'extrachill_link_page_view_recorded', $post_id );
 	}
 

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -261,7 +261,22 @@ function extrachill_analytics_get_or_mint_visitor_id() {
 function extrachill_analytics_should_prime_visitor_cookie() {
 	if (
 		extrachill_analytics_visitor_opted_out()
-		|| is_preview()
+		|| ! extrachill_analytics_is_eligible_public_template_request()
+	) {
+		return false;
+	}
+
+	return extrachill_analytics_request_host_is_first_party();
+}
+
+/**
+ * Whether the current request is a safe public browser template request.
+ *
+ * @return bool True for frontend GET/HEAD template requests.
+ */
+function extrachill_analytics_is_eligible_public_template_request() {
+	if (
+		is_preview()
 		|| is_admin()
 		|| wp_doing_ajax()
 		|| wp_doing_cron()
@@ -277,6 +292,16 @@ function extrachill_analytics_should_prime_visitor_cookie() {
 	if ( ! in_array( $request_method, array( 'GET', 'HEAD' ), true ) ) {
 		return false;
 	}
+
+	return true;
+}
+
+/**
+ * Whether the current template host belongs to the first-party network.
+ *
+ * @return bool True for the cookie domain or one of its subdomains.
+ */
+function extrachill_analytics_request_host_is_first_party() {
 
 	$request_host  = isset( $_SERVER['HTTP_HOST'] )
 		? wp_parse_url( 'https://' . sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ), PHP_URL_HOST )
@@ -369,10 +394,25 @@ add_action( 'wp_enqueue_scripts', 'extrachill_analytics_register_chart_asset', 5
 add_action( 'admin_enqueue_scripts', 'extrachill_analytics_register_chart_asset', 5 );
 
 /**
- * Enqueue view tracking script on singular pages.
+ * Enqueue view tracking on eligible public routes.
  */
 function extrachill_analytics_enqueue_view_tracking() {
-	if ( ! is_singular() || is_preview() ) {
+	if ( ! extrachill_analytics_is_eligible_public_template_request() ) {
+		return;
+	}
+
+	$post_id = is_singular() ? get_the_ID() : 0;
+	// Existing custom-domain singular views remain anonymous and post-backed;
+	// route-level collection is first-party only.
+	if ( $post_id <= 0 && ! extrachill_analytics_request_host_is_first_party() ) {
+		return;
+	}
+
+	$request_uri = isset( $_SERVER['REQUEST_URI'] )
+		? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+		: '/';
+	$source_path = extrachill_analytics_normalize_route_path( $request_uri );
+	if ( '' === $source_path ) {
 		return;
 	}
 
@@ -396,8 +436,10 @@ function extrachill_analytics_enqueue_view_tracking() {
 		'extrachill-view-tracking',
 		'ecViewTracking',
 		array(
-			'postId'   => get_the_ID(),
-			'endpoint' => rest_url( 'extrachill/v1/analytics/view' ),
+			'postId'      => $post_id,
+			'sourcePath'  => $source_path,
+			'routeFamily' => extrachill_analytics_classify_current_route( $source_path ),
+			'endpoint'    => rest_url( 'wp-abilities/v1/abilities/extrachill/track-page-view/run' ),
 		)
 	);
 }

--- a/inc/core/route-classifier.php
+++ b/inc/core/route-classifier.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Public route normalization and classification.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalize a browser route to a bounded, query-free path.
+ *
+ * @param string $route Raw URL or path.
+ * @return string Normalized path, or an empty string when invalid.
+ */
+function extrachill_analytics_normalize_route_path( $route ) {
+	$route = trim( (string) $route );
+	if ( '' === $route || false !== strpos( $route, "\0" ) ) {
+		return '';
+	}
+
+	$path = wp_parse_url( $route, PHP_URL_PATH );
+	if ( ! is_string( $path ) ) {
+		return '';
+	}
+
+	$path = '/' . ltrim( $path, '/' );
+	$path = preg_replace( '#/+#', '/', $path );
+	if ( ! is_string( $path ) ) {
+		return '';
+	}
+
+	// Keep malformed or attacker-generated paths from creating unbounded rows.
+	return substr( $path, 0, 512 );
+}
+
+/**
+ * Return the route families accepted by pageview events.
+ *
+ * @return string[] Route family slugs.
+ */
+function extrachill_analytics_route_families() {
+	return array( 'singular', 'home', 'archive', 'search', 'auth', 'directory', 'other' );
+}
+
+/**
+ * Classify the current frontend template into a bounded route family.
+ *
+ * @param string $path Normalized current path.
+ * @return string Route family slug.
+ */
+function extrachill_analytics_classify_current_route( $path ) {
+	$path = extrachill_analytics_normalize_route_path( $path );
+
+	if ( function_exists( 'is_search' ) && is_search() ) {
+		return 'search';
+	}
+
+	if ( '/' === $path || ( function_exists( 'is_front_page' ) && is_front_page() ) || ( function_exists( 'is_home' ) && is_home() ) ) {
+		return 'home';
+	}
+
+	if ( preg_match( '#^/(login|log-in|signin|sign-in|register|sign-up|signup|account|wp-login\.php)(/|$)#i', $path ) ) {
+		return 'auth';
+	}
+
+	if ( function_exists( 'is_archive' ) && is_archive() ) {
+		return 'archive';
+	}
+
+	if ( function_exists( 'is_singular' ) && is_singular() ) {
+		return 'singular';
+	}
+
+	if ( preg_match( '#^/(events|forums?|members?|artists?|venues?|locations?|festivals?|directory|newsletter)(/|$)#i', $path ) ) {
+		return 'directory';
+	}
+
+	return 'other';
+}

--- a/tests/ConversionMapScopeTest.php
+++ b/tests/ConversionMapScopeTest.php
@@ -66,17 +66,16 @@ final class ConversionMapScopeTest extends TestCase {
 	}
 
 	/**
-	 * Homepage and archive events have no post ID, so they are explicitly outside
-	 * the current post-view collector's destination scope.
+	 * Route-level destinations count without becoming editorial entries.
 	 */
-	public function test_homepage_and_archive_destinations_are_not_counted(): void {
+	public function test_homepage_and_archive_destinations_are_counted(): void {
 		$platform = array(
 			7 => 'events',
 			2 => 'community',
 			4 => 'artist',
 		);
 
-		$this->assertFalse(
+		$this->assertTrue(
 			extrachill_analytics_conversion_is_measured_platform_event(
 				array(
 					'blog_id' => 7,
@@ -85,7 +84,7 @@ final class ConversionMapScopeTest extends TestCase {
 				$platform
 			)
 		);
-		$this->assertFalse(
+		$this->assertTrue(
 			extrachill_analytics_conversion_is_measured_platform_event(
 				array(
 					'blog_id' => 2,
@@ -99,6 +98,15 @@ final class ConversionMapScopeTest extends TestCase {
 				array(
 					'blog_id' => 4,
 					'post_id' => 99,
+				),
+				$platform
+			)
+		);
+		$this->assertFalse(
+			extrachill_analytics_conversion_is_measured_platform_event(
+				array(
+					'blog_id' => 9,
+					'post_id' => 0,
 				),
 				$platform
 			)

--- a/tests/RouteJourneyTrackingTest.php
+++ b/tests/RouteJourneyTrackingTest.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Tests for non-singular route journey collection.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/route-classifier.php';
+require_once dirname( __DIR__ ) . '/inc/core/referrer-host-classifier.php';
+require_once dirname( __DIR__ ) . '/inc/core/assets.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities/track-page-view.php';
+
+/**
+ * Verify route identity stays bounded, query-free, and cache-safe.
+ */
+final class RouteJourneyTrackingTest extends TestCase {
+	/**
+	 * Establish a first-party browser beacon fixture.
+	 */
+	protected function setUp(): void {
+		$_SERVER['HTTP_HOST']                                    = 'events.extrachill.com';
+		$_SERVER['HTTP_ORIGIN']                                  = 'https://events.extrachill.com';
+		$_SERVER['HTTP_USER_AGENT']                              = 'Mozilla/5.0';
+		$_SERVER['REQUEST_METHOD']                               = 'GET';
+		$_COOKIE['ec_vid']                                       = '123e4567-e89b-42d3-a456-426614174000';
+		$GLOBALS['extrachill_analytics_test_tracked_post_views'] = array();
+		$GLOBALS['extrachill_analytics_test_events']             = array();
+		$GLOBALS['extrachill_analytics_test_actions']            = array();
+	}
+
+	/**
+	 * Restore conditional fixtures after each test.
+	 */
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['extrachill_analytics_test_is_singular'],
+			$GLOBALS['extrachill_analytics_test_is_search'],
+			$GLOBALS['extrachill_analytics_test_is_front_page'],
+			$GLOBALS['extrachill_analytics_test_is_home'],
+			$GLOBALS['extrachill_analytics_test_is_archive'],
+			$_SERVER['HTTP_HOST'],
+			$_SERVER['HTTP_ORIGIN'],
+			$_SERVER['HTTP_USER_AGENT'],
+			$_SERVER['HTTP_SEC_GPC'],
+			$_SERVER['REQUEST_METHOD'],
+			$_COOKIE['ec_vid']
+		);
+	}
+
+	/**
+	 * Query strings and fragments never enter the route identity.
+	 */
+	public function test_route_path_normalization_removes_query_and_fragment(): void {
+		$this->assertSame( '/', extrachill_analytics_normalize_route_path( 'https://extrachill.com/?s=user@example.com' ) );
+		$this->assertSame( '/events/charleston/', extrachill_analytics_normalize_route_path( '/events//charleston/?utm_source=email#shows' ) );
+		$this->assertSame( '/register/', extrachill_analytics_normalize_route_path( 'register/?email=user@example.com' ) );
+		$this->assertSame( '', extrachill_analytics_normalize_route_path( '' ) );
+	}
+
+	/**
+	 * Public route families cover the required network surfaces.
+	 *
+	 * @dataProvider route_family_provider
+	 *
+	 * @param string $path     Browser route path.
+	 * @param string $fixture  Conditional fixture global, or empty.
+	 * @param string $expected Expected bounded family.
+	 */
+	public function test_public_routes_have_bounded_families( $path, $fixture, $expected ): void {
+		if ( '' !== $fixture ) {
+			$GLOBALS[ $fixture ] = true;
+		}
+
+		$this->assertSame( $expected, extrachill_analytics_classify_current_route( $path ) );
+		$this->assertContains( $expected, extrachill_analytics_route_families() );
+	}
+
+	/**
+	 * Route classification fixtures.
+	 *
+	 * @return array<string,array{string,string,string}>
+	 */
+	public function route_family_provider() {
+		return array(
+			'homepage'       => array( '/', '', 'home' ),
+			'archive'        => array( '/2026/07/', 'extrachill_analytics_test_is_archive', 'archive' ),
+			'search results' => array( '/?s=dead', 'extrachill_analytics_test_is_search', 'search' ),
+			'login'          => array( '/login/', '', 'auth' ),
+			'register'       => array( '/register/', '', 'auth' ),
+			'directory'      => array( '/events/', '', 'directory' ),
+			'singular post'  => array( '/story/', 'extrachill_analytics_test_is_singular', 'singular' ),
+			'singular event' => array( '/events/show/', 'extrachill_analytics_test_is_singular', 'singular' ),
+			'other public'   => array( '/about/', '', 'other' ),
+		);
+	}
+
+	/**
+	 * Browser writes use Core's ability runner and its required input envelope.
+	 */
+	public function test_browser_uses_core_abilities_runner_contract(): void {
+		$assets  = $this->read_source( 'inc/core/assets.php' );
+		$script  = $this->read_source( 'assets/js/view-tracking.js' );
+		$ability = $this->read_source( 'inc/core/abilities/track-page-view.php' );
+
+		$this->assertStringContainsString( "rest_url( 'wp-abilities/v1/abilities/extrachill/track-page-view/run' )", $assets );
+		$this->assertStringContainsString( 'JSON.stringify( { input } )', $script );
+		$this->assertStringContainsString( 'source_path: config.sourcePath', $script );
+		$this->assertStringContainsString( 'route_family: config.routeFamily', $script );
+		$this->assertStringNotContainsString( "rest_url( 'extrachill/v1/analytics/view' )", $assets );
+		$this->assertStringContainsString( "array( 'required' => array( 'post_id' ) )", $ability );
+		$this->assertStringContainsString( "array( 'required' => array( 'source_path', 'route_family' ) )", $ability );
+	}
+
+	/**
+	 * Route events cannot increment post counters or link-page actions.
+	 */
+	public function test_post_side_effects_remain_guarded_by_valid_post_id(): void {
+		$ability = $this->read_source( 'inc/core/abilities/track-page-view.php' );
+
+		$this->assertStringContainsString( 'if ( $post_id > 0 ) {', $ability );
+		$this->assertStringContainsString( "if ( \$post_id > 0 && get_post_type( \$post_id ) === 'artist_link_page' )", $ability );
+		$this->assertStringContainsString( "'view_kind'    => \$post_id > 0 ? 'post' : 'route'", $ability );
+		$this->assertStringContainsString( 'if ( $post_id <= 0 && ! $is_first_party_beacon )', $ability );
+	}
+
+	/**
+	 * A first-party route writes one route event and no post side effects.
+	 */
+	public function test_first_party_route_view_writes_event_only(): void {
+		$result = extrachill_analytics_ability_track_page_view(
+			array(
+				'source_path'  => '/events/?city=charleston',
+				'route_family' => 'directory',
+				'referrer'     => 'https://extrachill.com/story/?email=user@example.com',
+			)
+		);
+
+		$this->assertSame( array( 'recorded' => true ), $result );
+		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_tracked_post_views'] );
+		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_actions'] );
+		$this->assertCount( 1, $GLOBALS['extrachill_analytics_test_events'] );
+		$this->assertSame( 'route', $GLOBALS['extrachill_analytics_test_events'][0][1]['view_kind'] );
+		$this->assertSame( 'directory', $GLOBALS['extrachill_analytics_test_events'][0][1]['route_family'] );
+		$this->assertArrayNotHasKey( 'post_id', $GLOBALS['extrachill_analytics_test_events'][0][1] );
+		$this->assertSame( 'extrachill.com', $GLOBALS['extrachill_analytics_test_events'][0][1]['referrer_host'] );
+		$this->assertSame( 'https://extrachill.com/events/', $GLOBALS['extrachill_analytics_test_events'][0][2] );
+	}
+
+	/**
+	 * Third-party route views are rejected rather than stitched or stored.
+	 */
+	public function test_custom_domain_route_view_is_rejected(): void {
+		$_SERVER['HTTP_ORIGIN'] = 'https://artist.example';
+
+		$result = extrachill_analytics_ability_track_page_view(
+			array(
+				'source_path'  => '/directory/',
+				'route_family' => 'directory',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_route_origin', $result->code );
+		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_events'] );
+	}
+
+	/**
+	 * GPC suppresses identity without suppressing anonymous aggregate views.
+	 */
+	public function test_privacy_opt_out_preserves_anonymous_route_eligibility(): void {
+		$_SERVER['HTTP_SEC_GPC'] = '1';
+
+		$this->assertTrue( extrachill_analytics_is_eligible_public_template_request() );
+		$this->assertFalse( extrachill_analytics_should_prime_visitor_cookie() );
+	}
+
+	/**
+	 * Singular posts retain legacy counters and artist link-page actions.
+	 */
+	public function test_post_backed_view_preserves_legacy_side_effects(): void {
+		$GLOBALS['extrachill_analytics_test_permalinks'][42] = 'https://artist.extrachill.com/example/';
+		$GLOBALS['extrachill_analytics_test_post_types'][42] = 'artist_link_page';
+
+		$result = extrachill_analytics_ability_track_page_view(
+			array(
+				'post_id'      => 42,
+				'source_path'  => '/example/',
+				'route_family' => 'singular',
+			)
+		);
+
+		$this->assertSame( array( 'recorded' => true ), $result );
+		$this->assertSame( array( 42 ), $GLOBALS['extrachill_analytics_test_tracked_post_views'] );
+		$this->assertSame( 'extrachill_link_page_view_recorded', $GLOBALS['extrachill_analytics_test_actions'][0][0] );
+		$this->assertSame( 'post', $GLOBALS['extrachill_analytics_test_events'][0][1]['view_kind'] );
+		$this->assertSame( 42, $GLOBALS['extrachill_analytics_test_events'][0][1]['post_id'] );
+	}
+
+	/**
+	 * Retention reports disclose mixed historical collection coverage.
+	 */
+	public function test_retention_contract_discloses_historical_coverage(): void {
+		$retention = $this->read_source( 'inc/core/abilities/get-retention-stats.php' );
+
+		$this->assertStringContainsString( "'collection_coverage'", $retention );
+		$this->assertStringContainsString( "'post_backed_pageviews'", $retention );
+		$this->assertStringContainsString( "'route_pageviews'", $retention );
+		$this->assertStringContainsString( "'historical_unclassified_pageviews'", $retention );
+		$this->assertStringContainsString( 'periods spanning deployment', $retention );
+	}
+
+	/**
+	 * Read a production source file.
+	 *
+	 * @param string $relative_path Repository-relative path.
+	 * @return string
+	 */
+	private function read_source( $relative_path ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local source fixtures.
+		$source = file_get_contents( dirname( __DIR__ ) . '/' . $relative_path );
+		$this->assertNotFalse( $source );
+		return $source;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,7 @@ if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 }
 
 require_once __DIR__ . '/class-wp-post.php';
+require_once __DIR__ . '/class-wp-error.php';
 
 // Minimal WordPress function stubs (only when a real WP is not present). These
 // are intentional polyfill stubs for the unit-test harness, written to satisfy
@@ -49,6 +50,17 @@ if ( ! function_exists( 'add_action' ) ) {
 	 */
 	function add_action( ...$args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		return true;
+	}
+}
+if ( ! function_exists( '__' ) ) {
+	/**
+	 * Return untranslated fixture text.
+	 *
+	 * @param string $text Text to translate.
+	 * @return string Original text.
+	 */
+	function __( $text ) {
+		return $text;
 	}
 }
 if ( ! function_exists( 'apply_filters' ) ) {
@@ -194,6 +206,56 @@ if ( ! function_exists( 'is_preview' ) ) {
 		return ! empty( $GLOBALS['extrachill_analytics_test_is_preview'] );
 	}
 }
+if ( ! function_exists( 'is_singular' ) ) {
+	/**
+	 * Return the singular-route fixture state.
+	 *
+	 * @return bool Whether the route is singular.
+	 */
+	function is_singular() {
+		return ! empty( $GLOBALS['extrachill_analytics_test_is_singular'] );
+	}
+}
+if ( ! function_exists( 'is_search' ) ) {
+	/**
+	 * Return the search-route fixture state.
+	 *
+	 * @return bool Whether the route is search results.
+	 */
+	function is_search() {
+		return ! empty( $GLOBALS['extrachill_analytics_test_is_search'] );
+	}
+}
+if ( ! function_exists( 'is_front_page' ) ) {
+	/**
+	 * Return the front-page fixture state.
+	 *
+	 * @return bool Whether the route is the front page.
+	 */
+	function is_front_page() {
+		return ! empty( $GLOBALS['extrachill_analytics_test_is_front_page'] );
+	}
+}
+if ( ! function_exists( 'is_home' ) ) {
+	/**
+	 * Return the posts-home fixture state.
+	 *
+	 * @return bool Whether the route is the posts home.
+	 */
+	function is_home() {
+		return ! empty( $GLOBALS['extrachill_analytics_test_is_home'] );
+	}
+}
+if ( ! function_exists( 'is_archive' ) ) {
+	/**
+	 * Return the archive-route fixture state.
+	 *
+	 * @return bool Whether the route is an archive.
+	 */
+	function is_archive() {
+		return ! empty( $GLOBALS['extrachill_analytics_test_is_archive'] );
+	}
+}
 if ( ! function_exists( 'is_admin' ) ) {
 	/**
 	 * Return the admin-request fixture state.
@@ -333,6 +395,65 @@ if ( ! function_exists( 'get_permalink' ) ) {
 		$post_id    = $post instanceof WP_Post ? (int) $post->ID : (int) $post;
 		$permalinks = isset( $GLOBALS['extrachill_analytics_test_permalinks'] ) ? $GLOBALS['extrachill_analytics_test_permalinks'] : array();
 		return isset( $permalinks[ $post_id ] ) ? (string) $permalinks[ $post_id ] : '';
+	}
+}
+if ( ! function_exists( 'ec_track_post_views' ) ) {
+	/**
+	 * Capture legacy post-counter increments.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	function ec_track_post_views( $post_id ) {
+		$GLOBALS['extrachill_analytics_test_tracked_post_views'][] = (int) $post_id;
+	}
+}
+if ( ! function_exists( 'get_post_type' ) ) {
+	/**
+	 * Return a post-type fixture.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Post type.
+	 */
+	function get_post_type( $post_id ) {
+		$types = isset( $GLOBALS['extrachill_analytics_test_post_types'] ) ? $GLOBALS['extrachill_analytics_test_post_types'] : array();
+		return isset( $types[ (int) $post_id ] ) ? $types[ (int) $post_id ] : 'post';
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	/**
+	 * Capture fired action hooks.
+	 *
+	 * @param string $hook Hook name.
+	 * @param mixed  ...$args Hook arguments.
+	 */
+	function do_action( $hook, ...$args ) {
+		$GLOBALS['extrachill_analytics_test_actions'][] = array( $hook, $args );
+	}
+}
+if ( ! function_exists( 'extrachill_analytics_classify_user_agent' ) ) {
+	/**
+	 * Classify a browser user-agent fixture.
+	 *
+	 * @param string $user_agent User agent.
+	 * @return string Browser or bot class.
+	 */
+	function extrachill_analytics_classify_user_agent( $user_agent ) {
+		return false !== stripos( (string) $user_agent, 'bot' ) ? 'bot' : 'browser';
+	}
+}
+if ( ! function_exists( 'extrachill_track_analytics_event' ) ) {
+	/**
+	 * Capture an analytics event write.
+	 *
+	 * @param string $event_type Event type.
+	 * @param array  $event_data Event payload.
+	 * @param string $source_url Source URL.
+	 * @param string $visitor_id Visitor UUID.
+	 * @return int Fixture event ID.
+	 */
+	function extrachill_track_analytics_event( $event_type, $event_data, $source_url, $visitor_id ) {
+		$GLOBALS['extrachill_analytics_test_events'][] = array( $event_type, $event_data, $source_url, $visitor_id );
+		return 1;
 	}
 }
 if ( ! function_exists( 'url_to_postid' ) ) {

--- a/tests/class-wp-error.php
+++ b/tests/class-wp-error.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Minimal WP_Error fixture.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	/**
+	 * Store an error code, message, and data for unit tests.
+	 */
+	class WP_Error {
+		/**
+		 * Error code.
+		 *
+		 * @var string
+		 */
+		public $code;
+
+		/**
+		 * Error message.
+		 *
+		 * @var string
+		 */
+		public $message;
+
+		/**
+		 * Error data.
+		 *
+		 * @var mixed
+		 */
+		public $data;
+
+		/**
+		 * Construct an error fixture.
+		 *
+		 * @param string $code    Error code.
+		 * @param string $message Error message.
+		 * @param mixed  $data    Error data.
+		 */
+		public function __construct( $code = '', $message = '', $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- collect eligible first-party homepage, archive, search, auth, directory, and other public route views in the existing `pageview` event table
- preserve post-meta counters and artist link-page actions only for valid post-backed views while keeping editorial conversion entries post-backed
- disclose post-backed, route-level, and historical collection coverage in retention diagnostics

## Route and write contract
- Browser writes use WordPress Core's `POST /wp-abilities/v1/abilities/extrachill/track-page-view/run` route with the required `{ input: ... }` envelope.
- Inputs accept either legacy `post_id` calls or normalized `source_path` plus bounded `route_family`; browser post views send both route identity and `post_id`.
- Route families are `singular`, `home`, `archive`, `search`, `auth`, `directory`, and `other`.
- `source_path` is query/fragment-free, slash-normalized, and capped at 512 bytes. The server constructs `source_url` on the current blog rather than accepting a client-provided full URL.
- Existing `pageview` rows gain `view_kind` and `route_family`; no new table, event type, endpoint, or journey substrate is introduced.
- Route views never increment post meta or fire `extrachill_link_page_view_recorded`. Valid singular views retain both behaviors.

## Existing primitive investigation
WordPress 6.9 Core already registers `WP_REST_Abilities_V1_Run_Controller` at `/wp-abilities/v1/abilities/<name>/run`. It enforces the ability annotations' POST method, normalizes and validates input, runs the ability permission callback, executes the callback, and validates output. The live runtime confirms that route exists and validates both the post-adapter and route input alternatives. Therefore this PR reuses Core's runner and does not require an Extra Chill API change. The existing API adapter remains compatible for post-only calls and is no longer required by the browser collector.

## Privacy and cache safeguards
- retains server-side `ec_vid` cookie resolution; no visitor ID enters localized/cacheable HTML or request bodies
- retains GPC/DNT behavior: no identity is minted or stored, while aggregate pageviews remain anonymous
- retains UUID v4 validation, UA bot rejection, host-only referrer normalization, and no query-string/PII storage
- rejects route-level writes from custom/third-party origins; existing custom-domain singular post views remain anonymous and post-backed
- excludes previews, admin, AJAX, cron, REST-render, CLI, and unsafe-method template requests

## Compatibility and diagnostics
- conversion-map entry sessions still require a published blog-1 post; route views can only count as eligible platform destinations
- retention output adds `collection_coverage` counts for post-backed, route-level, and historical unclassified rows
- output notes explicitly warn that historical periods before this deployment remain singular-only and mixed periods should not be interpreted as equivalent collection coverage

## Verification
- `vendor/bin/phpunit` (276 tests, 988 assertions)
- focused WordPress PHPCS: no errors; retention report retains its existing intentional direct-query warnings
- focused WordPress ESLint for `assets/js/view-tracking.js`: pass under Node 20
- `npm run build`: pass
- PHP syntax checks: pass
- WordPress REST schema validation: post adapter valid, route input valid, incomplete input rejected
- Core Abilities REST runner presence check: pass
- `git diff --check`: pass
- Homeboy review was not forced because its resource gate reported the host as hot and no Lab runner was available
- repository-wide JS lint remains blocked by 86 pre-existing errors outside this change

Closes #182