### PR TITLE
fix: enforce ordered activation funnel progression

### DIFF
--- a/inc/core/abilities/get-activation-funnel.php
+++ b/inc/core/abilities/get-activation-funnel.php
@@ -39,11 +39,12 @@
  * (populated server-side from `get_current_user_id()`) is the authoritative,
  * reliably-present per-person identity — confirmed against live rows where
  * `artist_profile_created` has a non-NULL user_id on 100% of rows. The
- * anonymous first-party `visitor_id` is the fallback for any row whose user_id
- * is NULL (opted-out context or a pre-login emit), which keeps the same
- * member's pre/post-login path stitched into one identity. The dedup key is
- * therefore `COALESCE(NULLIF(user_id,0), visitor_id)`; a row with neither is
- * excluded from the per-person count (it cannot be attributed to a person).
+ * anonymous first-party `visitor_id` bridges pre-login events to a later row
+ * carrying both that visitor and a user identity. As elsewhere in analytics,
+ * `event_data.user_id` is preferred because registration is emitted before the
+ * new account becomes the current user; the stored `user_id` column is the
+ * fallback. A visitor observed with exactly one user is resolved to that user.
+ * Rows with neither identity are excluded from per-person counts.
  *
  * The window, UTC handling, and `since`/`as_of` reproducibility echo
  * get-analytics-summary so a caller can reconcile the two readers exactly.
@@ -100,52 +101,76 @@ function extrachill_analytics_register_activation_funnel_ability() {
 }
 
 /**
- * Count ordered funnel progression from a bounded event stream.
+ * Read activation rows in bounded keyset pages.
  *
- * Timestamps establish chronology; the event row ID breaks equal-timestamp
- * ties, matching the conversion-map stream ordering. A person advances only
- * when the event is their next required step. Later repeats may still advance
- * after an earlier out-of-order emit was ignored.
+ * The upper UTC bound applies even to all-time reports. `created_at, id`
+ * keyset pagination preserves deterministic equal-timestamp ordering without
+ * materializing the report window in PHP.
  *
- * @param array<object> $rows  Funnel event rows with person_id, event_type, ts, and id.
- * @param string[]      $steps Required steps in order.
- * @return int[] Ordered person counts corresponding to $steps.
+ * @param string   $table         Trusted analytics events table name.
+ * @param string[] $event_types   Activation event types to read.
+ * @param string[] $window_where  Prepared window/blog predicates.
+ * @param array    $window_values Values for the window/blog predicates.
+ * @param callable $consume       Receives each ordered page of event rows.
  */
-function extrachill_analytics_activation_ordered_counts( $rows, $steps ) {
-	$counts     = array_fill( 0, count( $steps ), 0 );
-	$step_index = array_flip( $steps );
-	$progress   = array();
+function extrachill_analytics_activation_each_event_page( $table, $event_types, $window_where, $window_values, $consume ) {
+	global $wpdb;
 
-	usort(
-		$rows,
-		static function ( $left, $right ) {
-			$person_order = strcmp( (string) $left->person_id, (string) $right->person_id );
-			if ( 0 !== $person_order ) {
-				return $person_order;
-			}
+	$page_size          = 500;
+	$event_placeholders = implode( ', ', array_fill( 0, count( $event_types ), '%s' ) );
+	$cursor_time        = null;
+	$cursor_id          = 0;
 
-			$time_order = (int) $left->ts <=> (int) $right->ts;
-			return 0 !== $time_order ? $time_order : (int) $left->id <=> (int) $right->id;
+	do {
+		$where  = array_merge( array( "event_type IN ({$event_placeholders})" ), $window_where );
+		$values = array_merge( array_map( 'sanitize_key', $event_types ), $window_values );
+
+		if ( null !== $cursor_time ) {
+			$where[]  = '(created_at > %s OR (created_at = %s AND id > %d))';
+			$values[] = $cursor_time;
+			$values[] = $cursor_time;
+			$values[] = $cursor_id;
 		}
-	);
+		$values[] = $page_size;
 
-	foreach ( $rows as $row ) {
-		$person_id  = (string) $row->person_id;
-		$event_type = (string) $row->event_type;
-		if ( '' === $person_id || ! isset( $step_index[ $event_type ] ) ) {
-			continue;
+		$where_clause = implode( ' AND ', $where );
+		// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery -- Bounded reporting page; identifiers are code-defined and every value is prepared.
+		$sql  = "SELECT id, event_type, event_data, user_id, visitor_id, created_at
+			FROM {$table}
+			WHERE {$where_clause}
+			ORDER BY created_at ASC, id ASC
+			LIMIT %d";
+		$page = (array) $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+		// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery
+
+		if ( empty( $page ) ) {
+			break;
 		}
 
-		$next_step = isset( $progress[ $person_id ] ) ? $progress[ $person_id ] : 0;
-		if ( $step_index[ $event_type ] !== $next_step ) {
-			continue;
-		}
+		$consume( $page );
+		$page_count  = count( $page );
+		$last        = end( $page );
+		$cursor_time = (string) $last->created_at;
+		$cursor_id   = (int) $last->id;
+	} while ( $page_count === $page_size );
+}
 
-		++$counts[ $next_step ];
-		$progress[ $person_id ] = $next_step + 1;
-	}
+/**
+ * Resolve the strongest user identity stored on an analytics event.
+ *
+ * Registration events carry the newly created user in event_data before that
+ * account is authenticated, matching conversion-map outcome deduplication.
+ *
+ * @param object $row Analytics event row.
+ * @return int Positive user ID, or 0 when unavailable.
+ */
+function extrachill_analytics_activation_event_user_id( $row ) {
+	$data = is_array( $row->event_data )
+		? $row->event_data
+		: json_decode( (string) $row->event_data, true );
+	$data = is_array( $data ) ? $data : array();
 
-	return $counts;
+	return (int) ( $data['user_id'] ?? ( $row->user_id ?? 0 ) );
 }
 
 /**
@@ -155,8 +180,6 @@ function extrachill_analytics_activation_ordered_counts( $rows, $steps ) {
  * @return array Funnel data.
  */
 function extrachill_analytics_ability_get_activation_funnel( $input ) {
-	global $wpdb;
-
 	$days    = isset( $input['days'] ) ? (int) $input['days'] : 28;
 	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
 
@@ -188,33 +211,83 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 		$window_values[] = $blog_id;
 	}
 
-	// Per-person dedup key: prefer the authoritative user_id column, fall back
-	// to the anonymous visitor_id so a pre-login emit still attributes to one
-	// person. A row with neither identity is excluded (can't be a "person").
-	$person_key = 'COALESCE(NULLIF(user_id, 0), visitor_id)';
+	$friction_events = defined( 'EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS' )
+		? EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS
+		: array( 'artist_profile_duplicate_created', 'user_reregistration_attempt' );
+	$event_types     = array_merge( $steps, $friction_events );
 
-	$step_placeholders = implode( ', ', array_fill( 0, count( $steps ), '%s' ) );
-	$where             = array_merge(
-		array( "event_type IN ({$step_placeholders})", "{$person_key} IS NOT NULL AND {$person_key} != ''" ),
-		$window_where
+	// First pass: observe real visitor-to-user bridges. A visitor shared by more
+	// than one user is deliberately left ambiguous rather than merging accounts.
+	$visitor_users = array();
+	extrachill_analytics_activation_each_event_page(
+		$table,
+		$event_types,
+		$window_where,
+		$window_values,
+		static function ( $page ) use ( &$visitor_users ) {
+			foreach ( $page as $row ) {
+				$user_id    = extrachill_analytics_activation_event_user_id( $row );
+				$visitor_id = trim( (string) $row->visitor_id );
+				if ( $user_id > 0 && '' !== $visitor_id ) {
+					$visitor_users[ $visitor_id ][ $user_id ] = true;
+				}
+			}
+		}
 	);
-	$values            = array_merge( array_map( 'sanitize_key', $steps ), $window_values );
-	$where_clause      = implode( ' AND ', $where );
 
-	// Read one bounded stream and enforce progression in row order. The ID is
-	// the deterministic tie-breaker when two events share a stored timestamp.
-	// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery -- This bounded reporting read has no stable cache key; $sql interpolates only code-defined identifiers and generated placeholders bound via prepare().
-	$sql = "SELECT id, event_type, {$person_key} AS person_id, UNIX_TIMESTAMP(created_at) AS ts
-		FROM {$table}
-		WHERE {$where_clause}
-		ORDER BY person_id ASC, created_at ASC, id ASC";
+	$visitor_to_user = array();
+	foreach ( $visitor_users as $visitor_id => $user_ids ) {
+		if ( 1 === count( $user_ids ) ) {
+			$visitor_to_user[ $visitor_id ] = (int) array_key_first( $user_ids );
+		}
+	}
 
-	$event_rows = $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
-	// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery
+	$step_index     = array_flip( $steps );
+	$friction_index = array_flip( $friction_events );
+	$ordered_counts = array_fill( 0, count( $steps ), 0 );
+	$progress       = array();
+	$anomaly_events = array_fill_keys( $friction_events, 0 );
+	$anomaly_people = array_fill_keys( $friction_events, array() );
 
-	$ordered_counts = extrachill_analytics_activation_ordered_counts( (array) $event_rows, $steps );
-	$step_rows      = array();
-	$top_count      = isset( $ordered_counts[0] ) ? $ordered_counts[0] : 0;
+	// Second pass: resolve every row through the observed bridge and advance the
+	// per-person state machine in deterministic stored event order.
+	extrachill_analytics_activation_each_event_page(
+		$table,
+		$event_types,
+		$window_where,
+		$window_values,
+		static function ( $page ) use ( &$ordered_counts, &$progress, &$anomaly_events, &$anomaly_people, $visitor_to_user, $step_index, $friction_index ) {
+			foreach ( $page as $row ) {
+				$user_id    = extrachill_analytics_activation_event_user_id( $row );
+				$visitor_id = trim( (string) $row->visitor_id );
+
+				if ( $user_id > 0 ) {
+					$person_id = 'user:' . $user_id;
+				} elseif ( '' !== $visitor_id && isset( $visitor_to_user[ $visitor_id ] ) ) {
+					$person_id = 'user:' . $visitor_to_user[ $visitor_id ];
+				} elseif ( '' !== $visitor_id ) {
+					$person_id = 'visitor:' . $visitor_id;
+				} else {
+					continue;
+				}
+
+				$event_type = (string) $row->event_type;
+				if ( isset( $step_index[ $event_type ] ) ) {
+					$next_step = isset( $progress[ $person_id ] ) ? $progress[ $person_id ] : 0;
+					if ( $step_index[ $event_type ] === $next_step ) {
+						++$ordered_counts[ $next_step ];
+						$progress[ $person_id ] = $next_step + 1;
+					}
+				} elseif ( isset( $friction_index[ $event_type ] ) ) {
+					++$anomaly_events[ $event_type ];
+					$anomaly_people[ $event_type ][ $person_id ] = true;
+				}
+			}
+		}
+	);
+
+	$step_rows = array();
+	$top_count = isset( $ordered_counts[0] ) ? $ordered_counts[0] : 0;
 
 	foreach ( $steps as $index => $event_type ) {
 		$step_rows[] = array(
@@ -271,36 +344,14 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 	// make funnel leaks visible: instead of a person silently vanishing between
 	// two steps, an anomaly count records the thrash. Counted by DISTINCT person
 	// over the SAME window and dedup key as the steps so they reconcile exactly.
-	$friction_events = defined( 'EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS' )
-		? EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS
-		: array( 'artist_profile_duplicate_created', 'user_reregistration_attempt' );
-
 	$anomalies = array();
 
 	foreach ( $friction_events as $event_type ) {
-		$where  = array( 'event_type = %s', "{$person_key} IS NOT NULL AND {$person_key} != ''" );
-		$values = array( sanitize_key( $event_type ) );
-
-		if ( ! empty( $window_where ) ) {
-			$where  = array_merge( $where, $window_where );
-			$values = array_merge( $values, $window_values );
-		}
-
-		$where_clause = implode( ' AND ', $where );
-
-		// Count DISTINCT people who hit this friction signal (people, not rows:
-		// a member who created three duplicate profiles is one thrashing person)
-		// AND the raw row volume (how much thrash that cohort generated).
-		// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery -- These bounded reporting reads have no stable cache key; both queries interpolate only code-defined identifiers and a placeholder where_clause bound via prepare().
-		$people_sql = "SELECT COUNT(DISTINCT {$person_key}) FROM {$table} WHERE {$where_clause}";
-		$events_sql = "SELECT COUNT(*) FROM {$table} WHERE {$where_clause}";
-
 		$anomalies[] = array(
 			'event_type' => $event_type,
-			'people'     => (int) $wpdb->get_var( $wpdb->prepare( $people_sql, $values ) ),
-			'events'     => (int) $wpdb->get_var( $wpdb->prepare( $events_sql, $values ) ),
+			'people'     => count( $anomaly_people[ $event_type ] ),
+			'events'     => $anomaly_events[ $event_type ],
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery
 	}
 
 	return array(
@@ -317,6 +368,6 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 		// same created_at >= since bound used by get-analytics-summary.
 		'since'                => $since,
 		'as_of'                => $now_utc,
-		'note'                 => 'Ordered per-person funnel: identity is COALESCE(NULLIF(user_id,0), visitor_id). Within the bounded UTC window, events are ordered by created_at then event row ID; equal timestamps therefore follow insertion order. A person counts at a step only after completing every prior step, and repeated emits count once. Rows with neither identity are excluded because their progression is unknowable; no identity is inferred. Counts here are intentionally NOT comparable to get-analytics-summary COUNT(*) raw volume. The anomalies array remains independent reach for activation friction signals over the same window: people is DISTINCT persons hitting that signal, events is raw row volume.',
+		'note'                 => 'Ordered per-person funnel: event_data.user_id (registration-safe) then stored user_id is authoritative; visitor_id is the anonymous fallback and is stitched to a user only when this window observes that visitor with exactly one user. Ambiguous visitors are not merged. Events are read in bounded keyset pages and ordered by created_at then event row ID; equal timestamps follow insertion order. A person counts at a step only after completing every prior step, and repeated emits count once. Rows with neither identity are excluded because their progression is unknowable. Counts are intentionally NOT comparable to get-analytics-summary COUNT(*) raw volume. The anomalies array remains independent reach over the same bounded stream.',
 	);
 }

--- a/inc/core/abilities/get-activation-funnel.php
+++ b/inc/core/abilities/get-activation-funnel.php
@@ -19,10 +19,10 @@
  * funnel: counting rows instead of people inflates the top of the funnel and
  * makes every downstream conversion % too low.
  *
- * This ability is the funnel's rightful reader: it iterates the ordered
- * `EC_ANALYTICS_ARTIST_ACTIVATION_STEPS` group and counts each step by
- * DISTINCT person, then computes step-to-step and overall conversion plus the
- * single biggest abandon step.
+ * This ability is the funnel's rightful reader: it walks each person's events
+ * in `created_at`, then row-ID order and counts a step only after that person
+ * completed every preceding step. Repeated and out-of-order emits therefore
+ * cannot inflate a downstream population.
  *
  * Friction / anomaly signals
  * --------------------------
@@ -62,7 +62,7 @@ function extrachill_analytics_register_activation_funnel_ability() {
 		'extrachill/get-activation-funnel',
 		array(
 			'label'               => __( 'Get Activation Funnel', 'extrachill-analytics' ),
-			'description'         => __( 'Returns the artist-signup activation funnel as a per-person funnel (DISTINCT user_id/visitor_id) with step-to-step and overall conversion and the biggest abandon step.', 'extrachill-analytics' ),
+			'description'         => __( 'Returns the artist-signup activation funnel as an ordered per-person funnel (user_id with visitor_id fallback) with step-to-step and overall conversion and the biggest abandon step.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -81,7 +81,7 @@ function extrachill_analytics_register_activation_funnel_ability() {
 			),
 			'output_schema'       => array(
 				'type'        => 'object',
-				'description' => __( 'Object with an ordered steps array (event_type, people, conversion_from_prev, conversion_from_top), the biggest_abandon_step, an anomalies array of friction signals (duplicate profile creation, re-registration attempts) each with DISTINCT people and raw event counts, and the exact UTC window.', 'extrachill-analytics' ),
+				'description' => __( 'Object with a chronologically ordered per-person steps array (event_type, people, conversion_from_prev, conversion_from_top), the biggest_abandon_step, an anomalies array of friction signals (duplicate profile creation, re-registration attempts) each with DISTINCT people and raw event counts, and the exact UTC window.', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_activation_funnel',
 			'permission_callback' => function () {
@@ -97,6 +97,55 @@ function extrachill_analytics_register_activation_funnel_ability() {
 			),
 		)
 	);
+}
+
+/**
+ * Count ordered funnel progression from a bounded event stream.
+ *
+ * Timestamps establish chronology; the event row ID breaks equal-timestamp
+ * ties, matching the conversion-map stream ordering. A person advances only
+ * when the event is their next required step. Later repeats may still advance
+ * after an earlier out-of-order emit was ignored.
+ *
+ * @param array<object> $rows  Funnel event rows with person_id, event_type, ts, and id.
+ * @param string[]      $steps Required steps in order.
+ * @return int[] Ordered person counts corresponding to $steps.
+ */
+function extrachill_analytics_activation_ordered_counts( $rows, $steps ) {
+	$counts     = array_fill( 0, count( $steps ), 0 );
+	$step_index = array_flip( $steps );
+	$progress   = array();
+
+	usort(
+		$rows,
+		static function ( $left, $right ) {
+			$person_order = strcmp( (string) $left->person_id, (string) $right->person_id );
+			if ( 0 !== $person_order ) {
+				return $person_order;
+			}
+
+			$time_order = (int) $left->ts <=> (int) $right->ts;
+			return 0 !== $time_order ? $time_order : (int) $left->id <=> (int) $right->id;
+		}
+	);
+
+	foreach ( $rows as $row ) {
+		$person_id  = (string) $row->person_id;
+		$event_type = (string) $row->event_type;
+		if ( '' === $person_id || ! isset( $step_index[ $event_type ] ) ) {
+			continue;
+		}
+
+		$next_step = isset( $progress[ $person_id ] ) ? $progress[ $person_id ] : 0;
+		if ( $step_index[ $event_type ] !== $next_step ) {
+			continue;
+		}
+
+		++$counts[ $next_step ];
+		$progress[ $person_id ] = $next_step + 1;
+	}
+
+	return $counts;
 }
 
 /**
@@ -125,8 +174,8 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 	$now_utc = gmdate( 'Y-m-d H:i:s' );
 	$since   = '';
 
-	$window_where  = array();
-	$window_values = array();
+	$window_where  = array( 'created_at <= %s' );
+	$window_values = array( $now_utc );
 
 	if ( $days > 0 ) {
 		$since           = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
@@ -144,35 +193,33 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 	// person. A row with neither identity is excluded (can't be a "person").
 	$person_key = 'COALESCE(NULLIF(user_id, 0), visitor_id)';
 
-	$step_rows = array();
-	$top_count = 0;
+	$step_placeholders = implode( ', ', array_fill( 0, count( $steps ), '%s' ) );
+	$where             = array_merge(
+		array( "event_type IN ({$step_placeholders})", "{$person_key} IS NOT NULL AND {$person_key} != ''" ),
+		$window_where
+	);
+	$values            = array_merge( array_map( 'sanitize_key', $steps ), $window_values );
+	$where_clause      = implode( ' AND ', $where );
+
+	// Read one bounded stream and enforce progression in row order. The ID is
+	// the deterministic tie-breaker when two events share a stored timestamp.
+	// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery -- This bounded reporting read has no stable cache key; $sql interpolates only code-defined identifiers and generated placeholders bound via prepare().
+	$sql = "SELECT id, event_type, {$person_key} AS person_id, UNIX_TIMESTAMP(created_at) AS ts
+		FROM {$table}
+		WHERE {$where_clause}
+		ORDER BY person_id ASC, created_at ASC, id ASC";
+
+	$event_rows = $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+	// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery
+
+	$ordered_counts = extrachill_analytics_activation_ordered_counts( (array) $event_rows, $steps );
+	$step_rows      = array();
+	$top_count      = isset( $ordered_counts[0] ) ? $ordered_counts[0] : 0;
 
 	foreach ( $steps as $index => $event_type ) {
-		$where  = array( 'event_type = %s', "{$person_key} IS NOT NULL AND {$person_key} != ''" );
-		$values = array( sanitize_key( $event_type ) );
-
-		if ( ! empty( $window_where ) ) {
-			$where  = array_merge( $where, $window_where );
-			$values = array_merge( $values, $window_values );
-		}
-
-		$where_clause = implode( ' AND ', $where );
-
-		// Count DISTINCT people who reached this step — not rows. This is the
-		// whole point: re-views of the form collapse to one person here.
-		// phpcs:disable WordPress.DB.PreparedSQL -- $sql interpolates only code-defined identifiers ($person_key, $table) and a placeholder where_clause bound via prepare().
-		$sql = "SELECT COUNT(DISTINCT {$person_key}) FROM {$table} WHERE {$where_clause}";
-
-		$people = (int) $wpdb->get_var( $wpdb->prepare( $sql, $values ) );
-		// phpcs:enable WordPress.DB.PreparedSQL
-
-		if ( 0 === $index ) {
-			$top_count = $people;
-		}
-
 		$step_rows[] = array(
 			'event_type' => $event_type,
-			'people'     => $people,
+			'people'     => $ordered_counts[ $index ],
 			'index'      => $index,
 		);
 	}
@@ -244,7 +291,7 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 		// Count DISTINCT people who hit this friction signal (people, not rows:
 		// a member who created three duplicate profiles is one thrashing person)
 		// AND the raw row volume (how much thrash that cohort generated).
-		// phpcs:disable WordPress.DB.PreparedSQL -- both queries interpolate only code-defined identifiers and a placeholder where_clause bound via prepare().
+		// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery -- These bounded reporting reads have no stable cache key; both queries interpolate only code-defined identifiers and a placeholder where_clause bound via prepare().
 		$people_sql = "SELECT COUNT(DISTINCT {$person_key}) FROM {$table} WHERE {$where_clause}";
 		$events_sql = "SELECT COUNT(*) FROM {$table} WHERE {$where_clause}";
 
@@ -253,7 +300,7 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 			'people'     => (int) $wpdb->get_var( $wpdb->prepare( $people_sql, $values ) ),
 			'events'     => (int) $wpdb->get_var( $wpdb->prepare( $events_sql, $values ) ),
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL
+		// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery
 	}
 
 	return array(
@@ -270,6 +317,6 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 		// same created_at >= since bound used by get-analytics-summary.
 		'since'                => $since,
 		'as_of'                => $now_utc,
-		'note'                 => 'Per-person funnel: each step is COUNT(DISTINCT COALESCE(NULLIF(user_id,0), visitor_id)), so multiple emits per person (e.g. re-views of the create form emitting artist_signup_started) collapse to one. Rows with neither identity are excluded. Counts here are intentionally NOT comparable to get-analytics-summary COUNT(*) raw volume. The anomalies array reports activation friction signals (duplicate profile creation, re-registration attempts) over the same window: people is DISTINCT persons hitting that signal, events is raw row volume.',
+		'note'                 => 'Ordered per-person funnel: identity is COALESCE(NULLIF(user_id,0), visitor_id). Within the bounded UTC window, events are ordered by created_at then event row ID; equal timestamps therefore follow insertion order. A person counts at a step only after completing every prior step, and repeated emits count once. Rows with neither identity are excluded because their progression is unknowable; no identity is inferred. Counts here are intentionally NOT comparable to get-analytics-summary COUNT(*) raw volume. The anomalies array remains independent reach for activation friction signals over the same window: people is DISTINCT persons hitting that signal, events is raw row volume.',
 	);
 }

--- a/tests/ActivationFunnelTest.php
+++ b/tests/ActivationFunnelTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Tests for ordered activation-funnel progression.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-activation-funnel.php';
+
+/**
+ * Protect chronological, per-person funnel semantics.
+ */
+final class ActivationFunnelTest extends TestCase {
+	/**
+	 * Required funnel steps used by every fixture.
+	 *
+	 * @var string[]
+	 */
+	private $steps = array( 'started', 'created', 'published' );
+
+	/**
+	 * Downstream-only events never enter an ordered funnel population.
+	 */
+	public function test_downstream_without_upstream_is_excluded(): void {
+		$rows = array(
+			$this->row( 1, 'person-a', 'created', 100 ),
+			$this->row( 2, 'person-a', 'published', 101 ),
+		);
+
+		$this->assertSame( array( 0, 0, 0 ), extrachill_analytics_activation_ordered_counts( $rows, $this->steps ) );
+	}
+
+	/**
+	 * An out-of-order step is ignored until it occurs after its prerequisite.
+	 */
+	public function test_out_of_order_events_do_not_advance_early(): void {
+		$rows = array(
+			$this->row( 1, 'person-a', 'started', 100 ),
+			$this->row( 2, 'person-a', 'published', 101 ),
+			$this->row( 3, 'person-a', 'created', 102 ),
+		);
+
+		$this->assertSame( array( 1, 1, 0 ), extrachill_analytics_activation_ordered_counts( $rows, $this->steps ) );
+	}
+
+	/**
+	 * Repeated lifecycle emits count a person once at each reached step.
+	 */
+	public function test_repeated_steps_do_not_inflate_people(): void {
+		$rows = array(
+			$this->row( 1, 'person-a', 'started', 100 ),
+			$this->row( 2, 'person-a', 'started', 101 ),
+			$this->row( 3, 'person-a', 'created', 102 ),
+			$this->row( 4, 'person-a', 'created', 103 ),
+			$this->row( 5, 'person-a', 'published', 104 ),
+		);
+
+		$this->assertSame( array( 1, 1, 1 ), extrachill_analytics_activation_ordered_counts( $rows, $this->steps ) );
+	}
+
+	/**
+	 * Equal timestamps use the stored event ID as insertion-order tie-breaker.
+	 */
+	public function test_equal_timestamps_are_ordered_by_event_id(): void {
+		$rows = array(
+			$this->row( 12, 'person-a', 'published', 100 ),
+			$this->row( 10, 'person-a', 'started', 100 ),
+			$this->row( 11, 'person-a', 'created', 100 ),
+		);
+
+		$this->assertSame( array( 1, 1, 1 ), extrachill_analytics_activation_ordered_counts( $rows, $this->steps ) );
+	}
+
+	/**
+	 * Independent people progress normally while unknown identity stays excluded.
+	 */
+	public function test_normal_progression_is_per_person_and_excludes_unknown_identity(): void {
+		$rows = array(
+			$this->row( 1, 'person-a', 'started', 100 ),
+			$this->row( 2, '', 'started', 101 ),
+			$this->row( 3, 'person-b', 'started', 102 ),
+			$this->row( 4, 'person-a', 'created', 103 ),
+			$this->row( 5, 'person-a', 'published', 104 ),
+		);
+
+		$this->assertSame( array( 2, 1, 1 ), extrachill_analytics_activation_ordered_counts( $rows, $this->steps ) );
+	}
+
+	/**
+	 * Build one event-row fixture.
+	 *
+	 * @param int    $id         Stored event ID.
+	 * @param string $person_id Person identity.
+	 * @param string $event_type Event type.
+	 * @param int    $timestamp  Event timestamp.
+	 * @return object Event row.
+	 */
+	private function row( $id, $person_id, $event_type, $timestamp ) {
+		return (object) array(
+			'id'         => $id,
+			'person_id'  => $person_id,
+			'event_type' => $event_type,
+			'ts'         => $timestamp,
+		);
+	}
+}

--- a/tests/ActivationFunnelTest.php
+++ b/tests/ActivationFunnelTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for ordered activation-funnel progression.
+ * Ability-level tests for ordered activation-funnel progression.
  *
  * @package ExtraChill\Analytics
  */
@@ -10,99 +10,217 @@ use PHPUnit\Framework\TestCase;
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-activation-funnel.php';
 
 /**
- * Protect chronological, per-person funnel semantics.
+ * Protect identity, ordering, response math, and read bounds.
  */
 final class ActivationFunnelTest extends TestCase {
 	/**
-	 * Required funnel steps used by every fixture.
+	 * Anonymous activity stitches to the one observed authenticated user, and
+	 * the public response uses ordered populations for every rate and drop.
+	 */
+	public function test_ability_stitches_identity_and_returns_ordered_drop_math(): void {
+		$rows = array(
+			$this->row( 1, 'artist_signup_started', 100, 0, 'visitor-a' ),
+			$this->row( 2, 'artist_profile_created', 101, 0, 'visitor-a', 10 ),
+			$this->row( 3, 'artist_profile_first_publish', 102, 10 ),
+			$this->row( 4, 'artist_signup_started', 103, 20 ),
+			$this->row( 5, 'artist_signup_started', 104, 30 ),
+			$this->row( 6, 'artist_profile_created', 105, 30 ),
+		);
+		$db   = $this->install_database( array( $rows, $rows ) );
+
+		$response = extrachill_analytics_ability_get_activation_funnel(
+			array(
+				'days'    => 28,
+				'blog_id' => 4,
+			)
+		);
+
+		$this->assertSame( array( 3, 2, 1 ), array_column( $response['steps'], 'people' ) );
+		$this->assertSame( 1.0, $response['steps'][0]['conversion_from_prev'] );
+		$this->assertSame( 0.6667, $response['steps'][1]['conversion_from_prev'] );
+		$this->assertSame( 0.5, $response['steps'][2]['conversion_from_prev'] );
+		$this->assertSame( 0.3333, $response['steps'][2]['conversion_from_top'] );
+		$this->assertSame( 0.3333, $response['overall_conversion'] );
+		$this->assertSame(
+			array(
+				'from_step' => 'artist_profile_created',
+				'to_step'   => 'artist_profile_first_publish',
+				'dropped'   => 1,
+				'drop_rate' => 0.5,
+			),
+			$response['biggest_abandon_step']
+		);
+		$this->assertCount( 2, $db->prepared_queries );
+		$this->assertStringContainsString( 'created_at <= %s', $db->prepared_queries[0]['query'] );
+		$this->assertStringContainsString( 'created_at >= %s', $db->prepared_queries[0]['query'] );
+		$this->assertStringContainsString( 'blog_id = %d', $db->prepared_queries[0]['query'] );
+	}
+
+	/**
+	 * Downstream-only and premature events do not advance, while later ordered
+	 * repeats can complete the path without inflating its populations.
+	 */
+	public function test_ability_enforces_order_and_deduplicates_repeats(): void {
+		$rows = array(
+			$this->row( 1, 'artist_profile_created', 100, 40 ),
+			$this->row( 2, 'artist_signup_started', 101, 40 ),
+			$this->row( 3, 'artist_profile_first_publish', 102, 40 ),
+			$this->row( 4, 'artist_signup_started', 103, 40 ),
+			$this->row( 5, 'artist_profile_created', 104, 40 ),
+			$this->row( 6, 'artist_profile_created', 105, 40 ),
+			$this->row( 7, 'artist_profile_first_publish', 106, 40 ),
+			$this->row( 8, 'artist_profile_first_publish', 107, 50 ),
+		);
+		$this->install_database( array( $rows, $rows ) );
+
+		$response = extrachill_analytics_ability_get_activation_funnel( array( 'days' => 28 ) );
+
+		$this->assertSame( array( 1, 1, 1 ), array_column( $response['steps'], 'people' ) );
+		$this->assertSame( 1.0, $response['overall_conversion'] );
+		$this->assertSame( 0, $response['biggest_abandon_step']['dropped'] );
+		$this->assertSame( 0.0, $response['biggest_abandon_step']['drop_rate'] );
+	}
+
+	/**
+	 * Equal timestamps follow row-ID order in the ability's persisted stream.
+	 */
+	public function test_ability_uses_event_id_for_equal_timestamp_ordering(): void {
+		$rows = array(
+			$this->row( 10, 'artist_signup_started', 100, 60 ),
+			$this->row( 11, 'artist_profile_created', 100, 60 ),
+			$this->row( 12, 'artist_profile_first_publish', 100, 60 ),
+		);
+		$db   = $this->install_database( array( $rows, $rows ) );
+
+		$response = extrachill_analytics_ability_get_activation_funnel( array( 'days' => 28 ) );
+
+		$this->assertSame( array( 1, 1, 1 ), array_column( $response['steps'], 'people' ) );
+		$this->assertStringContainsString( 'ORDER BY created_at ASC, id ASC', $db->prepared_queries[0]['query'] );
+	}
+
+	/**
+	 * All-time mode remains upper-bounded and keyset-paged on both identity and
+	 * progression passes rather than materializing every matching event.
+	 */
+	public function test_all_time_mode_is_upper_bounded_and_paged(): void {
+		$rows = array();
+		for ( $id = 1; $id <= 501; ++$id ) {
+			$rows[] = $this->row( $id, 'artist_signup_started', 100 + $id, 70 );
+		}
+		$first_page = array_slice( $rows, 0, 500 );
+		$last_page  = array_slice( $rows, 500 );
+		$db         = $this->install_database( array( $first_page, $last_page, $first_page, $last_page ) );
+
+		$response = extrachill_analytics_ability_get_activation_funnel( array( 'days' => 0 ) );
+
+		$this->assertSame( array( 1, 0, 0 ), array_column( $response['steps'], 'people' ) );
+		$this->assertCount( 4, $db->prepared_queries );
+		foreach ( $db->prepared_queries as $prepared ) {
+			$this->assertStringContainsString( 'created_at <= %s', $prepared['query'] );
+			$this->assertStringNotContainsString( 'created_at >= %s', $prepared['query'] );
+			$this->assertStringContainsString( 'LIMIT %d', $prepared['query'] );
+			$this->assertSame( 500, end( $prepared['args'] ) );
+		}
+		$this->assertStringContainsString( 'id > %d', $db->prepared_queries[1]['query'] );
+		$this->assertStringContainsString( 'id > %d', $db->prepared_queries[3]['query'] );
+	}
+
+	/**
+	 * Install a database fixture globally for the production callback.
 	 *
-	 * @var string[]
+	 * @param array<int,array<object>> $pages Ordered result pages.
+	 * @return object Database fixture.
 	 */
-	private $steps = array( 'started', 'created', 'published' );
+	private function install_database( $pages ) {
+		$db              = new class( $pages ) {
+			/**
+			 * Prepared queries and arguments.
+			 *
+			 * @var array<int,array{query:string,args:array}>
+			 */
+			public $prepared_queries = array();
 
-	/**
-	 * Downstream-only events never enter an ordered funnel population.
-	 */
-	public function test_downstream_without_upstream_is_excluded(): void {
-		$rows = array(
-			$this->row( 1, 'person-a', 'created', 100 ),
-			$this->row( 2, 'person-a', 'published', 101 ),
-		);
+			/**
+			 * Ordered pages returned by successive reads.
+			 *
+			 * @var array<int,array<object>>
+			 */
+			private $pages;
 
-		$this->assertSame( array( 0, 0, 0 ), extrachill_analytics_activation_ordered_counts( $rows, $this->steps ) );
+			/**
+			 * Current page index.
+			 *
+			 * @var int
+			 */
+			private $page_index = 0;
+
+			/**
+			 * Set fixture pages.
+			 *
+			 * @param array<int,array<object>> $fixture_pages Ordered query result pages.
+			 */
+			public function __construct( $fixture_pages ) {
+				$this->pages = $fixture_pages;
+			}
+
+			/**
+			 * Capture a prepared query.
+			 *
+			 * @param string $query SQL query.
+			 * @param mixed  ...$args Prepared values.
+			 * @return string Unchanged SQL query.
+			 */
+			public function prepare( $query, ...$args ) {
+				if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+					$args = $args[0];
+				}
+
+				$this->prepared_queries[] = array(
+					'query' => $query,
+					'args'  => $args,
+				);
+
+				return $query;
+			}
+
+			/**
+			 * Return the next configured result page.
+			 *
+			 * @param string $query SQL query (unused by the fixture).
+			 * @return array<object> Event rows.
+			 */
+			public function get_results( $query ) {
+				unset( $query );
+				$page = $this->pages[ $this->page_index ] ?? array();
+				++$this->page_index;
+
+				return $page;
+			}
+		};
+		$GLOBALS['wpdb'] = $db;
+
+		return $db;
 	}
 
 	/**
-	 * An out-of-order step is ignored until it occurs after its prerequisite.
-	 */
-	public function test_out_of_order_events_do_not_advance_early(): void {
-		$rows = array(
-			$this->row( 1, 'person-a', 'started', 100 ),
-			$this->row( 2, 'person-a', 'published', 101 ),
-			$this->row( 3, 'person-a', 'created', 102 ),
-		);
-
-		$this->assertSame( array( 1, 1, 0 ), extrachill_analytics_activation_ordered_counts( $rows, $this->steps ) );
-	}
-
-	/**
-	 * Repeated lifecycle emits count a person once at each reached step.
-	 */
-	public function test_repeated_steps_do_not_inflate_people(): void {
-		$rows = array(
-			$this->row( 1, 'person-a', 'started', 100 ),
-			$this->row( 2, 'person-a', 'started', 101 ),
-			$this->row( 3, 'person-a', 'created', 102 ),
-			$this->row( 4, 'person-a', 'created', 103 ),
-			$this->row( 5, 'person-a', 'published', 104 ),
-		);
-
-		$this->assertSame( array( 1, 1, 1 ), extrachill_analytics_activation_ordered_counts( $rows, $this->steps ) );
-	}
-
-	/**
-	 * Equal timestamps use the stored event ID as insertion-order tie-breaker.
-	 */
-	public function test_equal_timestamps_are_ordered_by_event_id(): void {
-		$rows = array(
-			$this->row( 12, 'person-a', 'published', 100 ),
-			$this->row( 10, 'person-a', 'started', 100 ),
-			$this->row( 11, 'person-a', 'created', 100 ),
-		);
-
-		$this->assertSame( array( 1, 1, 1 ), extrachill_analytics_activation_ordered_counts( $rows, $this->steps ) );
-	}
-
-	/**
-	 * Independent people progress normally while unknown identity stays excluded.
-	 */
-	public function test_normal_progression_is_per_person_and_excludes_unknown_identity(): void {
-		$rows = array(
-			$this->row( 1, 'person-a', 'started', 100 ),
-			$this->row( 2, '', 'started', 101 ),
-			$this->row( 3, 'person-b', 'started', 102 ),
-			$this->row( 4, 'person-a', 'created', 103 ),
-			$this->row( 5, 'person-a', 'published', 104 ),
-		);
-
-		$this->assertSame( array( 2, 1, 1 ), extrachill_analytics_activation_ordered_counts( $rows, $this->steps ) );
-	}
-
-	/**
-	 * Build one event-row fixture.
+	 * Build one stored analytics event fixture.
 	 *
-	 * @param int    $id         Stored event ID.
-	 * @param string $person_id Person identity.
-	 * @param string $event_type Event type.
-	 * @param int    $timestamp  Event timestamp.
+	 * @param int    $id              Stored event ID.
+	 * @param string $event_type      Event type.
+	 * @param int    $timestamp       Relative fixture timestamp.
+	 * @param int    $user_id         Stored authenticated user ID.
+	 * @param string $visitor_id      Anonymous visitor ID.
+	 * @param int    $payload_user_id User ID stored in event_data.
 	 * @return object Event row.
 	 */
-	private function row( $id, $person_id, $event_type, $timestamp ) {
+	private function row( $id, $event_type, $timestamp, $user_id = 0, $visitor_id = '', $payload_user_id = 0 ) {
 		return (object) array(
 			'id'         => $id,
-			'person_id'  => $person_id,
 			'event_type' => $event_type,
-			'ts'         => $timestamp,
+			'event_data' => $payload_user_id > 0 ? sprintf( '{"user_id":%d}', $payload_user_id ) : '{}',
+			'user_id'    => $user_id,
+			'visitor_id' => $visitor_id,
+			'created_at' => gmdate( 'Y-m-d H:i:s', $timestamp ),
 		);
 	}
 }


### PR DESCRIPTION
## Summary
- replace independent step populations with ordered per-person progression so downstream-only, out-of-order, and repeated events cannot inflate conversion
- genuinely stitch anonymous activation events to an authenticated user through an observed `visitor_id` + user bridge, reusing analytics' existing payload-user/stored-user identity precedence
- read the bounded report window twice in 500-row `created_at, id` keyset pages instead of materializing and sorting every event, including all-time mode
- exercise the production ability callback for identity transition, ordering, response/drop math, repeats, equal timestamps, and paged bounds

## Funnel semantics

**Person identity:** The strongest user identity follows existing analytics semantics: `event_data.user_id` first (required for registration events emitted before the new account is current), then the stored `user_id` column. `visitor_id` is the anonymous fallback. The first paged pass observes rows carrying both identities; when one visitor maps to exactly one user, anonymous rows for that visitor resolve to `user:<id>` during progression. A visitor observed with multiple users remains ambiguous and is not merged. Rows with neither identity remain excluded because no progression can be attributed. This is report-local resolution over existing event fields, not a new identity substrate.

**Ordering and timestamps:** Only events inside the report's UTC window participate: `created_at >= since` when `days > 0`, and always `created_at <= as_of`, including `days=0`. Both passes use 500-row keyset pages ordered by `created_at ASC, id ASC`; the cursor is `(created_at, id)`, so equal timestamps follow stored insertion order. A person advances only on their next required step. Premature downstream events are ignored, while a later repeat can advance after its prerequisite occurs.

**Denominators:** The first-step population is identified/stitched people completing the first required step in-window. Every downstream population is the subset completing all preceding steps in order in the same window. `conversion_from_prev` divides by the preceding ordered population; `conversion_from_top` and `overall_conversion` divide by the ordered first-step population. Existing zero-denominator behavior is preserved, and ordered populations cannot produce negative drops or rates above 100%.

**Coverage limitations:** Progression and identity bridges are window-local, so a prerequisite or visitor/user bridge existing only before `since` does not qualify activity inside a bounded lookback. All-time mode scans the complete history only through bounded pages and remains capped at `as_of`. Identity-free and ambiguous multi-user visitor rows are never inferred into a user. Friction anomalies use the same stitched identity resolution but remain independent reach metrics rather than required happy-path steps.

## Compatibility impact

The response shape and field names are unchanged. Step populations, conversion rates, overall conversion, and abandon metrics can decrease where prior results included downstream-only or out-of-order people; anonymous-to-authenticated paths can now consolidate into one real person instead of two. Anomaly output is unchanged in shape and now shares the same stitched identity semantics. The explicit `as_of` upper bound makes all modes reproducible and excludes future-dated rows.

## Verification

- `vendor/bin/phpunit tests/ActivationFunnelTest.php` (4 tests, 37 assertions)
- `vendor/bin/phpunit tests/ConversionMapOutcomesTest.php` (6 tests, 15 assertions)
- `php -l inc/core/abilities/get-activation-funnel.php`
- `php -l tests/ActivationFunnelTest.php`
- `vendor/bin/phpcs --standard=WordPress inc/core/abilities/get-activation-funnel.php tests/ActivationFunnelTest.php`
- `git diff --check`

Closes #185