### PR TITLE
fix: protect public analytics writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ The ExtraChill Analytics plugin provides network-wide analytics tracking and rep
 - `navigator.sendBeacon()` preferred (modern browsers, automatic cleanup)
 - Fallback to `fetch()` with `keepalive` option
 - Excludes preview mode via `is_preview()` check
-- Only loads on singular pages (`is_singular()`)
+- Loads on eligible public routes, including signed post-backed and route views
+- Enqueues through the custom minimal-head lifecycle on mapped link-page domains that bypass `wp_head()`
 
 **File**: `inc/core/assets.php` → `extrachill_analytics_enqueue_view_tracking()`
 
@@ -24,36 +25,38 @@ User visits post
 ↓
 wp_enqueue_scripts hook fires
 ↓
-view-tracking.js enqueued with localized data (postId, endpoint)
+view-tracking.js enqueued with localized host/path/family/post proof
 ↓
 IIFE executes on page load
 ↓
-POST request to /extrachill/v1/analytics/view
+POST request to the Core Abilities runner
 ↓
-extrachill-api plugin handles endpoint
+extrachill/track-page-view validates origin, proof, rate, and post state
 ↓
-ec_track_post_views() increments post meta
+pageview event is stored; post-backed views also increment post meta
 ```
 
-### 2. REST API Endpoint Usage
+### 2. Signed Pageview Ability
 
-**Pattern**: Plugin does not define its own REST endpoints; consumes network-activated endpoint from extrachill-api plugin.
+**Pattern**: The Analytics-owned ability is exposed through WordPress's Core Abilities REST runner. No pageview adapter is owned by `extrachill-api`.
 
-**Endpoint**: `POST /extrachill/v1/analytics/view`
+**Endpoint**: `POST /wp-abilities/v1/abilities/extrachill/track-page-view/run`
 
-**Plugin Contract**:
-- **Provider**: extrachill-api plugin defines and registers the endpoint
-- **Consumer**: extrachill-analytics plugin calls the endpoint
-- **Handler**: `ec_track_post_views()` in `inc/core/view-counts.php` processes the request
+**Required Input**:
+- `source_path` - normalized, query-free browser path
+- `route_family` - bounded server-classified route family
+- `proof` - server-rendered HMAC binding blog, host, path, family, and post
+- `post_id` - optional; present only for a post-backed view
 
-**Function Existence Check**:
-```php
-if (function_exists('ec_track_post_views')) {
-    ec_track_post_views($post_id);
-}
-```
+**Admission Contract**:
+- The browser origin must resolve to the current canonical or mapped site.
+- The proof must match the exact rendered tuple.
+- Claimed posts must exist in the published state.
+- Public writes use the Analytics-owned atomic abuse bound.
+- GPC/DNT views remain aggregate-only with no visitor identity.
+- Post-only public input is invalid and must not be inferred from `Referer`.
 
-**Rationale**: Centralized API infrastructure ensures consistent endpoint patterns across all network plugins.
+**Coordinated Removal**: The obsolete post-only adapter/client references are removed by Extra-Chill/extrachill-artist-platform#133, Extra-Chill/extrachill-api#118, and Extra-Chill/extrachill-api-client#14. Do not restore compatibility in Analytics. API #116 continues to own click/impression request normalization and destination validation.
 
 ### 3. Post Meta Storage
 
@@ -126,15 +129,18 @@ if ('extra-chill-network_page_extrachill-analytics' !== $hook) {
 
 ### Frontend Asset Loading
 
-**Hook**: `wp_enqueue_scripts`
+**Hooks**: `wp_enqueue_scripts` and the mapped link-page minimal-head lifecycle
 
-**Condition**: `is_singular() && !is_preview()`
+**Condition**: Eligible, non-preview public template requests; non-post routes are first-party only
 
 **Localization**:
 ```php
 wp_localize_script('extrachill-view-tracking', 'ecViewTracking', [
-    'postId' => get_the_ID(),
-    'endpoint' => rest_url('extrachill/v1/analytics/view'),
+    'postId'      => is_singular() ? get_the_ID() : 0,
+    'sourcePath'  => $source_path,
+    'routeFamily' => $route_family,
+    'proof'       => extrachill_analytics_pageview_proof($post_id, $source_path, $route_family, $request_host),
+    'endpoint'    => rest_url('wp-abilities/v1/abilities/extrachill/track-page-view/run'),
 ]);
 ```
 
@@ -148,11 +154,11 @@ wp_localize_script('extrachill-view-tracking', 'ecViewTracking', [
 
 ## Architectural Decisions
 
-### 1. Why REST API for View Tracking?
+### 1. Why the Core Abilities Runner for View Tracking?
 - **Performance**: Asynchronous, non-blocking request
 - **Reliability**: `sendBeacon` ensures request completes even if user navigates away
-- **Consistency**: Follows modern WordPress patterns
-- **Debuggability**: REST API requests visible in browser dev tools
+- **Integrity**: The Analytics-owned write contract validates the signed render tuple before persistence
+- **Layer Purity**: WordPress exposes the ability without a duplicate Extra Chill API pageview adapter
 
 ### 2. Why Post Meta Over Custom Table?
 - **Simplicity**: Uses built-in WordPress storage mechanism
@@ -160,11 +166,10 @@ wp_localize_script('extrachill-view-tracking', 'ecViewTracking', [
 - **Performance**: WordPress caches meta queries
 - **Integration**: Works with standard WP_Query and post list views
 
-### 3. Why Consume extrachill-api Endpoint?
-- **Single Source of Truth**: All API endpoints defined in one plugin
-- **Version Control**: API namespace (`extrachill/v1`) managed centrally
-- **Dependency Management**: Clear dependency declaration in plugin requirements
-- **Consistency**: Same authentication and permission patterns across all endpoints
+### 3. Why No Pageview API Adapter?
+- **Single Write Owner**: Analytics owns pageview admission, identity, side effects, and persistence
+- **No Contract Drift**: The signed input reaches the ability without being reduced to a post ID
+- **Layer Purity**: Extra Chill API keeps click/impression HTTP normalization from #116 and does not duplicate pageview semantics
 
 ### 4. Why React for Admin Dashboard?
 - **WordPress Native**: Uses same libraries as Gutenberg
@@ -174,26 +179,24 @@ wp_localize_script('extrachill-view-tracking', 'ecViewTracking', [
 
 ## Plugin Integration Points
 
-### extrachill-api Integration
+### Browser Pageview Integration
 
-**Required Endpoints** (must be registered by extrachill-api):
-- `POST /extrachill/v1/analytics/view` - View tracking
+**Required Ability Runner**:
+- `POST /wp-abilities/v1/abilities/extrachill/track-page-view/run`
 
-**Registration Pattern** (in extrachill-api):
+**Browser Envelope**:
 ```php
-// inc/routes/analytics/view-count.php
-register_rest_route('extrachill/v1', '/analytics/view', [
-    'methods' => 'POST',
-    'callback' => function($request) {
-        $post_id = $request->get_param('post_id');
-        if (function_exists('ec_track_post_views')) {
-            ec_track_post_views($post_id);
-        }
-        return new WP_REST_Response(['success' => true]);
-    },
-    'permission_callback' => '__return_true', // Public endpoint
-]);
+array(
+    'input' => array(
+        'post_id'      => 123,
+        'source_path'  => '/story/',
+        'route_family' => 'singular',
+        'proof'        => '<server-rendered proof>',
+    ),
+)
 ```
+
+The signed tracker is the sole browser pageview path. The former post-only public route is being removed in Artist #133, API #118, and API Client #14 and must not be treated as an active integration.
 
 ### Theme Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,13 +39,11 @@ wp_register_ability( 'extrachill/track-analytics-event', [
 ] );
 ```
 
-### REST API Integration
+### Browser and REST Integration
 
-The plugin consumes network/extrachill-api endpoints for data persistence:
-
-- `POST /wp-json/extrachill/v1/analytics/view-count` - Track content views
-- `POST /wp-json/extrachill/v1/analytics/click` - Track link clicks
-- `POST /wp-json/extrachill/v1/analytics/link-page` - Track link page analytics
+- Signed first-party browser pageviews submit to the Analytics tracking Ability.
+- Extra Chill API owns thin public click and impression adapters; Analytics validates canonical events and persists them.
+- The retired post-only pageview adapter is not a supported integration path.
 
 ### Admin Dashboard Display
 
@@ -59,7 +57,7 @@ The analytics plugin integrates with other network plugins through:
 
 - **extrachill-users**: User registration tracking
 - **extrachill-newsletter**: Newsletter signup tracking
-- **extrachill-api**: Data persistence via REST endpoints
+- **extrachill-api**: Thin public click and impression request adapters
 - **Theme**: Analytics display in admin areas
 
 ### Data Storage
@@ -81,20 +79,3 @@ Follows Extra Chill Platform architectural patterns:
 - WordPress coding standards compliance
 - Security-first development practices
 - Network-activated plugin structure
-
-## File Structure
-
-```
-extrachill-analytics/
-├── extrachill-analytics.php     # Main plugin file
-├── inc/
-│   ├── core/
-│   │   ├── abilities.php         # Abilities API registration
-│   │   ├── tracking.php          # Event tracking functions
-│   │   └── admin-display.php     # Admin dashboard integration
-│   └── api/
-│       └── endpoints.php         # REST API integration
-└── assets/
-    └── js/
-        └── tracking.js           # Frontend tracking script
-```

--- a/README.md
+++ b/README.md
@@ -4,40 +4,44 @@ Network-wide analytics tracking and reporting for the ExtraChill Platform WordPr
 
 ## Overview
 
-The ExtraChill Analytics plugin provides comprehensive view tracking and analytics reporting across all sites in the ExtraChill Platform multisite network. It tracks post views via asynchronous REST API requests to avoid blocking page loads, excluding preview views to maintain data accuracy. A network admin dashboard displays analytics data across all sites.
+The ExtraChill Analytics plugin provides comprehensive view tracking and analytics reporting across all sites in the ExtraChill Platform multisite network. It tracks eligible public routes through a signed, asynchronous browser request to the WordPress Abilities API, excluding previews and rejecting writes that do not match the rendered host, path, route family, and optional post. A network admin dashboard displays analytics data across all sites.
 
 ## Features
 
 - **Unified Event Tracking**: Network-wide custom table for tracking newsletters, registrations, and more
 - **Network-Wide Activation**: Plugin activated across all sites in the multisite network
 - **Async View Tracking**: Uses `navigator.sendBeacon` and `fetch` with `keepalive` for non-blocking tracking
-- **REST API Integration**: Tracks views via extrachill-api endpoint at `/wp-json/extrachill/v1/analytics/view`
+- **Signed Ability Writes**: Tracks browser views through the Core Abilities runner at `/wp-json/wp-abilities/v1/abilities/extrachill/track-page-view/run`
 - **Preview Exclusion**: Automatically excludes preview mode from view counting
 - **Post Meta Storage**: Stores view counts in WordPress post meta (`ec_post_views`)
 - **Network Admin Dashboard**: React-powered analytics dashboard under Extra Chill Multisite menu
 - **Asset Versioning**: Automatic cache busting using `filemtime()` on all enqueued assets
-- **Conditional Loading**: Frontend tracking only loads on singular posts, admin dashboard only loads on analytics page
+- **Conditional Loading**: Frontend tracking loads on eligible public routes, while the admin dashboard loads only on the analytics page
 
 ## Requirements
 
 - WordPress Multisite
 - PHP 7.4+
 - WordPress 5.0+
-- **Requires Plugin**: extrachill-api (REST API infrastructure for analytics endpoint)
+- WordPress Abilities API support
 
 ## Notes
 
 This plugin is a network plugin used inside the Extra Chill Platform multisite network.
 
 
-## API Integration
+## Browser Pageview Contract
 
-This plugin integrates with the ExtraChill API (`extrachill-api`) plugin for the analytics tracking endpoint:
+The signed Analytics-owned tracker is the sole browser pageview path:
 
-- **Track View** - `POST /wp-json/extrachill/v1/analytics/view` - Records a view for a post ID
-  - Request body: `{"post_id": 123}`
-  - Handler lives in `extrachill-api`; the counter is incremented by `extrachill-analytics` (`ec_track_post_views()`)
-  - Stores count in `ec_post_views` post meta
+- **Track View** - `POST /wp-json/wp-abilities/v1/abilities/extrachill/track-page-view/run`
+- **Envelope** - `{"input":{"source_path":"/story/","route_family":"singular","proof":"<server-rendered proof>","post_id":123}}`
+- `source_path`, `route_family`, and `proof` are required. `post_id` is present only for post-backed views.
+- The server renders the proof into the tracker configuration. Browser or API consumers must not construct or substitute it.
+- Analytics validates the signed blog/host/path/family/post tuple before incrementing `ec_post_views` or storing a pageview event.
+- Route views store only the pageview event; post-backed views also retain the legacy post-meta counter.
+
+The former public post-only `/extrachill/v1/analytics/view` path is not compatible and must not be documented or reintroduced. Its coordinated removals are tracked in Extra-Chill/extrachill-artist-platform#133, Extra-Chill/extrachill-api#118, and Extra-Chill/extrachill-api-client#14. Extra Chill API remains responsible for its click/impression HTTP adapters; those responsibilities do not move into Analytics.
 
 ## Development
 

--- a/assets/js/view-tracking.js
+++ b/assets/js/view-tracking.js
@@ -4,6 +4,7 @@
 		! config ||
 		! config.sourcePath ||
 		! config.routeFamily ||
+		! config.proof ||
 		! config.endpoint
 	) {
 		return;
@@ -12,6 +13,7 @@
 	const input = {
 		source_path: config.sourcePath,
 		route_family: config.routeFamily,
+		proof: config.proof,
 	};
 	if ( config.postId ) {
 		input.post_id = config.postId;

--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -42,6 +42,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/isbot-backfill.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/link-page-analytics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/write-integrity.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/gtm.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/reports-permission.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -124,7 +124,15 @@ function extrachill_analytics_ability_track_event( $input ) {
 		return 0;
 	}
 
-	$event_type = $input['event_type'];
+	$raw_event_type = (string) $input['event_type'];
+	$event_type     = sanitize_key( $raw_event_type );
+	if ( $raw_event_type !== $event_type ) {
+		return new WP_Error(
+			'invalid_event_type',
+			__( 'Event type must use its canonical lowercase identifier.', 'extrachill-analytics' ),
+			array( 'status' => 400 )
+		);
+	}
 	$event_data = isset( $input['event_data'] ) ? $input['event_data'] : array();
 	$source_url = isset( $input['source_url'] ) ? $input['source_url'] : '';
 	$visitor_id = isset( $input['visitor_id'] ) ? (string) $input['visitor_id'] : '';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -117,7 +117,7 @@ function extrachill_analytics_register_abilities() {
  * Execute callback for track-analytics-event ability.
  *
  * @param array $input Input parameters.
- * @return int Event ID on success, 0 on failure.
+ * @return int|WP_Error Event ID on success, 0 on failure, or an admission error.
  */
 function extrachill_analytics_ability_track_event( $input ) {
 	if ( empty( $input['event_type'] ) ) {
@@ -128,6 +128,16 @@ function extrachill_analytics_ability_track_event( $input ) {
 	$event_data = isset( $input['event_data'] ) ? $input['event_data'] : array();
 	$source_url = isset( $input['source_url'] ) ? $input['source_url'] : '';
 	$visitor_id = isset( $input['visitor_id'] ) ? (string) $input['visitor_id'] : '';
+
+	$admission = extrachill_analytics_validate_public_event_write( $event_type, $event_data, $source_url );
+	if ( is_wp_error( $admission ) ) {
+		return $admission;
+	}
+	$event_data = $admission['event_data'];
+	$source_url = $admission['source_url'];
+	if ( in_array( $event_type, extrachill_analytics_public_browser_event_types(), true ) ) {
+		$visitor_id = function_exists( 'extrachill_analytics_read_visitor_id' ) ? extrachill_analytics_read_visitor_id() : '';
+	}
 
 	// Defense-in-depth: if a 'search' event arrives with a payload-shaped term,
 	// reclassify it as 'search_attack' so real search metrics stay clean while

--- a/inc/core/abilities/track-page-view.php
+++ b/inc/core/abilities/track-page-view.php
@@ -46,6 +46,11 @@ function extrachill_analytics_register_track_page_view_ability(): void {
 						'description' => __( 'Optional raw client-side referrer (document.referrer). Normalized server-side to a host-only `referrer_host` (no query strings, no PII) on the pageview event. Empty for direct traffic.', 'extrachill-analytics' ),
 						'default'     => '',
 					),
+					'proof'        => array(
+						'type'        => 'string',
+						'description' => __( 'Cache-safe proof binding the rendered host, path, route family, and post.', 'extrachill-analytics' ),
+						'maxLength'   => 64,
+					),
 				),
 				'anyOf'      => array(
 					array( 'required' => array( 'post_id' ) ),
@@ -89,13 +94,17 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 	$referrer     = isset( $input['referrer'] ) ? (string) $input['referrer'] : '';
 	$source_path  = isset( $input['source_path'] ) ? extrachill_analytics_normalize_route_path( $input['source_path'] ) : '';
 	$route_family = isset( $input['route_family'] ) ? sanitize_key( $input['route_family'] ) : '';
+	$proof        = isset( $input['proof'] ) ? (string) $input['proof'] : '';
 
 	// The deployed Extra Chill API adapter still calls this ability directly
-	// with post_id/referrer. Keep that valid while browser writes move to Core's
-	// Abilities REST runner and carry the complete route contract.
+	// with post_id/referrer. Derive its source path from the browser Referer; the
+	// integrity boundary admits it only when that path and mapped host match the
+	// public post. New direct Ability runner writes carry a signed proof.
 	if ( $post_id > 0 && '' === $source_path ) {
-		$permalink   = get_permalink( $post_id );
-		$source_path = is_string( $permalink ) ? extrachill_analytics_normalize_route_path( $permalink ) : '';
+		$browser_source = isset( $_SERVER['HTTP_REFERER'] )
+			? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) )
+			: '';
+		$source_path    = extrachill_analytics_normalize_route_path( $browser_source );
 	}
 	if ( $post_id > 0 && '' === $route_family ) {
 		$route_family = 'singular';
@@ -107,6 +116,11 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 			__( 'A normalized source_path and valid route_family are required.', 'extrachill-analytics' ),
 			array( 'status' => 400 )
 		);
+	}
+
+	$admission = extrachill_analytics_validate_pageview_write( $post_id, $source_path, $route_family, $proof );
+	if ( is_wp_error( $admission ) ) {
+		return $admission;
 	}
 
 	if ( $post_id > 0 && ! function_exists( 'ec_track_post_views' ) ) {
@@ -126,14 +140,6 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 	$visitor_id            = '';
 	$is_first_party_beacon = function_exists( 'extrachill_analytics_beacon_is_first_party' )
 		&& extrachill_analytics_beacon_is_first_party();
-	if ( $post_id <= 0 && ! $is_first_party_beacon ) {
-		return new \WP_Error(
-			'invalid_route_origin',
-			__( 'Route-level views must originate on the first-party network.', 'extrachill-analytics' ),
-			array( 'status' => 403 )
-		);
-	}
-
 	// Do not stitch a custom-domain request even if a browser permits its
 	// third-party cookie. Cross-site beacons have no durable first-party
 	// identity guarantee and intentionally remain anonymous.

--- a/inc/core/abilities/track-page-view.php
+++ b/inc/core/abilities/track-page-view.php
@@ -52,10 +52,7 @@ function extrachill_analytics_register_track_page_view_ability(): void {
 						'maxLength'   => 64,
 					),
 				),
-				'anyOf'      => array(
-					array( 'required' => array( 'post_id' ) ),
-					array( 'required' => array( 'source_path', 'route_family' ) ),
-				),
+				'required'   => array( 'source_path', 'route_family', 'proof' ),
 			),
 			'output_schema'       => array(
 				'type'        => 'object',
@@ -95,20 +92,6 @@ function extrachill_analytics_ability_track_page_view( array $input ) {
 	$source_path  = isset( $input['source_path'] ) ? extrachill_analytics_normalize_route_path( $input['source_path'] ) : '';
 	$route_family = isset( $input['route_family'] ) ? sanitize_key( $input['route_family'] ) : '';
 	$proof        = isset( $input['proof'] ) ? (string) $input['proof'] : '';
-
-	// The deployed Extra Chill API adapter still calls this ability directly
-	// with post_id/referrer. Derive its source path from the browser Referer; the
-	// integrity boundary admits it only when that path and mapped host match the
-	// public post. New direct Ability runner writes carry a signed proof.
-	if ( $post_id > 0 && '' === $source_path ) {
-		$browser_source = isset( $_SERVER['HTTP_REFERER'] )
-			? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) )
-			: '';
-		$source_path    = extrachill_analytics_normalize_route_path( $browser_source );
-	}
-	if ( $post_id > 0 && '' === $route_family ) {
-		$route_family = 'singular';
-	}
 
 	if ( '' === $source_path || ! in_array( $route_family, extrachill_analytics_route_families(), true ) ) {
 		return new \WP_Error(

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -453,6 +453,10 @@ function extrachill_analytics_enqueue_view_tracking() {
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_analytics_enqueue_view_tracking' );
 
+// Custom-domain link pages intentionally bypass wp_head(), so their existing
+// minimal-head lifecycle must enqueue the same signed Analytics-owned tracker.
+add_action( 'extrachill_artist_link_page_minimal_head', 'extrachill_analytics_enqueue_view_tracking', 20 );
+
 /**
  * Enqueue outbound-click tracking on every front-end view.
  *

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -415,6 +415,13 @@ function extrachill_analytics_enqueue_view_tracking() {
 	if ( '' === $source_path ) {
 		return;
 	}
+	$route_family = extrachill_analytics_classify_current_route( $source_path );
+	$request_host = isset( $_SERVER['HTTP_HOST'] )
+		? wp_parse_url( 'https://' . sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ), PHP_URL_HOST )
+		: '';
+	if ( ! is_string( $request_host ) || '' === $request_host ) {
+		return;
+	}
 
 	$js_path = EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'assets/js/view-tracking.js';
 	if ( ! file_exists( $js_path ) ) {
@@ -438,7 +445,8 @@ function extrachill_analytics_enqueue_view_tracking() {
 		array(
 			'postId'      => $post_id,
 			'sourcePath'  => $source_path,
-			'routeFamily' => extrachill_analytics_classify_current_route( $source_path ),
+			'routeFamily' => $route_family,
+			'proof'       => extrachill_analytics_pageview_proof( $post_id, $source_path, $route_family, $request_host ),
 			'endpoint'    => rest_url( 'wp-abilities/v1/abilities/extrachill/track-page-view/run' ),
 		)
 	);

--- a/inc/core/write-integrity.php
+++ b/inc/core/write-integrity.php
@@ -58,7 +58,7 @@ function extrachill_analytics_public_write_host_is_current_site( $host ) {
 }
 
 /**
- * Apply a fixed-window cap to public analytics writes.
+ * Apply an atomic fixed-window cap to public analytics writes.
  *
  * The cache key contains only a salted hash of the client IP. The raw address
  * is never persisted by this limiter.
@@ -67,26 +67,48 @@ function extrachill_analytics_public_write_host_is_current_site( $host ) {
  */
 function extrachill_analytics_check_public_write_rate_limit() {
 	$limit = (int) apply_filters( 'extrachill_analytics_public_write_rate_limit', 240 );
-	if ( $limit < 1 || ! function_exists( 'get_transient' ) || ! function_exists( 'set_transient' ) ) {
+	if ( $limit < 1 ) {
 		return true;
 	}
 
 	$ip = function_exists( 'extrachill_analytics_get_client_ip' ) ? extrachill_analytics_get_client_ip() : '';
-	if ( '' === $ip ) {
-		return true;
+	if (
+		'' === $ip
+		|| ! function_exists( 'wp_using_ext_object_cache' )
+		|| ! wp_using_ext_object_cache()
+		|| ! function_exists( 'wp_cache_add' )
+		|| ! function_exists( 'wp_cache_incr' )
+	) {
+		return new WP_Error(
+			'analytics_write_limiter_unavailable',
+			__( 'Analytics write admission is temporarily unavailable.', 'extrachill-analytics' ),
+			array( 'status' => 503 )
+		);
 	}
 
-	$key   = 'ec_an_write_' . substr( hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) ), 0, 32 );
-	$count = (int) get_transient( $key );
-	if ( $count >= $limit ) {
+	$key   = 'write_' . substr( hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) ), 0, 32 );
+	$group = 'extrachill-analytics-admission';
+	if ( wp_cache_add( $key, 1, $group, MINUTE_IN_SECONDS ) ) {
+		$count = 1;
+	} else {
+		$count = wp_cache_incr( $key, 1, $group );
+	}
+
+	if ( false === $count || ! is_numeric( $count ) ) {
+		return new WP_Error(
+			'analytics_write_limiter_unavailable',
+			__( 'Analytics write admission is temporarily unavailable.', 'extrachill-analytics' ),
+			array( 'status' => 503 )
+		);
+	}
+
+	if ( (int) $count > $limit ) {
 		return new WP_Error(
 			'analytics_write_rate_limited',
 			__( 'Too many analytics writes.', 'extrachill-analytics' ),
 			array( 'status' => 429 )
 		);
 	}
-
-	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
 
 	return true;
 }
@@ -199,7 +221,7 @@ function extrachill_analytics_validate_pageview_write( $post_id, $source_path, $
 	}
 
 	$expected = extrachill_analytics_pageview_proof( $post_id, $source_path, $route_family, $source_host );
-	if ( '' !== $proof && ! hash_equals( $expected, $proof ) ) {
+	if ( '' === $proof || ! hash_equals( $expected, $proof ) ) {
 		return new WP_Error(
 			'invalid_pageview_proof',
 			__( 'Pageview source details do not match the rendered page.', 'extrachill-analytics' ),
@@ -207,15 +229,7 @@ function extrachill_analytics_validate_pageview_write( $post_id, $source_path, $
 		);
 	}
 
-	if ( '' === $proof && ( $post_id <= 0 || ! extrachill_analytics_public_post_matches_source( $post_id, $source_path, $source_host ) ) ) {
-		return new WP_Error(
-			'invalid_pageview_source',
-			__( 'Legacy pageview source does not match the public post.', 'extrachill-analytics' ),
-			array( 'status' => 403 )
-		);
-	}
-
-	if ( '' !== $proof && $post_id > 0 ) {
+	if ( $post_id > 0 ) {
 		$post = get_post( $post_id );
 		if ( ! $post || ! extrachill_analytics_write_post_is_published( $post ) ) {
 			return new WP_Error(

--- a/inc/core/write-integrity.php
+++ b/inc/core/write-integrity.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Admission checks for public analytics writes.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return the browser host that initiated the current write.
+ *
+ * @return string Lowercase host, or an empty string.
+ */
+function extrachill_analytics_public_write_source_host() {
+	$source = '';
+	if ( isset( $_SERVER['HTTP_ORIGIN'] ) ) {
+		$source = sanitize_text_field( wp_unslash( $_SERVER['HTTP_ORIGIN'] ) );
+	} elseif ( isset( $_SERVER['HTTP_REFERER'] ) ) {
+		$source = sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) );
+	}
+
+	$host = wp_parse_url( $source, PHP_URL_HOST );
+
+	return is_string( $host ) ? strtolower( rtrim( $host, '.' ) ) : '';
+}
+
+/**
+ * Determine whether a host belongs to the current network site.
+ *
+ * Includes mapped domains such as the public link-page domain when the network
+ * domain map is available.
+ *
+ * @param string $host Candidate host.
+ * @return bool
+ */
+function extrachill_analytics_public_write_host_is_current_site( $host ) {
+	$host            = strtolower( rtrim( (string) $host, '.' ) );
+	$current_blog_id = (int) get_current_blog_id();
+	$allowed_hosts   = array();
+
+	foreach ( array( home_url( '/' ), function_exists( 'site_url' ) ? site_url( '/' ) : '' ) as $site_url ) {
+		$site_host = wp_parse_url( $site_url, PHP_URL_HOST );
+		if ( is_string( $site_host ) && '' !== $site_host ) {
+			$allowed_hosts[] = strtolower( rtrim( $site_host, '.' ) );
+		}
+	}
+
+	if ( function_exists( 'ec_get_domain_map' ) ) {
+		foreach ( ec_get_domain_map() as $domain => $blog_id ) {
+			if ( $current_blog_id === (int) $blog_id ) {
+				$allowed_hosts[] = strtolower( rtrim( (string) $domain, '.' ) );
+			}
+		}
+	}
+
+	return '' !== $host && in_array( $host, array_unique( $allowed_hosts ), true );
+}
+
+/**
+ * Apply a fixed-window cap to public analytics writes.
+ *
+ * The cache key contains only a salted hash of the client IP. The raw address
+ * is never persisted by this limiter.
+ *
+ * @return true|WP_Error
+ */
+function extrachill_analytics_check_public_write_rate_limit() {
+	$limit = (int) apply_filters( 'extrachill_analytics_public_write_rate_limit', 240 );
+	if ( $limit < 1 || ! function_exists( 'get_transient' ) || ! function_exists( 'set_transient' ) ) {
+		return true;
+	}
+
+	$ip = function_exists( 'extrachill_analytics_get_client_ip' ) ? extrachill_analytics_get_client_ip() : '';
+	if ( '' === $ip ) {
+		return true;
+	}
+
+	$key   = 'ec_an_write_' . substr( hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) ), 0, 32 );
+	$count = (int) get_transient( $key );
+	if ( $count >= $limit ) {
+		return new WP_Error(
+			'analytics_write_rate_limited',
+			__( 'Too many analytics writes.', 'extrachill-analytics' ),
+			array( 'status' => 429 )
+		);
+	}
+
+	set_transient( $key, $count + 1, MINUTE_IN_SECONDS );
+
+	return true;
+}
+
+/**
+ * Create a cache-safe proof for one rendered pageview tuple.
+ *
+ * @param int    $post_id      Post ID, or zero for a route view.
+ * @param string $source_path  Normalized route path.
+ * @param string $route_family Route family.
+ * @param string $source_host  Browser host.
+ * @return string
+ */
+function extrachill_analytics_pageview_proof( $post_id, $source_path, $route_family, $source_host ) {
+	$payload = implode(
+		'|',
+		array(
+			(int) get_current_blog_id(),
+			(int) $post_id,
+			strtolower( rtrim( (string) $source_host, '.' ) ),
+			(string) $source_path,
+			(string) $route_family,
+		)
+	);
+
+	return hash_hmac( 'sha256', $payload, wp_salt( 'nonce' ) );
+}
+
+/**
+ * Determine whether a post exists in the published state.
+ *
+ * Custom-domain post types can be publicly routed while their registration is
+ * not `public`, so `is_post_publicly_viewable()` is not sufficient here.
+ *
+ * @param WP_Post $post Post object.
+ * @return bool
+ */
+function extrachill_analytics_write_post_is_published( $post ) {
+	$status = isset( $post->post_status ) ? (string) $post->post_status : get_post_status( $post );
+
+	return 'publish' === $status;
+}
+
+/**
+ * Determine whether a public post is legitimately served at a browser source.
+ *
+ * Canonical permalinks match exactly. Mapped custom domains may expose the
+ * same post at its slug path; a mapped domain root may expose the one post
+ * whose slug is the normalized domain label.
+ *
+ * @param int    $post_id     Post ID.
+ * @param string $source_path Normalized browser path.
+ * @param string $source_host Browser host.
+ * @return bool
+ */
+function extrachill_analytics_public_post_matches_source( $post_id, $source_path, $source_host ) {
+	$post = get_post( $post_id );
+	if ( ! $post || ! extrachill_analytics_write_post_is_published( $post ) ) {
+		return false;
+	}
+
+	$permalink      = get_permalink( $post );
+	$canonical_host = is_string( $permalink ) ? wp_parse_url( $permalink, PHP_URL_HOST ) : '';
+	$canonical_path = is_string( $permalink ) ? extrachill_analytics_normalize_route_path( $permalink ) : '';
+	$canonical_host = is_string( $canonical_host ) ? strtolower( rtrim( $canonical_host, '.' ) ) : '';
+	$source_host    = strtolower( rtrim( (string) $source_host, '.' ) );
+	if ( $canonical_host === $source_host && $canonical_path === $source_path ) {
+		return true;
+	}
+
+	if ( ! extrachill_analytics_public_write_host_is_current_site( $source_host ) || $canonical_host === $source_host ) {
+		return false;
+	}
+
+	$post_slug = isset( $post->post_name ) ? sanitize_title( $post->post_name ) : '';
+	$path_slug = sanitize_title( basename( untrailingslashit( $source_path ) ) );
+	if ( '' !== $post_slug && $post_slug === $path_slug ) {
+		return true;
+	}
+
+	$host_label = sanitize_title( strtok( $source_host, '.' ) );
+
+	return '/' === $source_path
+		&& '' !== $post_slug
+		&& str_replace( '-', '', $post_slug ) === str_replace( '-', '', $host_label );
+}
+
+/**
+ * Validate a browser pageview against its server-rendered tuple.
+ *
+ * @param int    $post_id      Post ID, or zero for a route view.
+ * @param string $source_path  Normalized route path.
+ * @param string $route_family Route family.
+ * @param string $proof        Server-rendered proof.
+ * @return true|WP_Error
+ */
+function extrachill_analytics_validate_pageview_write( $post_id, $source_path, $route_family, $proof ) {
+	$rate_limit = extrachill_analytics_check_public_write_rate_limit();
+	if ( is_wp_error( $rate_limit ) ) {
+		return $rate_limit;
+	}
+
+	$source_host = extrachill_analytics_public_write_source_host();
+	if ( ! extrachill_analytics_public_write_host_is_current_site( $source_host ) ) {
+		return new WP_Error(
+			'invalid_pageview_origin',
+			__( 'Pageviews must originate on the current public site.', 'extrachill-analytics' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	$expected = extrachill_analytics_pageview_proof( $post_id, $source_path, $route_family, $source_host );
+	if ( '' !== $proof && ! hash_equals( $expected, $proof ) ) {
+		return new WP_Error(
+			'invalid_pageview_proof',
+			__( 'Pageview source details do not match the rendered page.', 'extrachill-analytics' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	if ( '' === $proof && ( $post_id <= 0 || ! extrachill_analytics_public_post_matches_source( $post_id, $source_path, $source_host ) ) ) {
+		return new WP_Error(
+			'invalid_pageview_source',
+			__( 'Legacy pageview source does not match the public post.', 'extrachill-analytics' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	if ( '' !== $proof && $post_id > 0 ) {
+		$post = get_post( $post_id );
+		if ( ! $post || ! extrachill_analytics_write_post_is_published( $post ) ) {
+			return new WP_Error(
+				'invalid_pageview_post',
+				__( 'Pageview post is not publicly viewable.', 'extrachill-analytics' ),
+				array( 'status' => 400 )
+			);
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Event types accepted from public browser adapters.
+ *
+ * @return string[]
+ */
+function extrachill_analytics_public_browser_event_types() {
+	return array( 'bridge_click', 'bridge_impression', 'outbound_click', 'share_click' );
+}
+
+/**
+ * Validate and normalize an Analytics-owned public browser event contract.
+ *
+ * @param string $event_type Event type.
+ * @param array  $event_data Event dimensions.
+ * @param string $source_url Claimed browser source.
+ * @return array{event_data: array, source_url: string}|WP_Error
+ */
+function extrachill_analytics_validate_public_event_write( $event_type, $event_data, $source_url ) {
+	if ( ! in_array( $event_type, extrachill_analytics_public_browser_event_types(), true ) ) {
+		return array(
+			'event_data' => $event_data,
+			'source_url' => $source_url,
+		);
+	}
+
+	$rate_limit = extrachill_analytics_check_public_write_rate_limit();
+	if ( is_wp_error( $rate_limit ) ) {
+		return $rate_limit;
+	}
+
+	$source_host = extrachill_analytics_public_write_source_host();
+	if ( ! extrachill_analytics_public_write_host_is_current_site( $source_host ) ) {
+		return new WP_Error( 'invalid_event_origin', __( 'Analytics events must originate on the current public site.', 'extrachill-analytics' ), array( 'status' => 403 ) );
+	}
+
+	$parts        = wp_parse_url( (string) $source_url );
+	$claimed_host = is_array( $parts ) && isset( $parts['host'] ) ? strtolower( rtrim( (string) $parts['host'], '.' ) ) : '';
+	if ( '' !== $claimed_host && $source_host !== $claimed_host ) {
+		return new WP_Error( 'invalid_event_source', __( 'Event source host does not match the browser origin.', 'extrachill-analytics' ), array( 'status' => 403 ) );
+	}
+
+	$source_path = extrachill_analytics_normalize_route_path( (string) $source_url );
+	if ( '' === $source_path ) {
+		return new WP_Error( 'invalid_event_source', __( 'A valid event source path is required.', 'extrachill-analytics' ), array( 'status' => 400 ) );
+	}
+
+	if ( ! is_array( $event_data ) ) {
+		return new WP_Error( 'invalid_event_data', __( 'Event data must be an object.', 'extrachill-analytics' ), array( 'status' => 400 ) );
+	}
+
+	$source_post = isset( $event_data['source_post'] ) ? (int) $event_data['source_post'] : 0;
+	if ( $source_post > 0 ) {
+		if ( '/' === $source_path ) {
+			$event_data['source_post'] = 0;
+		} elseif ( ! extrachill_analytics_public_post_matches_source( $source_post, $source_path, $source_host ) ) {
+			return new WP_Error( 'invalid_event_post', __( 'Event source post does not match the source path.', 'extrachill-analytics' ), array( 'status' => 400 ) );
+		}
+	}
+
+	if ( isset( $event_data['source_site'] ) && '' !== $event_data['source_site'] && function_exists( 'ec_get_blog_slug_by_id' ) ) {
+		$current_site = (string) ec_get_blog_slug_by_id( get_current_blog_id() );
+		if ( '' !== $current_site && $current_site !== (string) $event_data['source_site'] ) {
+			return new WP_Error( 'invalid_event_source_site', __( 'Event source site does not match the current site.', 'extrachill-analytics' ), array( 'status' => 400 ) );
+		}
+	}
+
+	if ( isset( $event_data['dest_site'] ) && '' !== $event_data['dest_site'] && function_exists( 'ec_get_blog_id' ) ) {
+		$dest_blog_id = ec_get_blog_id( (string) $event_data['dest_site'] );
+		if ( null === $dest_blog_id || (int) get_current_blog_id() === (int) $dest_blog_id ) {
+			return new WP_Error( 'invalid_event_destination_site', __( 'Event destination must be another network site.', 'extrachill-analytics' ), array( 'status' => 400 ) );
+		}
+	}
+
+	unset( $event_data['is_bot'] );
+
+	return array(
+		'event_data' => $event_data,
+		'source_url' => $source_path,
+	);
+}

--- a/tests/PublicWriteIntegrityTest.php
+++ b/tests/PublicWriteIntegrityTest.php
@@ -11,6 +11,7 @@ require_once dirname( __DIR__ ) . '/inc/core/route-classifier.php';
 require_once dirname( __DIR__ ) . '/inc/core/assets.php';
 require_once dirname( __DIR__ ) . '/inc/core/write-integrity.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities/track-page-view.php';
 
 /**
  * Verify public writes carry consistent first-party evidence and stay bounded.
@@ -21,30 +22,35 @@ final class PublicWriteIntegrityTest extends TestCase {
 	 */
 	protected function setUp(): void {
 		$_SERVER['HTTP_ORIGIN'] = 'https://extrachill.com';
-		unset( $_SERVER['HTTP_REFERER'], $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_SEC_GPC'], $_SERVER['HTTP_DNT'] );
-		$GLOBALS['extrachill_analytics_test_blog_id']     = 1;
-		$GLOBALS['extrachill_analytics_test_home_urls']   = array( 1 => 'https://extrachill.com' );
-		$GLOBALS['extrachill_analytics_test_domain_map']  = array(
+		unset( $_SERVER['HTTP_REFERER'], $_SERVER['HTTP_SEC_GPC'], $_SERVER['HTTP_DNT'] );
+		$_SERVER['HTTP_USER_AGENT']                              = 'Mozilla/5.0';
+		$_SERVER['REMOTE_ADDR']                                  = '203.0.113.10';
+		$GLOBALS['extrachill_analytics_test_blog_id']            = 1;
+		$GLOBALS['extrachill_analytics_test_home_urls']          = array( 1 => 'https://extrachill.com' );
+		$GLOBALS['extrachill_analytics_test_domain_map']         = array(
 			'extrachill.com'  => 1,
 			'extrachill.link' => 4,
 		);
-		$GLOBALS['extrachill_analytics_test_blog_slugs']  = array(
+		$GLOBALS['extrachill_analytics_test_blog_slugs']         = array(
 			1 => 'main',
 			4 => 'artist',
 			7 => 'events',
 		);
-		$GLOBALS['extrachill_analytics_test_transients']  = array();
-		$GLOBALS['extrachill_analytics_test_events']      = array();
-		$GLOBALS['extrachill_analytics_classifier_posts'] = array();
-		$GLOBALS['extrachill_analytics_test_permalinks']  = array();
-		$_COOKIE['ec_vid']                                = '123e4567-e89b-42d3-a456-426614174000';
+		$GLOBALS['extrachill_analytics_test_cache']              = array();
+		$GLOBALS['extrachill_analytics_test_ext_object_cache']   = true;
+		$GLOBALS['extrachill_analytics_test_events']             = array();
+		$GLOBALS['extrachill_analytics_test_tracked_post_views'] = array();
+		$GLOBALS['extrachill_analytics_test_actions']            = array();
+		$GLOBALS['extrachill_analytics_classifier_posts']        = array();
+		$GLOBALS['extrachill_analytics_test_permalinks']         = array();
+		$_COOKIE['ec_vid']                                       = '123e4567-e89b-42d3-a456-426614174000';
 	}
 
 	/**
 	 * Restore request fixtures.
 	 */
 	protected function tearDown(): void {
-		unset( $_SERVER['HTTP_ORIGIN'], $_SERVER['HTTP_REFERER'], $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_SEC_GPC'], $_SERVER['HTTP_DNT'], $_COOKIE['ec_vid'] );
+		unset( $_SERVER['HTTP_ORIGIN'], $_SERVER['HTTP_REFERER'], $_SERVER['HTTP_USER_AGENT'], $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_SEC_GPC'], $_SERVER['HTTP_DNT'], $_COOKIE['ec_vid'] );
 	}
 
 	/**
@@ -60,26 +66,47 @@ final class PublicWriteIntegrityTest extends TestCase {
 		$GLOBALS['extrachill_analytics_classifier_posts'][42] = $post;
 		$proof = extrachill_analytics_pageview_proof( 42, '/band/', 'singular', 'extrachill.link' );
 
-		$this->assertTrue( extrachill_analytics_validate_pageview_write( 42, '/band/', 'singular', $proof ) );
+		$result = extrachill_analytics_ability_track_page_view(
+			array(
+				'post_id'      => 42,
+				'source_path'  => '/band/',
+				'route_family' => 'singular',
+				'proof'        => $proof,
+			)
+		);
+
+		$this->assertSame( array( 'recorded' => true ), $result );
+		$this->assertSame( array( 42 ), $GLOBALS['extrachill_analytics_test_tracked_post_views'] );
+		$this->assertSame( '', $GLOBALS['extrachill_analytics_test_events'][0][3] );
 	}
 
 	/**
-	 * The deployed custom-domain adapter remains valid without a signed proof.
+	 * The custom template lifecycle enqueues the signed tracker it persists.
 	 */
-	public function test_legacy_mapped_domain_view_requires_matching_public_post(): void {
+	public function test_custom_domain_template_uses_signed_tracker(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local source fixture.
+		$assets = file_get_contents( dirname( __DIR__ ) . '/inc/core/assets.php' );
+
+		$this->assertNotFalse( $assets );
+		$this->assertStringContainsString(
+			"add_action( 'extrachill_artist_link_page_minimal_head', 'extrachill_analytics_enqueue_view_tracking', 20 )",
+			$assets
+		);
+	}
+
+	/**
+	 * The unreliable cross-origin legacy adapter is explicitly rejected.
+	 */
+	public function test_legacy_mapped_domain_view_without_source_proof_is_rejected(): void {
 		$GLOBALS['extrachill_analytics_test_blog_id']      = 4;
 		$GLOBALS['extrachill_analytics_test_home_urls'][4] = 'https://artist.extrachill.com';
 		$_SERVER['HTTP_ORIGIN']                            = 'https://extrachill.link';
-		$post            = new WP_Post();
-		$post->ID        = 42;
-		$post->post_name = 'band';
-		$GLOBALS['extrachill_analytics_classifier_posts'][42] = $post;
-		$GLOBALS['extrachill_analytics_test_permalinks'][42]  = 'https://artist.extrachill.com/artist-link-page/band/';
+		$_SERVER['HTTP_REFERER']                           = 'https://extrachill.link/';
 
-		$this->assertTrue( extrachill_analytics_validate_pageview_write( 42, '/band/', 'singular', '' ) );
-		$result = extrachill_analytics_validate_pageview_write( 42, '/another-band/', 'singular', '' );
+		$result = extrachill_analytics_ability_track_page_view( array( 'post_id' => 42 ) );
 		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_pageview_source', $result->code );
+		$this->assertSame( 'invalid_route', $result->code );
+		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_tracked_post_views'] );
 	}
 
 	/**
@@ -147,11 +174,16 @@ final class PublicWriteIntegrityTest extends TestCase {
 	}
 
 	/**
-	 * Public adapters cannot inject visitor identity, including under GPC.
+	 * Privacy signals stay anonymous and non-canonical protected names are rejected.
+	 *
+	 * @dataProvider privacy_header_provider
+	 *
+	 * @param string $header     Privacy header.
+	 * @param string $event_type Non-canonical protected event name.
 	 */
-	public function test_gpc_public_event_stays_anonymous(): void {
-		$_SERVER['HTTP_SEC_GPC'] = '1';
-		$result                  = extrachill_analytics_ability_track_event(
+	public function test_privacy_signal_and_noncanonical_event_admission( $header, $event_type ): void {
+		$_SERVER[ $header ] = '1';
+		$result             = extrachill_analytics_ability_track_event(
 			array(
 				'event_type' => 'outbound_click',
 				'event_data' => array( 'dest_host' => 'tickets.example' ),
@@ -162,6 +194,30 @@ final class PublicWriteIntegrityTest extends TestCase {
 
 		$this->assertSame( 1, $result );
 		$this->assertSame( '', $GLOBALS['extrachill_analytics_test_events'][0][3] );
+
+		$rejected = extrachill_analytics_ability_track_event(
+			array(
+				'event_type' => $event_type,
+				'event_data' => array( 'dest_host' => 'tickets.example' ),
+				'source_url' => '/story/',
+			)
+		);
+		$this->assertInstanceOf( WP_Error::class, $rejected );
+		$this->assertSame( 'invalid_event_type', $rejected->code );
+		$this->assertCount( 1, $GLOBALS['extrachill_analytics_test_events'] );
+	}
+
+	/**
+	 * Privacy headers.
+	 *
+	 * @return array<string,array{string,string}>
+	 */
+	public function privacy_header_provider() {
+		return array(
+			'gpc with uppercase event' => array( 'HTTP_SEC_GPC', 'OUTBOUND_CLICK' ),
+			'dnt with padded event'    => array( 'HTTP_DNT', ' outbound_click ' ),
+			'dnt with spaced event'    => array( 'HTTP_DNT', 'outbound click' ),
+		);
 	}
 
 	/**
@@ -178,14 +234,28 @@ final class PublicWriteIntegrityTest extends TestCase {
 	 * The Analytics-owned limiter rejects writes at its documented ceiling.
 	 */
 	public function test_public_write_rate_limit_is_bounded(): void {
-		$_SERVER['REMOTE_ADDR'] = '203.0.113.10';
-		$key                    = 'ec_an_write_' . substr( hash_hmac( 'sha256', '203.0.113.10', wp_salt( 'nonce' ) ), 0, 32 );
-		$GLOBALS['extrachill_analytics_test_transients'][ $key ] = 240;
+		$key   = 'write_' . substr( hash_hmac( 'sha256', '203.0.113.10', wp_salt( 'nonce' ) ), 0, 32 );
+		$group = 'extrachill-analytics-admission';
+		$GLOBALS['extrachill_analytics_test_cache'][ $group ][ $key ] = 240;
 
 		$result = extrachill_analytics_check_public_write_rate_limit();
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'analytics_write_rate_limited', $result->code );
 		$this->assertSame( 429, $result->data['status'] );
+		$this->assertSame( 241, $GLOBALS['extrachill_analytics_test_cache'][ $group ][ $key ] );
+	}
+
+	/**
+	 * Missing atomic storage fails closed instead of becoming unbounded.
+	 */
+	public function test_public_write_limiter_fails_closed_without_atomic_cache(): void {
+		$GLOBALS['extrachill_analytics_test_ext_object_cache'] = false;
+
+		$result = extrachill_analytics_check_public_write_rate_limit();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'analytics_write_limiter_unavailable', $result->code );
+		$this->assertSame( 503, $result->data['status'] );
 	}
 }

--- a/tests/PublicWriteIntegrityTest.php
+++ b/tests/PublicWriteIntegrityTest.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Tests for the public analytics write boundary.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/route-classifier.php';
+require_once dirname( __DIR__ ) . '/inc/core/assets.php';
+require_once dirname( __DIR__ ) . '/inc/core/write-integrity.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities.php';
+
+/**
+ * Verify public writes carry consistent first-party evidence and stay bounded.
+ */
+final class PublicWriteIntegrityTest extends TestCase {
+	/**
+	 * Establish a normal browser request.
+	 */
+	protected function setUp(): void {
+		$_SERVER['HTTP_ORIGIN'] = 'https://extrachill.com';
+		unset( $_SERVER['HTTP_REFERER'], $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_SEC_GPC'], $_SERVER['HTTP_DNT'] );
+		$GLOBALS['extrachill_analytics_test_blog_id']     = 1;
+		$GLOBALS['extrachill_analytics_test_home_urls']   = array( 1 => 'https://extrachill.com' );
+		$GLOBALS['extrachill_analytics_test_domain_map']  = array(
+			'extrachill.com'  => 1,
+			'extrachill.link' => 4,
+		);
+		$GLOBALS['extrachill_analytics_test_blog_slugs']  = array(
+			1 => 'main',
+			4 => 'artist',
+			7 => 'events',
+		);
+		$GLOBALS['extrachill_analytics_test_transients']  = array();
+		$GLOBALS['extrachill_analytics_test_events']      = array();
+		$GLOBALS['extrachill_analytics_classifier_posts'] = array();
+		$GLOBALS['extrachill_analytics_test_permalinks']  = array();
+		$_COOKIE['ec_vid']                                = '123e4567-e89b-42d3-a456-426614174000';
+	}
+
+	/**
+	 * Restore request fixtures.
+	 */
+	protected function tearDown(): void {
+		unset( $_SERVER['HTTP_ORIGIN'], $_SERVER['HTTP_REFERER'], $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_SEC_GPC'], $_SERVER['HTTP_DNT'], $_COOKIE['ec_vid'] );
+	}
+
+	/**
+	 * A mapped custom-domain render can submit its exact signed post tuple.
+	 */
+	public function test_mapped_custom_domain_post_view_is_accepted(): void {
+		$GLOBALS['extrachill_analytics_test_blog_id']      = 4;
+		$GLOBALS['extrachill_analytics_test_home_urls'][4] = 'https://artist.extrachill.com';
+		$_SERVER['HTTP_ORIGIN']                            = 'https://extrachill.link';
+		$post            = new WP_Post();
+		$post->ID        = 42;
+		$post->post_name = 'band';
+		$GLOBALS['extrachill_analytics_classifier_posts'][42] = $post;
+		$proof = extrachill_analytics_pageview_proof( 42, '/band/', 'singular', 'extrachill.link' );
+
+		$this->assertTrue( extrachill_analytics_validate_pageview_write( 42, '/band/', 'singular', $proof ) );
+	}
+
+	/**
+	 * The deployed custom-domain adapter remains valid without a signed proof.
+	 */
+	public function test_legacy_mapped_domain_view_requires_matching_public_post(): void {
+		$GLOBALS['extrachill_analytics_test_blog_id']      = 4;
+		$GLOBALS['extrachill_analytics_test_home_urls'][4] = 'https://artist.extrachill.com';
+		$_SERVER['HTTP_ORIGIN']                            = 'https://extrachill.link';
+		$post            = new WP_Post();
+		$post->ID        = 42;
+		$post->post_name = 'band';
+		$GLOBALS['extrachill_analytics_classifier_posts'][42] = $post;
+		$GLOBALS['extrachill_analytics_test_permalinks'][42]  = 'https://artist.extrachill.com/artist-link-page/band/';
+
+		$this->assertTrue( extrachill_analytics_validate_pageview_write( 42, '/band/', 'singular', '' ) );
+		$result = extrachill_analytics_validate_pageview_write( 42, '/another-band/', 'singular', '' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_pageview_source', $result->code );
+	}
+
+	/**
+	 * A proof cannot be moved to another post, path, host, or route family.
+	 */
+	public function test_pageview_proof_rejects_changed_source_tuple(): void {
+		$proof  = extrachill_analytics_pageview_proof( 0, '/events/', 'directory', 'extrachill.com' );
+		$result = extrachill_analytics_validate_pageview_write( 99, '/fake/', 'singular', $proof );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_pageview_proof', $result->code );
+	}
+
+	/**
+	 * Headerless clients cannot present public browser events as first-party.
+	 */
+	public function test_public_event_requires_current_site_browser_origin(): void {
+		unset( $_SERVER['HTTP_ORIGIN'] );
+		$result = extrachill_analytics_validate_public_event_write( 'outbound_click', array(), '/story/' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_event_origin', $result->code );
+	}
+
+	/**
+	 * Absolute source claims must agree with the browser origin.
+	 */
+	public function test_public_event_rejects_source_host_mismatch(): void {
+		$result = extrachill_analytics_validate_public_event_write( 'bridge_click', array(), 'https://attacker.example/story/' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_event_source', $result->code );
+	}
+
+	/**
+	 * Public event dimensions are checked and source URLs become query-free paths.
+	 */
+	public function test_public_event_normalizes_consistent_network_dimensions(): void {
+		$result = extrachill_analytics_validate_public_event_write(
+			'bridge_impression',
+			array(
+				'source_site' => 'main',
+				'dest_site'   => 'events',
+			),
+			'https://extrachill.com/story/?email=reader@example.test'
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( '/story/', $result['source_url'] );
+	}
+
+	/**
+	 * A source post cannot be attached to a different page path.
+	 */
+	public function test_public_event_rejects_source_post_mismatch(): void {
+		$GLOBALS['extrachill_analytics_test_permalinks'][42] = 'https://extrachill.com/real-story/';
+		$result = extrachill_analytics_validate_public_event_write(
+			'bridge_click',
+			array( 'source_post' => 42 ),
+			'/other-story/'
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_event_post', $result->code );
+	}
+
+	/**
+	 * Public adapters cannot inject visitor identity, including under GPC.
+	 */
+	public function test_gpc_public_event_stays_anonymous(): void {
+		$_SERVER['HTTP_SEC_GPC'] = '1';
+		$result                  = extrachill_analytics_ability_track_event(
+			array(
+				'event_type' => 'outbound_click',
+				'event_data' => array( 'dest_host' => 'tickets.example' ),
+				'source_url' => '/story/',
+				'visitor_id' => 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+			)
+		);
+
+		$this->assertSame( 1, $result );
+		$this->assertSame( '', $GLOBALS['extrachill_analytics_test_events'][0][3] );
+	}
+
+	/**
+	 * Server-owned event types do not inherit browser admission requirements.
+	 */
+	public function test_internal_event_contract_remains_unchanged(): void {
+		unset( $_SERVER['HTTP_ORIGIN'] );
+		$result = extrachill_analytics_validate_public_event_write( 'user_registration', array( 'method' => 'form' ), '/register/' );
+
+		$this->assertSame( '/register/', $result['source_url'] );
+	}
+
+	/**
+	 * The Analytics-owned limiter rejects writes at its documented ceiling.
+	 */
+	public function test_public_write_rate_limit_is_bounded(): void {
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.10';
+		$key                    = 'ec_an_write_' . substr( hash_hmac( 'sha256', '203.0.113.10', wp_salt( 'nonce' ) ), 0, 32 );
+		$GLOBALS['extrachill_analytics_test_transients'][ $key ] = 240;
+
+		$result = extrachill_analytics_check_public_write_rate_limit();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'analytics_write_rate_limited', $result->code );
+		$this->assertSame( 429, $result->data['status'] );
+	}
+}

--- a/tests/RouteJourneyTrackingTest.php
+++ b/tests/RouteJourneyTrackingTest.php
@@ -24,12 +24,14 @@ final class RouteJourneyTrackingTest extends TestCase {
 		$_SERVER['HTTP_HOST']                                    = 'extrachill.com';
 		$_SERVER['HTTP_ORIGIN']                                  = 'https://extrachill.com';
 		$_SERVER['HTTP_USER_AGENT']                              = 'Mozilla/5.0';
+		$_SERVER['REMOTE_ADDR']                                  = '203.0.113.20';
 		$_SERVER['REQUEST_METHOD']                               = 'GET';
 		$_COOKIE['ec_vid']                                       = '123e4567-e89b-42d3-a456-426614174000';
 		$GLOBALS['extrachill_analytics_test_tracked_post_views'] = array();
 		$GLOBALS['extrachill_analytics_test_events']             = array();
 		$GLOBALS['extrachill_analytics_test_actions']            = array();
-		$GLOBALS['extrachill_analytics_test_transients']         = array();
+		$GLOBALS['extrachill_analytics_test_cache']              = array();
+		$GLOBALS['extrachill_analytics_test_ext_object_cache']   = true;
 	}
 
 	/**
@@ -45,6 +47,7 @@ final class RouteJourneyTrackingTest extends TestCase {
 			$_SERVER['HTTP_HOST'],
 			$_SERVER['HTTP_ORIGIN'],
 			$_SERVER['HTTP_USER_AGENT'],
+			$_SERVER['REMOTE_ADDR'],
 			$_SERVER['HTTP_SEC_GPC'],
 			$_SERVER['REQUEST_METHOD'],
 			$_COOKIE['ec_vid']
@@ -111,8 +114,7 @@ final class RouteJourneyTrackingTest extends TestCase {
 		$this->assertStringContainsString( 'source_path: config.sourcePath', $script );
 		$this->assertStringContainsString( 'route_family: config.routeFamily', $script );
 		$this->assertStringNotContainsString( "rest_url( 'extrachill/v1/analytics/view' )", $assets );
-		$this->assertStringContainsString( "array( 'required' => array( 'post_id' ) )", $ability );
-		$this->assertStringContainsString( "array( 'required' => array( 'source_path', 'route_family' ) )", $ability );
+		$this->assertStringContainsString( "'required'   => array( 'source_path', 'route_family', 'proof' )", $ability );
 	}
 
 	/**

--- a/tests/RouteJourneyTrackingTest.php
+++ b/tests/RouteJourneyTrackingTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 require_once dirname( __DIR__ ) . '/inc/core/route-classifier.php';
 require_once dirname( __DIR__ ) . '/inc/core/referrer-host-classifier.php';
 require_once dirname( __DIR__ ) . '/inc/core/assets.php';
+require_once dirname( __DIR__ ) . '/inc/core/write-integrity.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/track-page-view.php';
 
 /**
@@ -20,14 +21,15 @@ final class RouteJourneyTrackingTest extends TestCase {
 	 * Establish a first-party browser beacon fixture.
 	 */
 	protected function setUp(): void {
-		$_SERVER['HTTP_HOST']                                    = 'events.extrachill.com';
-		$_SERVER['HTTP_ORIGIN']                                  = 'https://events.extrachill.com';
+		$_SERVER['HTTP_HOST']                                    = 'extrachill.com';
+		$_SERVER['HTTP_ORIGIN']                                  = 'https://extrachill.com';
 		$_SERVER['HTTP_USER_AGENT']                              = 'Mozilla/5.0';
 		$_SERVER['REQUEST_METHOD']                               = 'GET';
 		$_COOKIE['ec_vid']                                       = '123e4567-e89b-42d3-a456-426614174000';
 		$GLOBALS['extrachill_analytics_test_tracked_post_views'] = array();
 		$GLOBALS['extrachill_analytics_test_events']             = array();
 		$GLOBALS['extrachill_analytics_test_actions']            = array();
+		$GLOBALS['extrachill_analytics_test_transients']         = array();
 	}
 
 	/**
@@ -122,7 +124,7 @@ final class RouteJourneyTrackingTest extends TestCase {
 		$this->assertStringContainsString( 'if ( $post_id > 0 ) {', $ability );
 		$this->assertStringContainsString( "if ( \$post_id > 0 && get_post_type( \$post_id ) === 'artist_link_page' )", $ability );
 		$this->assertStringContainsString( "'view_kind'    => \$post_id > 0 ? 'post' : 'route'", $ability );
-		$this->assertStringContainsString( 'if ( $post_id <= 0 && ! $is_first_party_beacon )', $ability );
+		$this->assertStringContainsString( 'extrachill_analytics_validate_pageview_write', $ability );
 	}
 
 	/**
@@ -130,10 +132,12 @@ final class RouteJourneyTrackingTest extends TestCase {
 	 */
 	public function test_first_party_route_view_writes_event_only(): void {
 		$result = extrachill_analytics_ability_track_page_view(
-			array(
-				'source_path'  => '/events/?city=charleston',
-				'route_family' => 'directory',
-				'referrer'     => 'https://extrachill.com/story/?email=user@example.com',
+			$this->with_proof(
+				array(
+					'source_path'  => '/events/?city=charleston',
+					'route_family' => 'directory',
+					'referrer'     => 'https://community.extrachill.com/story/?email=user@example.com',
+				)
 			)
 		);
 
@@ -144,7 +148,7 @@ final class RouteJourneyTrackingTest extends TestCase {
 		$this->assertSame( 'route', $GLOBALS['extrachill_analytics_test_events'][0][1]['view_kind'] );
 		$this->assertSame( 'directory', $GLOBALS['extrachill_analytics_test_events'][0][1]['route_family'] );
 		$this->assertArrayNotHasKey( 'post_id', $GLOBALS['extrachill_analytics_test_events'][0][1] );
-		$this->assertSame( 'extrachill.com', $GLOBALS['extrachill_analytics_test_events'][0][1]['referrer_host'] );
+		$this->assertSame( 'community.extrachill.com', $GLOBALS['extrachill_analytics_test_events'][0][1]['referrer_host'] );
 		$this->assertSame( 'https://extrachill.com/events/', $GLOBALS['extrachill_analytics_test_events'][0][2] );
 	}
 
@@ -155,14 +159,16 @@ final class RouteJourneyTrackingTest extends TestCase {
 		$_SERVER['HTTP_ORIGIN'] = 'https://artist.example';
 
 		$result = extrachill_analytics_ability_track_page_view(
-			array(
-				'source_path'  => '/directory/',
-				'route_family' => 'directory',
+			$this->with_proof(
+				array(
+					'source_path'  => '/directory/',
+					'route_family' => 'directory',
+				)
 			)
 		);
 
 		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_route_origin', $result->code );
+		$this->assertSame( 'invalid_pageview_origin', $result->code );
 		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_events'] );
 	}
 
@@ -182,12 +188,17 @@ final class RouteJourneyTrackingTest extends TestCase {
 	public function test_post_backed_view_preserves_legacy_side_effects(): void {
 		$GLOBALS['extrachill_analytics_test_permalinks'][42] = 'https://artist.extrachill.com/example/';
 		$GLOBALS['extrachill_analytics_test_post_types'][42] = 'artist_link_page';
+		$post     = new WP_Post();
+		$post->ID = 42;
+		$GLOBALS['extrachill_analytics_classifier_posts'][42] = $post;
 
 		$result = extrachill_analytics_ability_track_page_view(
-			array(
-				'post_id'      => 42,
-				'source_path'  => '/example/',
-				'route_family' => 'singular',
+			$this->with_proof(
+				array(
+					'post_id'      => 42,
+					'source_path'  => '/example/',
+					'route_family' => 'singular',
+				)
 			)
 		);
 
@@ -196,6 +207,23 @@ final class RouteJourneyTrackingTest extends TestCase {
 		$this->assertSame( 'extrachill_link_page_view_recorded', $GLOBALS['extrachill_analytics_test_actions'][0][0] );
 		$this->assertSame( 'post', $GLOBALS['extrachill_analytics_test_events'][0][1]['view_kind'] );
 		$this->assertSame( 42, $GLOBALS['extrachill_analytics_test_events'][0][1]['post_id'] );
+	}
+
+	/**
+	 * Add the cache-safe proof emitted with a pageview configuration.
+	 *
+	 * @param array $input Pageview input.
+	 * @return array
+	 */
+	private function with_proof( $input ) {
+		$path           = extrachill_analytics_normalize_route_path( $input['source_path'] );
+		$input['proof'] = extrachill_analytics_pageview_proof(
+			isset( $input['post_id'] ) ? (int) $input['post_id'] : 0,
+			$path,
+			$input['route_family'],
+			extrachill_analytics_public_write_source_host()
+		);
+		return $input;
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -75,6 +75,55 @@ if ( ! function_exists( 'apply_filters' ) ) {
 		return $value;
 	}
 }
+if ( ! function_exists( 'is_wp_error' ) ) {
+	/**
+	 * Check the test error fixture type.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @return bool
+	 */
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! function_exists( 'wp_salt' ) ) {
+	/**
+	 * Return a stable test salt.
+	 *
+	 * @param string $scheme Salt scheme.
+	 * @return string
+	 */
+	function wp_salt( $scheme = 'auth' ) {
+		return 'test-salt-' . $scheme;
+	}
+}
+if ( ! function_exists( 'get_transient' ) ) {
+	/**
+	 * Read an in-memory transient fixture.
+	 *
+	 * @param string $key Transient key.
+	 * @return mixed
+	 */
+	function get_transient( $key ) {
+		return isset( $GLOBALS['extrachill_analytics_test_transients'][ $key ] )
+			? $GLOBALS['extrachill_analytics_test_transients'][ $key ]
+			: false;
+	}
+}
+if ( ! function_exists( 'set_transient' ) ) {
+	/**
+	 * Store an in-memory transient fixture.
+	 *
+	 * @param string $key        Transient key.
+	 * @param mixed  $value      Transient value.
+	 * @param int    $expiration Expiration (unused in fixture).
+	 * @return bool
+	 */
+	function set_transient( $key, $value, $expiration ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$GLOBALS['extrachill_analytics_test_transients'][ $key ] = $value;
+		return true;
+	}
+}
 if ( ! function_exists( 'sanitize_key' ) ) {
 	/**
 	 * Stub for sanitize_key().
@@ -84,6 +133,28 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	 */
 	function sanitize_key( $key ) {
 		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) );
+	}
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	/**
+	 * Normalize a title fixture to a slug.
+	 *
+	 * @param string $title Candidate title.
+	 * @return string
+	 */
+	function sanitize_title( $title ) {
+		return trim( strtolower( preg_replace( '/[^a-z0-9]+/i', '-', (string) $title ) ), '-' );
+	}
+}
+if ( ! function_exists( 'untrailingslashit' ) ) {
+	/**
+	 * Remove trailing slashes from a fixture string.
+	 *
+	 * @param string $value Input value.
+	 * @return string
+	 */
+	function untrailingslashit( $value ) {
+		return rtrim( (string) $value, '/\\' );
 	}
 }
 if ( ! function_exists( 'extrachill_analytics_events_table' ) ) {
@@ -370,6 +441,54 @@ if ( ! function_exists( 'home_url' ) ) {
 		$homes   = isset( $GLOBALS['extrachill_analytics_test_home_urls'] ) ? $GLOBALS['extrachill_analytics_test_home_urls'] : array();
 		$home    = isset( $homes[ $blog_id ] ) ? $homes[ $blog_id ] : 'https://extrachill.com';
 		return rtrim( $home, '/' ) . '/' . ltrim( $path, '/' );
+	}
+}
+if ( ! function_exists( 'site_url' ) ) {
+	/**
+	 * Return the configured site URL fixture.
+	 *
+	 * @param string $path Optional path.
+	 * @return string
+	 */
+	function site_url( $path = '' ) {
+		return home_url( $path );
+	}
+}
+if ( ! function_exists( 'ec_get_domain_map' ) ) {
+	/**
+	 * Return mapped-domain fixtures.
+	 *
+	 * @return array<string,int>
+	 */
+	function ec_get_domain_map() {
+		return isset( $GLOBALS['extrachill_analytics_test_domain_map'] )
+			? $GLOBALS['extrachill_analytics_test_domain_map']
+			: array( 'extrachill.com' => 1 );
+	}
+}
+if ( ! function_exists( 'ec_get_blog_slug_by_id' ) ) {
+	/**
+	 * Return a logical site slug fixture.
+	 *
+	 * @param int $blog_id Blog ID.
+	 * @return string
+	 */
+	function ec_get_blog_slug_by_id( $blog_id ) {
+		$slugs = isset( $GLOBALS['extrachill_analytics_test_blog_slugs'] ) ? $GLOBALS['extrachill_analytics_test_blog_slugs'] : array( 1 => 'main' );
+		return isset( $slugs[ (int) $blog_id ] ) ? $slugs[ (int) $blog_id ] : '';
+	}
+}
+if ( ! function_exists( 'ec_get_blog_id' ) ) {
+	/**
+	 * Resolve a logical site fixture.
+	 *
+	 * @param string $slug Logical site slug.
+	 * @return int|null
+	 */
+	function ec_get_blog_id( $slug ) {
+		$slugs   = isset( $GLOBALS['extrachill_analytics_test_blog_slugs'] ) ? $GLOBALS['extrachill_analytics_test_blog_slugs'] : array( 1 => 'main' );
+		$blog_id = array_search( $slug, $slugs, true );
+		return false === $blog_id ? null : (int) $blog_id;
 	}
 }
 if ( ! function_exists( 'wp_parse_url' ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -97,31 +97,50 @@ if ( ! function_exists( 'wp_salt' ) ) {
 		return 'test-salt-' . $scheme;
 	}
 }
-if ( ! function_exists( 'get_transient' ) ) {
+if ( ! function_exists( 'wp_using_ext_object_cache' ) ) {
 	/**
-	 * Read an in-memory transient fixture.
+	 * Return the persistent-cache fixture state.
 	 *
-	 * @param string $key Transient key.
-	 * @return mixed
+	 * @return bool
 	 */
-	function get_transient( $key ) {
-		return isset( $GLOBALS['extrachill_analytics_test_transients'][ $key ] )
-			? $GLOBALS['extrachill_analytics_test_transients'][ $key ]
-			: false;
+	function wp_using_ext_object_cache() {
+		return ! isset( $GLOBALS['extrachill_analytics_test_ext_object_cache'] )
+			|| (bool) $GLOBALS['extrachill_analytics_test_ext_object_cache'];
 	}
 }
-if ( ! function_exists( 'set_transient' ) ) {
+if ( ! function_exists( 'wp_cache_add' ) ) {
 	/**
-	 * Store an in-memory transient fixture.
+	 * Atomically add a cache fixture when absent.
 	 *
-	 * @param string $key        Transient key.
-	 * @param mixed  $value      Transient value.
+	 * @param string $key        Cache key.
+	 * @param mixed  $value      Cache value.
+	 * @param string $group      Cache group.
 	 * @param int    $expiration Expiration (unused in fixture).
 	 * @return bool
 	 */
-	function set_transient( $key, $value, $expiration ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$GLOBALS['extrachill_analytics_test_transients'][ $key ] = $value;
+	function wp_cache_add( $key, $value, $group = '', $expiration = 0 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( isset( $GLOBALS['extrachill_analytics_test_cache'][ $group ][ $key ] ) ) {
+			return false;
+		}
+		$GLOBALS['extrachill_analytics_test_cache'][ $group ][ $key ] = $value;
 		return true;
+	}
+}
+if ( ! function_exists( 'wp_cache_incr' ) ) {
+	/**
+	 * Atomically increment an existing cache fixture.
+	 *
+	 * @param string $key    Cache key.
+	 * @param int    $offset Increment amount.
+	 * @param string $group  Cache group.
+	 * @return int|false
+	 */
+	function wp_cache_incr( $key, $offset = 1, $group = '' ) {
+		if ( ! isset( $GLOBALS['extrachill_analytics_test_cache'][ $group ][ $key ] ) ) {
+			return false;
+		}
+		$GLOBALS['extrachill_analytics_test_cache'][ $group ][ $key ] += (int) $offset;
+		return $GLOBALS['extrachill_analytics_test_cache'][ $group ][ $key ];
 	}
 }
 if ( ! function_exists( 'sanitize_key' ) ) {

--- a/tests/class-wp-post.php
+++ b/tests/class-wp-post.php
@@ -23,5 +23,19 @@ if ( ! class_exists( 'WP_Post' ) ) {
 		 * @var string
 		 */
 		public $post_title = '';
+
+		/**
+		 * Post slug.
+		 *
+		 * @var string
+		 */
+		public $post_name = '';
+
+		/**
+		 * Post status.
+		 *
+		 * @var string
+		 */
+		public $post_status = 'publish';
 	}
 }


### PR DESCRIPTION
## Summary
- bind every pageview write to a cache-safe server-rendered proof covering blog, host, path, route family, and post
- canonicalize event names before admission and reject any non-canonical spelling before protected-event checks or persistence
- enforce Analytics-owned source/post/site consistency and an atomic per-client write ceiling
- enqueue the signed tracker through the custom-domain minimal-head lifecycle and retire the unreliable post-only legacy Ability shape

## Trust model
Public browser telemetry is behavioral evidence, not authenticated user input. A supplied `Origin`/`Referer` must resolve to the current multisite blog through its canonical URL or the existing network domain map. Pageviews additionally require an HMAC proof emitted with the rendered page; the proof has no visitor data and binds only the cache-safe blog/host/path/family/post tuple.

Public click/impression adapters remain responsible for HTTP request normalization. Analytics independently owns canonical event names, source/post/site consistency, visitor identity, admission bounds, and persistence.

The proof is replayable because the page is public, so replay is bounded rather than treated as authentication. Analytics atomically admits at most 240 public writes per validated client IP in a one-minute cache window. The persistent object-cache key contains only a salted IP hash. `wp_cache_add()` creates the expiring window and `wp_cache_incr()` atomically increments it. Missing client IP, persistent cache, or atomic increment fails closed with HTTP 503 rather than silently creating an unbounded fallback.

## Accepted requests
- pageview Ability writes with a current-site or mapped-domain browser origin and a valid proof for the exact blog/host/path/family/post tuple
- `bridge_click`, `bridge_impression`, `outbound_click`, and `share_click` writes using exact canonical identifiers from the current site
- public event writes with a relative source path or an absolute source URL whose host agrees with the browser origin
- bridge events whose source site matches the current blog and whose destination resolves to another known network blog
- homepage bridge events, with an incidental loop post ID normalized to zero
- server-owned canonical event types such as registration, onboarding, and search without browser admission requirements

## Rejected requests
- non-canonical event identifiers, including uppercase, padded, or space-separated forms, before they can bypass protected admission and later sanitize into another value
- headerless, third-party, or wrong-blog browser writes
- pageview requests without a proof or with a proof replayed against another host, path, route family, post, or blog
- the legacy post-only `/analytics/view` Ability shape, which cannot prove its path because normal cross-origin referrer policy reduces the custom-domain referrer to its origin
- unpublished or missing claimed posts
- absolute event source URLs that contradict the browser origin
- bridge source-site, destination-site, or source-post dimensions that contradict the current blog/path
- writes above the atomic 240-write limit with HTTP 429
- writes when atomic admission cannot be guaranteed with HTTP 503

## Custom domains
Mapped domains resolve through the existing `ec_get_domain_map()` contract. The `extrachill.link` template bypasses `wp_head()`, so Analytics now enqueues the same signed direct tracker through its existing minimal-head lifecycle. The signed custom-domain request remains anonymous and records the normal post counter/event side effects. The broken post-only legacy shape is explicitly rejected rather than inferred from an origin-only referrer.

A live WordPress smoke confirmed a real published `artist_link_page` passes signed `extrachill.link` admission.

## Privacy
GPC (`Sec-GPC: 1`) and DNT (`DNT: 1`) behavior is unchanged: eligible aggregate rows are recorded, but public event callers cannot inject `visitor_id`; Analytics rereads the first-party cookie through the existing privacy-aware resolver. End-to-end tests cover canonical anonymous writes and uppercase, padded, and space-separated protected-event rejection under both privacy signals.

Custom-domain requests remain anonymous because the existing first-party cookie boundary does not stitch across registrable domains. No visitor identity, session state, or per-user value is added to cacheable HTML.

## API #116 compatibility
Extra-Chill/extrachill-api#116 continues to own click/impression HTTP normalization, scanner/payload rejection, destination checks, and its adapter-level limit. Its canonical event names and query-free relative `source_url` output are accepted, then independently checked against the browser origin and current-site event dimensions. Analytics does not duplicate destination parsing or move API adapter responsibilities.

## Verification
- `vendor/bin/phpunit` (290 tests, 1,028 assertions)
- changed-file WordPress PHPCS
- PHP syntax checks for all changed production PHP files
- `node --check assets/js/view-tracking.js`
- live WordPress/Redis atomic counter smoke (`add` -> 1, `incr` -> 2; temporary key deleted)
- live signed mapped-domain admission smoke against a published `artist_link_page` (temporary key deleted)
- `git diff --check`

Closes #184

## Documentation coordination
README and AGENTS now define the signed Core Abilities tracker as the sole browser pageview path and mark post-only public input as invalid. Coordinated legacy removals are tracked in Extra-Chill/extrachill-artist-platform#133, Extra-Chill/extrachill-api#118, and Extra-Chill/extrachill-api-client#14. Focused verification: 31 pageview integrity tests / 102 assertions, stale active-pattern scan clean, and git diff --check.