### PR TITLE
fix: filter encoded search attack probes

### DIFF
--- a/inc/core/security-classifier.php
+++ b/inc/core/security-classifier.php
@@ -42,7 +42,13 @@ function extrachill_analytics_classify_search_payload( $term ) {
 	$raw        = wp_unslash( $term );
 	$normalized = $raw;
 	$normalized = html_entity_decode( $normalized, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
-	$normalized = rawurldecode( $normalized );
+	for ( $decode_pass = 0; $decode_pass < 3; $decode_pass++ ) {
+		$decoded = rawurldecode( $normalized );
+		if ( $decoded === $normalized ) {
+			break;
+		}
+		$normalized = $decoded;
+	}
 
 	$catalog = array(
 		// Time-based blind SQLi — highest signal, near-zero false positives.
@@ -123,6 +129,12 @@ function extrachill_analytics_classify_search_payload( $term ) {
 			'pattern_family' => 'rce',
 			'regex'          => '/\bprint\s*\(\s*md5\s*\(\s*\d+\s*\)\s*\)/i',
 		),
+		array(
+			'pattern_name'   => 'code_exec_base64_probe',
+			'pattern_family' => 'rce',
+			// PHP payloads commonly pass encoded code directly to assert() or eval().
+			'regex'          => '/\b(?:assert|eval)\s*\(\s*base64_decode\s*\(/i',
+		),
 		// Path traversal.
 		array(
 			'pattern_name'   => 'path_traversal',
@@ -132,7 +144,7 @@ function extrachill_analytics_classify_search_payload( $term ) {
 		array(
 			'pattern_name'   => 'path_traversal',
 			'pattern_family' => 'lfi',
-			'regex'          => '/\/etc\/passwd\b/i',
+			'regex'          => '/\/etc\/(?:passwd|shadow|group|hosts|shells)\b/i',
 		),
 		// Scanner session markers — sqlmap / AcuneticX-style fingerprints.
 		array(

--- a/tests/GetSearchGapsSecurityFilterTest.php
+++ b/tests/GetSearchGapsSecurityFilterTest.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Search-gap report security-filter regression tests.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-search-gaps.php';
+
+/**
+ * Verifies that payload terms are removed before both result buckets aggregate.
+ */
+final class GetSearchGapsSecurityFilterTest extends TestCase {
+
+	/**
+	 * Restore the global database fixture.
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['wpdb'] );
+	}
+
+	/**
+	 * Observed and encoded payload families must not occupy either report bucket.
+	 */
+	public function test_payload_terms_are_excluded_from_zero_and_low_result_buckets(): void {
+		$attack_terms = array(
+			'/etc/shells',
+			'%252Fetc%252Fshells',
+			';assert(base64_decode("Q09NTUFORA=="));',
+			'%253Bassert%2528base64_decode%2528%2522U0FGRQ%253D%253D%2522%2529%2529%253B',
+		);
+
+		$GLOBALS['wpdb'] = new class( $attack_terms ) {
+			/**
+			 * Payload fixture terms.
+			 *
+			 * @var array<int,string>
+			 */
+			public $attack_terms;
+
+			/**
+			 * Values bound through wpdb::prepare().
+			 *
+			 * @var array<int,array<int,mixed>>
+			 */
+			public $prepared_values = array();
+
+			/**
+			 * Number of scalar aggregate queries handled.
+			 *
+			 * @var int
+			 */
+			private $get_var_calls = 0;
+
+			/**
+			 * Set payload fixture terms.
+			 *
+			 * @param array<int,string> $attack_terms Payload fixtures.
+			 */
+			public function __construct( $attack_terms ) {
+				$this->attack_terms = $attack_terms;
+			}
+
+			/**
+			 * Capture bound values while returning the query for fixture dispatch.
+			 *
+			 * @param string           $query  SQL query.
+			 * @param array<int,mixed> $values Bound values.
+			 * @return string
+			 */
+			public function prepare( $query, $values ) {
+				$this->prepared_values[] = (array) $values;
+				return $query;
+			}
+
+			/**
+			 * Return rows for each report query shape.
+			 *
+			 * @param string $query SQL query.
+			 * @return array<int,object>
+			 */
+			public function get_results( $query ) {
+				if ( false !== strpos( $query, 'MIN(' ) ) {
+					return array(
+						(object) array(
+							'term'        => 'AC/DC',
+							'min_results' => 0,
+							'zero_cnt'    => 5,
+							'low_cnt'     => 0,
+							'cnt'         => 5,
+						),
+						(object) array(
+							'term'        => 'P!nk',
+							'min_results' => 2,
+							'zero_cnt'    => 0,
+							'low_cnt'     => 3,
+							'cnt'         => 3,
+						),
+					);
+				}
+
+				if ( false !== strpos( $query, 'COALESCE(' ) ) {
+					return array(
+						(object) array(
+							'source'   => 'nav',
+							'cnt'      => 8,
+							'zero_cnt' => 5,
+						),
+					);
+				}
+
+				return array(
+					(object) array(
+						'term' => $this->attack_terms[0],
+						'cnt'  => 77,
+					),
+					(object) array(
+						'term' => $this->attack_terms[1],
+						'cnt'  => 4,
+					),
+					(object) array(
+						'term' => $this->attack_terms[2],
+						'cnt'  => 45,
+					),
+					(object) array(
+						'term' => $this->attack_terms[3],
+						'cnt'  => 3,
+					),
+					(object) array(
+						'term' => 'AC/DC',
+						'cnt'  => 5,
+					),
+					(object) array(
+						'term' => 'P!nk',
+						'cnt'  => 3,
+					),
+				);
+			}
+
+			/**
+			 * Return human total followed by the legacy-unclassified subset.
+			 *
+			 * @param string $query SQL query (unused in fixture).
+			 * @return int
+			 */
+			public function get_var( $query ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+				++$this->get_var_calls;
+				return 1 === $this->get_var_calls ? 8 : 3;
+			}
+		};
+
+		$report = extrachill_analytics_ability_get_search_gaps(
+			array(
+				'days'        => 0,
+				'limit'       => 10,
+				'max_results' => 3,
+			)
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'term'  => 'AC/DC',
+					'count' => 5,
+				),
+			),
+			$report['zero_result']
+		);
+		$this->assertSame(
+			array(
+				array(
+					'term'        => 'P!nk',
+					'count'       => 3,
+					'min_results' => 2,
+				),
+			),
+			$report['low_result']
+		);
+		$this->assertSame( 129, $report['excluded_attack_searches'] );
+		$this->assertSame( 4, $report['excluded_attack_terms'] );
+		$this->assertSame( 129, $report['excluded_bot'] );
+		$this->assertSame( 8, $report['total_searches'] );
+
+		$bound_values = array_merge( ...$GLOBALS['wpdb']->prepared_values );
+		foreach ( $attack_terms as $attack_term ) {
+			$this->assertContains( $attack_term, $bound_values );
+		}
+	}
+}

--- a/tests/SearchPayloadClassifierTest.php
+++ b/tests/SearchPayloadClassifierTest.php
@@ -15,6 +15,8 @@
 
 use PHPUnit\Framework\TestCase;
 
+require_once dirname( __DIR__ ) . '/inc/core/abilities.php';
+
 /**
  * Pins the live probe families from issue #133 plus the pre-existing catalog.
  */
@@ -59,6 +61,15 @@ final class SearchPayloadClassifierTest extends TestCase {
 			array( 'Gemfile', 'scanner', 'dependency_manifest_probe' ),
 			array( 'the/Gemfile', 'scanner', 'dependency_manifest_probe' ),
 			array( 'Gemfile.lock', 'scanner', 'dependency_manifest_probe' ),
+			// Unix file probes, including URL-encoded and double-encoded forms.
+			array( '/etc/shells', 'lfi', 'path_traversal' ),
+			array( '%2Fetc%2Fshells', 'lfi', 'path_traversal' ),
+			array( '%252Fetc%252Fshadow', 'lfi', 'path_traversal' ),
+			// Sanitized PHP assertion/eval payloads and encoded variants.
+			array( ';assert(base64_decode("Q09NTUFORA=="));', 'rce', 'code_exec_base64_probe' ),
+			array( 'eval(base64_decode("U0FGRV9GSVhUVVJF"))', 'rce', 'code_exec_base64_probe' ),
+			array( '%3Bassert%28base64_decode%28%22U0FGRQ%3D%3D%22%29%29%3B', 'rce', 'code_exec_base64_probe' ),
+			array( '%253Bassert%2528base64_decode%2528%2522U0FGRQ%253D%253D%2522%2529%2529%253B', 'rce', 'code_exec_base64_probe' ),
 		);
 		// phpcs:enable WordPress.Arrays.ArrayDeclarationSpacing
 	}
@@ -137,6 +148,14 @@ final class SearchPayloadClassifierTest extends TestCase {
 			array( 'Gemma' ),
 			array( 'memphis' ),
 			array( 'the jealous seas' ),
+			// Slash-heavy searches and artist punctuation remain human demand.
+			array( 'AC/DC' ),
+			array( '/artists/phish' ),
+			array( 'songs/base64' ),
+			array( 'assert yourself lyrics' ),
+			array( 'P!nk' ),
+			array( "Guns N' Roses" ),
+			array( 'Portugal. The Man' ),
 		);
 		// phpcs:enable WordPress.Arrays.ArrayDeclarationSpacing
 	}
@@ -147,5 +166,31 @@ final class SearchPayloadClassifierTest extends TestCase {
 	public function test_empty_input_is_benign() {
 		$this->assertNull( extrachill_analytics_classify_search_payload( '' ) );
 		$this->assertNull( extrachill_analytics_classify_search_payload( null ) );
+	}
+
+	/**
+	 * The write path must preserve attack telemetry while routing payload terms
+	 * away from ordinary search demand.
+	 */
+	public function test_payload_search_is_routed_to_search_attack() {
+		$GLOBALS['extrachill_analytics_test_events'] = array();
+
+		extrachill_analytics_ability_track_event(
+			array(
+				'event_type' => 'search',
+				'event_data' => array(
+					'search_term'  => '%252Fetc%252Fshells',
+					'result_count' => 2,
+				),
+			)
+		);
+
+		$this->assertCount( 1, $GLOBALS['extrachill_analytics_test_events'] );
+		$this->assertSame( 'search_attack', $GLOBALS['extrachill_analytics_test_events'][0][0] );
+		$this->assertSame( 'path_traversal', $GLOBALS['extrachill_analytics_test_events'][0][1]['classification'] );
+		$this->assertSame( 'lfi', $GLOBALS['extrachill_analytics_test_events'][0][1]['pattern_family'] );
+		$this->assertSame( 2, $GLOBALS['extrachill_analytics_test_events'][0][1]['result_count'] );
+
+		unset( $GLOBALS['extrachill_analytics_test_events'] );
 	}
 }


### PR DESCRIPTION
## Summary
- repeatedly URL-decode search terms within a bounded three-pass limit so encoded and double-encoded payloads reach the canonical classifier
- classify known Unix `/etc` file probes under the existing `path_traversal` / `lfi` taxonomy and direct `assert|eval(base64_decode(...))` forms as `code_exec_base64_probe` / `rce`
- verify write-time `search_attack` routing, read-time zero/low-result filtering, and preserved excluded-attack counters

## Classification boundaries
- Unix path matching is limited to `/etc/passwd`, `/etc/shadow`, `/etc/group`, `/etc/hosts`, and `/etc/shells`
- PHP RCE matching requires `assert()` or `eval()` to directly wrap `base64_decode()`
- benign slash searches and artist punctuation remain unclassified, including `AC/DC`, `/artists/phish`, `P!nk`, `Guns N' Roses`, and `Portugal. The Man`

## Tests
- `composer test` (292 tests, 1,031 assertions)
- focused classifier/report suite (44 tests, 84 assertions)
- changed-file WordPress PHPCS and PHP syntax checks
- WordPress runtime classifier smoke for raw/double-encoded attacks and benign terms
- read-only live 90-day fixture report: observed payloads absent from zero/low-result leaders; 1,296 attack searches across 207 terms remain counted as excluded
- `git diff --check`

Repository-wide PHPCS was also attempted; its unscoped `.` target scans installed vendor sources and reports pre-existing project baseline violations. Changed files pass, excluding the classifier's two pre-existing `$_SERVER` sanitation findings outside this patch.

Closes #187