### PR TITLE
feat: attribute lifecycle conversion outcomes

### DIFF
--- a/inc/core/abilities/get-conversion-map.php
+++ b/inc/core/abilities/get-conversion-map.php
@@ -230,28 +230,6 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 	);
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
-	// Outcomes are read independently from the pageview cohort because direct
-	// source attribution remains useful when a signup has no visitor identity.
-	// Successful registrations/newsletter signups are server-side outcomes, so
-	// their write-time request classifier is not used as an outcome validity
-	// filter (REST registration requests can legitimately carry is_bot=true).
-	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$outcome_rows = $wpdb->get_results(
-		$wpdb->prepare(
-			"SELECT id, event_type, event_data, source_url, user_id, visitor_id, UNIX_TIMESTAMP(created_at) AS ts
-			FROM {$table}
-			WHERE event_type IN (%s, %s)
-				AND created_at >= %s
-				AND created_at <= %s
-			ORDER BY created_at ASC, id ASC",
-			'newsletter_signup',
-			'user_registration',
-			$since,
-			$now_utc
-		)
-	);
-	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-
 	// Accumulators.
 	$overall = array(
 		'entry_sessions'           => 0,
@@ -273,8 +251,8 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 	$by_article  = array();
 	$by_category = array();
 
-	$outcome_types        = array( 'newsletter_signup', 'user_registration' );
-	$outcome_overall      = extrachill_analytics_conversion_outcome_zero_bucket();
+	$outcome_types        = extrachill_analytics_conversion_outcome_types();
+	$outcome_overall      = extrachill_analytics_conversion_outcome_zero_bucket( $outcome_types );
 	$outcomes_by_article  = array();
 	$outcomes_by_category = array();
 	$outcome_coverage     = array();
@@ -452,94 +430,31 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 
 	// Attribute each deduplicated outcome through two independent lenses:
 	// direct source_url resolution and the visitor's eligible entry journey.
-	// Neither lens fills gaps in the other.
+	// Neither lens fills gaps in the other. Read in deterministic keyset pages so
+	// adding lifecycle outcomes does not materialize an unbounded event window.
 	$seen_outcomes = array();
-	foreach ( (array) $outcome_rows as $row ) {
-		$type = (string) $row->event_type;
-		if ( ! isset( $outcome_coverage[ $type ] ) ) {
-			continue;
+	extrachill_analytics_conversion_each_outcome_page(
+		$table,
+		$outcome_types,
+		$since,
+		$now_utc,
+		static function ( $page ) use ( $entry_blog_id, $journeys_by_visitor, &$outcome_overall, &$outcomes_by_article, &$outcomes_by_category, &$outcome_coverage, &$seen_outcomes ) {
+			extrachill_analytics_conversion_attribute_outcome_rows(
+				$page,
+				$entry_blog_id,
+				$journeys_by_visitor,
+				$outcome_overall,
+				$outcomes_by_article,
+				$outcomes_by_category,
+				$outcome_coverage,
+				$seen_outcomes
+			);
 		}
-
-		$data = json_decode( (string) $row->event_data, true );
-		$data = is_array( $data ) ? $data : array();
-		++$outcome_coverage[ $type ]['stored_events'];
-
-		// The newsletter emitter already skips registration subscriptions. Keep
-		// this guard so legacy or alternate emitters cannot inflate the outcome.
-		if ( 'newsletter_signup' === $type && 'registration' === (string) ( $data['context'] ?? '' ) ) {
-			++$outcome_coverage[ $type ]['automatic_registration_excluded'];
-			continue;
-		}
-
-		$outcome    = array(
-			'id'         => (int) $row->id,
-			'event_type' => $type,
-			'event_data' => $data,
-			'source_url' => (string) $row->source_url,
-			'user_id'    => (int) $row->user_id,
-			'visitor_id' => (string) $row->visitor_id,
-			'ts'         => (int) $row->ts,
-		);
-		$dedupe_key = extrachill_analytics_conversion_outcome_dedupe_key( $outcome );
-		if ( isset( $seen_outcomes[ $type ][ $dedupe_key ] ) ) {
-			++$outcome_coverage[ $type ]['duplicate_events'];
-			continue;
-		}
-		$seen_outcomes[ $type ][ $dedupe_key ] = true;
-		++$outcome_coverage[ $type ]['deduplicated_outcomes'];
-
-		$direct_post_id = 0;
-		if ( '' === trim( $outcome['source_url'] ) ) {
-			++$outcome_coverage[ $type ]['missing_source_url'];
-		} else {
-			++$outcome_coverage[ $type ]['with_source_url'];
-			$direct_post_id = extrachill_analytics_conversion_source_article_id( $outcome['source_url'], $entry_blog_id );
-			if ( $direct_post_id > 0 ) {
-				++$outcome_coverage[ $type ]['direct_source_attributed'];
-				extrachill_analytics_conversion_apply_outcome( $outcome_overall, $type, 'direct_source' );
-				extrachill_analytics_conversion_apply_article_outcome(
-					$outcomes_by_article,
-					$outcomes_by_category,
-					$direct_post_id,
-					$type,
-					'direct_source'
-				);
-			} else {
-				++$outcome_coverage[ $type ]['unresolved_source_url'];
-			}
-		}
-
-		$visitor_id = $outcome['visitor_id'];
-		if ( '' === $visitor_id ) {
-			++$outcome_coverage[ $type ]['missing_visitor_identity'];
-			continue;
-		}
-		++$outcome_coverage[ $type ]['with_visitor_identity'];
-
-		if ( ! isset( $journeys_by_visitor[ $visitor_id ] ) ) {
-			++$outcome_coverage[ $type ]['identity_without_eligible_journey'];
-			continue;
-		}
-
-		$stage = extrachill_analytics_conversion_outcome_journey_stage( $outcome['ts'], $journeys_by_visitor[ $visitor_id ] );
-		if ( null === $stage ) {
-			++$outcome_coverage[ $type ]['outcome_before_entry'];
-			continue;
-		}
-
-		++$outcome_coverage[ $type ]['visitor_journey_attributed'];
-		extrachill_analytics_conversion_apply_outcome( $outcome_overall, $type, $stage );
-		extrachill_analytics_conversion_apply_article_outcome(
-			$outcomes_by_article,
-			$outcomes_by_category,
-			(int) $journeys_by_visitor[ $visitor_id ]['post_id'],
-			$type,
-			$stage
-		);
-	}
+	);
 
 	foreach ( $outcome_types as $outcome_type ) {
-		$outcome_coverage[ $outcome_type ] = extrachill_analytics_conversion_finalize_outcome_coverage( $outcome_coverage[ $outcome_type ] );
+		$is_new_lifecycle_outcome          = ! in_array( $outcome_type, array( 'newsletter_signup', 'user_registration' ), true );
+		$outcome_coverage[ $outcome_type ] = extrachill_analytics_conversion_finalize_outcome_coverage( $outcome_coverage[ $outcome_type ], $is_new_lifecycle_outcome );
 	}
 
 	$article_outcomes  = extrachill_analytics_conversion_rank_article_outcomes(
@@ -620,26 +535,196 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 		'period'                      => gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' ),
 		'since'                       => $since,
 		'as_of'                       => $now_utc,
-		'note'                        => 'First-party, bot-filtered editorial-to-platform funnel. entry_sessions is a legacy field name: it counts one first eligible, mature entry journey per visitor, not every entry session. Eligible entries start on a published blog-1 post; route views never become editorial entries. Same-session and return reach include eligible collected events/community/artist routes. Newsletter and registration outcomes are successful server-side events and are reported through separate direct-source and visitor-journey lenses. Automatic registration newsletter subscriptions are excluded. Missing source or visitor identity remains explicit coverage, never an inferred zero. Route-level destination collection is additive from issue #182 onward, so historical periods remain singular-only. The query reads one inactivity-gap before the lower boundary to avoid session truncation, and excludes late entries until they have the configured return observation period. NULL-visitor pageviews (GPC/DNT opt-out) cannot be sessionized and are excluded.',
+		'note'                        => 'First-party, bot-filtered editorial-to-platform funnel. entry_sessions is a legacy field name: it counts one first eligible, mature entry journey per visitor, not every entry session. Eligible entries start on a published blog-1 post; route views never become editorial entries. Same-session and return reach include eligible collected events/community/artist routes. Newsletter signup, registration, onboarding completion, artist profile first publication, and Local Scene prompt completion are successful server-side outcomes reported through separate direct-source and visitor-journey lenses. Automatic registration newsletter subscriptions are excluded. Missing source or visitor identity and outcome types absent from the window remain explicit coverage, never an inferred zero. Route-level destination collection is additive from issue #182 onward, so historical periods remain singular-only. Pageviews include one inactivity-gap before the lower boundary; outcomes are read in bounded keyset pages. Late entries without the configured return observation period and NULL-visitor pageviews (GPC/DNT opt-out) are excluded.',
 	);
+}
+
+/**
+ * Concrete successful outcomes included in the conversion map.
+ *
+ * These names remain visible in output and are not collapsed into a generic
+ * conversion type. Each lifecycle emitter carries user_id in event_data and
+ * uses the existing analytics visitor cookie path; source_url coverage remains
+ * independently reported because those emitters currently omit it.
+ *
+ * @return string[] Canonical outcome event names.
+ */
+function extrachill_analytics_conversion_outcome_types() {
+	return array(
+		'newsletter_signup',
+		'user_registration',
+		defined( 'EC_ANALYTICS_EVENT_ONBOARDING_COMPLETED' ) ? EC_ANALYTICS_EVENT_ONBOARDING_COMPLETED : 'onboarding_completed',
+		defined( 'EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH' ) ? EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH : 'artist_profile_first_publish',
+		defined( 'EC_ANALYTICS_EVENT_LOCAL_SCENE_PROMPT_COMPLETED' ) ? EC_ANALYTICS_EVENT_LOCAL_SCENE_PROMPT_COMPLETED : 'local_scene_prompt_completed',
+	);
+}
+
+/**
+ * Read outcome rows in deterministic bounded keyset pages.
+ *
+ * @param string   $table         Trusted analytics events table name.
+ * @param string[] $outcome_types Concrete outcome event names.
+ * @param string   $since         Inclusive UTC lower bound.
+ * @param string   $as_of         Inclusive UTC upper bound.
+ * @param callable $consume       Receives each ordered page.
+ */
+function extrachill_analytics_conversion_each_outcome_page( $table, $outcome_types, $since, $as_of, $consume ) {
+	global $wpdb;
+
+	$page_size          = 500;
+	$event_placeholders = implode( ', ', array_fill( 0, count( $outcome_types ), '%s' ) );
+	$cursor_time        = null;
+	$cursor_id          = 0;
+
+	do {
+		$where  = array(
+			"event_type IN ({$event_placeholders})",
+			'created_at >= %s',
+			'created_at <= %s',
+		);
+		$values = array_merge( array_map( 'sanitize_key', $outcome_types ), array( $since, $as_of ) );
+
+		if ( null !== $cursor_time ) {
+			$where[]  = '(created_at > %s OR (created_at = %s AND id > %d))';
+			$values[] = $cursor_time;
+			$values[] = $cursor_time;
+			$values[] = $cursor_id;
+		}
+		$values[] = $page_size;
+
+		$where_clause = implode( ' AND ', $where );
+		// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery -- Bounded reporting page; identifiers are code-defined and every value is prepared.
+		$sql  = "SELECT id, event_type, event_data, source_url, user_id, visitor_id, created_at, UNIX_TIMESTAMP(created_at) AS ts
+			FROM {$table}
+			WHERE {$where_clause}
+			ORDER BY created_at ASC, id ASC
+			LIMIT %d";
+		$page = (array) $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+		// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery
+
+		if ( empty( $page ) ) {
+			break;
+		}
+
+		$consume( $page );
+		$page_count  = count( $page );
+		$last        = end( $page );
+		$cursor_time = (string) $last->created_at;
+		$cursor_id   = (int) $last->id;
+	} while ( $page_count === $page_size );
+}
+
+/**
+ * Attribute one ordered page of concrete outcome rows.
+ *
+ * State is passed by reference so deduplication and counts remain stable across
+ * keyset pages. The first stored event for a person/outcome wins; therefore an
+ * outcome before entry is never replaced by a later duplicate.
+ *
+ * @param object[] $rows                  Ordered outcome rows.
+ * @param int      $entry_blog_id         Editorial blog ID.
+ * @param array    $journeys_by_visitor   Eligible journeys keyed by visitor.
+ * @param array    $outcome_overall       Overall buckets, by reference.
+ * @param array    $outcomes_by_article   Article buckets, by reference.
+ * @param array    $outcomes_by_category  Category buckets, by reference.
+ * @param array    $outcome_coverage      Coverage by event type, by reference.
+ * @param array    $seen_outcomes         Seen person/outcome keys, by reference.
+ */
+function extrachill_analytics_conversion_attribute_outcome_rows( $rows, $entry_blog_id, $journeys_by_visitor, &$outcome_overall, &$outcomes_by_article, &$outcomes_by_category, &$outcome_coverage, &$seen_outcomes ) {
+	foreach ( $rows as $row ) {
+		$type = (string) $row->event_type;
+		if ( ! isset( $outcome_coverage[ $type ] ) ) {
+			continue;
+		}
+
+		$data = json_decode( (string) $row->event_data, true );
+		$data = is_array( $data ) ? $data : array();
+		++$outcome_coverage[ $type ]['stored_events'];
+
+		if ( 'newsletter_signup' === $type && 'registration' === (string) ( $data['context'] ?? '' ) ) {
+			++$outcome_coverage[ $type ]['automatic_registration_excluded'];
+			continue;
+		}
+
+		$outcome    = array(
+			'id'         => (int) $row->id,
+			'event_type' => $type,
+			'event_data' => $data,
+			'source_url' => (string) $row->source_url,
+			'user_id'    => (int) $row->user_id,
+			'visitor_id' => (string) $row->visitor_id,
+			'ts'         => (int) $row->ts,
+		);
+		$dedupe_key = extrachill_analytics_conversion_outcome_dedupe_key( $outcome );
+		if ( isset( $seen_outcomes[ $type ][ $dedupe_key ] ) ) {
+			++$outcome_coverage[ $type ]['duplicate_events'];
+			continue;
+		}
+		$seen_outcomes[ $type ][ $dedupe_key ] = true;
+		++$outcome_coverage[ $type ]['deduplicated_outcomes'];
+
+		if ( '' === trim( $outcome['source_url'] ) ) {
+			++$outcome_coverage[ $type ]['missing_source_url'];
+		} else {
+			++$outcome_coverage[ $type ]['with_source_url'];
+			$direct_post_id = extrachill_analytics_conversion_source_article_id( $outcome['source_url'], $entry_blog_id );
+			if ( $direct_post_id > 0 ) {
+				++$outcome_coverage[ $type ]['direct_source_attributed'];
+				extrachill_analytics_conversion_apply_outcome( $outcome_overall, $type, 'direct_source' );
+				extrachill_analytics_conversion_apply_article_outcome( $outcomes_by_article, $outcomes_by_category, $direct_post_id, $type, 'direct_source' );
+			} else {
+				++$outcome_coverage[ $type ]['unresolved_source_url'];
+			}
+		}
+
+		$visitor_id = trim( $outcome['visitor_id'] );
+		if ( '' === $visitor_id ) {
+			++$outcome_coverage[ $type ]['missing_visitor_identity'];
+			continue;
+		}
+		++$outcome_coverage[ $type ]['with_visitor_identity'];
+
+		if ( ! isset( $journeys_by_visitor[ $visitor_id ] ) ) {
+			++$outcome_coverage[ $type ]['identity_without_eligible_journey'];
+			continue;
+		}
+
+		$stage = extrachill_analytics_conversion_outcome_journey_stage( $outcome['ts'], $journeys_by_visitor[ $visitor_id ] );
+		if ( null === $stage ) {
+			++$outcome_coverage[ $type ]['outcome_before_entry'];
+			continue;
+		}
+
+		++$outcome_coverage[ $type ]['visitor_journey_attributed'];
+		extrachill_analytics_conversion_apply_outcome( $outcome_overall, $type, $stage );
+		extrachill_analytics_conversion_apply_article_outcome(
+			$outcomes_by_article,
+			$outcomes_by_category,
+			(int) $journeys_by_visitor[ $visitor_id ]['post_id'],
+			$type,
+			$stage
+		);
+	}
 }
 
 /**
  * Build an empty outcome-attribution bucket.
  *
+ * @param string[]|null $outcome_types Outcome event names, or the canonical set.
  * @return array<string,array<string,int>> Outcome counts by type and lens.
  */
-function extrachill_analytics_conversion_outcome_zero_bucket() {
+function extrachill_analytics_conversion_outcome_zero_bucket( $outcome_types = null ) {
 	$shape = array(
 		'direct_source' => 0,
 		'same_session'  => 0,
 		'later_session' => 0,
 	);
 
-	return array(
-		'newsletter_signup' => $shape,
-		'user_registration' => $shape,
-	);
+	$bucket = array();
+	foreach ( null === $outcome_types ? extrachill_analytics_conversion_outcome_types() : $outcome_types as $outcome_type ) {
+		$bucket[ $outcome_type ] = $shape;
+	}
+	return $bucket;
 }
 
 /**
@@ -789,14 +874,15 @@ function extrachill_analytics_conversion_apply_article_outcome( &$by_article, &$
 /**
  * Finalize coverage statuses without converting missing instrumentation to zero.
  *
- * @param array $coverage Raw coverage counters.
+ * @param array $coverage       Raw coverage counters.
+ * @param bool  $absence_is_gap Whether no observed rows means unavailable coverage.
  * @return array Coverage counters plus stable lens statuses.
  */
-function extrachill_analytics_conversion_finalize_outcome_coverage( $coverage ) {
+function extrachill_analytics_conversion_finalize_outcome_coverage( $coverage, $absence_is_gap = false ) {
 	$total = (int) $coverage['deduplicated_outcomes'];
 	if ( 0 === $total ) {
-		$direct_status  = 'measured';
-		$journey_status = 'measured';
+		$direct_status  = $absence_is_gap ? 'not_instrumented' : 'measured';
+		$journey_status = $absence_is_gap ? 'not_instrumented' : 'measured';
 	} else {
 		$direct_status  = 0 === (int) $coverage['with_source_url']
 			? 'not_instrumented'
@@ -806,6 +892,7 @@ function extrachill_analytics_conversion_finalize_outcome_coverage( $coverage ) 
 			: ( (int) $coverage['with_visitor_identity'] === $total ? 'measured' : 'partial' );
 	}
 
+	$coverage['instrumentation_status'] = 0 === (int) $coverage['stored_events'] ? 'not_observed' : 'observed';
 	$coverage['direct_source_status']   = $direct_status;
 	$coverage['visitor_journey_status'] = $journey_status;
 	return $coverage;
@@ -823,7 +910,7 @@ function extrachill_analytics_conversion_finalize_outcome_coverage( $coverage ) 
  */
 function extrachill_analytics_conversion_outcome_row( $bucket, $coverage ) {
 	$row = array();
-	foreach ( array( 'newsletter_signup', 'user_registration' ) as $type ) {
+	foreach ( array_keys( $coverage ) as $type ) {
 		$direct_status  = (string) $coverage[ $type ]['direct_source_status'];
 		$journey_status = (string) $coverage[ $type ]['visitor_journey_status'];
 		$row[ $type ]   = array(

--- a/inc/core/abilities/get-conversion-map.php
+++ b/inc/core/abilities/get-conversion-map.php
@@ -428,28 +428,44 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 		$flush( $buffer, $current_visitor );
 	}
 
-	// Attribute each deduplicated outcome through two independent lenses:
-	// direct source_url resolution and the visitor's eligible entry journey.
-	// Neither lens fills gaps in the other. Read in deterministic keyset pages so
-	// adding lifecycle outcomes does not materialize an unbounded event window.
-	$seen_outcomes = array();
+	// First observe window-local visitor/user bridges, exactly matching the
+	// activation funnel: only one-to-one visitors stitch to a user. The second
+	// bounded pass can then deduplicate mixed anonymous/authenticated rows before
+	// applying either attribution lens.
+	$visitor_users = array();
 	extrachill_analytics_conversion_each_outcome_page(
 		$table,
 		$outcome_types,
 		$since,
 		$now_utc,
-		static function ( $page ) use ( $entry_blog_id, $journeys_by_visitor, &$outcome_overall, &$outcomes_by_article, &$outcomes_by_category, &$outcome_coverage, &$seen_outcomes ) {
-			extrachill_analytics_conversion_attribute_outcome_rows(
+		static function ( $page ) use ( &$visitor_users ) {
+			extrachill_analytics_conversion_observe_outcome_identities( $page, $visitor_users );
+		}
+	);
+	$visitor_to_user = extrachill_analytics_conversion_resolve_outcome_identities( $visitor_users );
+	$outcome_records = array();
+	extrachill_analytics_conversion_each_outcome_page(
+		$table,
+		$outcome_types,
+		$since,
+		$now_utc,
+		static function ( $page ) use ( $entry_blog_id, $journeys_by_visitor, $visitor_to_user, &$outcome_records, &$outcome_coverage ) {
+			extrachill_analytics_conversion_collect_outcome_rows(
 				$page,
 				$entry_blog_id,
 				$journeys_by_visitor,
-				$outcome_overall,
-				$outcomes_by_article,
-				$outcomes_by_category,
-				$outcome_coverage,
-				$seen_outcomes
+				$visitor_to_user,
+				$outcome_records,
+				$outcome_coverage
 			);
 		}
+	);
+	extrachill_analytics_conversion_apply_outcome_records(
+		$outcome_records,
+		$outcome_overall,
+		$outcomes_by_article,
+		$outcomes_by_category,
+		$outcome_coverage
 	);
 
 	foreach ( $outcome_types as $outcome_type ) {
@@ -525,7 +541,7 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 			'by_article'            => $article_outcomes,
 			'by_category'           => $category_outcomes,
 			'coverage'              => $outcome_coverage,
-			'attribution_semantics' => 'direct_source resolves the outcome event source_url to a published main-site article. visitor_journey attributes an identified outcome occurring after that visitor\'s first eligible mature entry journey, split at the configured pageview-session boundary. The lenses are independent and may both attribute one outcome; do not add them as unique people. Coverage status measured, partial, or not_instrumented must be read with each count.',
+			'attribution_semantics' => 'direct_source resolves the outcome event source_url to a published main-site article. visitor_journey attributes an identified outcome occurring after that visitor\'s first eligible mature entry journey, split at the configured pageview-session boundary. Outcome identity is event_data.user_id then stored user_id, with visitor_id stitched to a user only when this window observes exactly one user for that visitor; ambiguous visitors are not merged. Repeated person/outcome rows count once, while later rows may supply attribution missing from an earlier duplicate. The lenses are independent and may both attribute one outcome; do not add them as unique people. Coverage status measured, partial, or not_instrumented must be read with each count.',
 		),
 		'days'                        => $days,
 		'session_gap_mins'            => $session_gap_mins,
@@ -535,7 +551,7 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 		'period'                      => gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' ),
 		'since'                       => $since,
 		'as_of'                       => $now_utc,
-		'note'                        => 'First-party, bot-filtered editorial-to-platform funnel. entry_sessions is a legacy field name: it counts one first eligible, mature entry journey per visitor, not every entry session. Eligible entries start on a published blog-1 post; route views never become editorial entries. Same-session and return reach include eligible collected events/community/artist routes. Newsletter signup, registration, onboarding completion, artist profile first publication, and Local Scene prompt completion are successful server-side outcomes reported through separate direct-source and visitor-journey lenses. Automatic registration newsletter subscriptions are excluded. Missing source or visitor identity and outcome types absent from the window remain explicit coverage, never an inferred zero. Route-level destination collection is additive from issue #182 onward, so historical periods remain singular-only. Pageviews include one inactivity-gap before the lower boundary; outcomes are read in bounded keyset pages. Late entries without the configured return observation period and NULL-visitor pageviews (GPC/DNT opt-out) are excluded.',
+		'note'                        => 'First-party, bot-filtered editorial-to-platform funnel. entry_sessions is a legacy field name: it counts one first eligible, mature entry journey per visitor, not every entry session. Eligible entries start on a published blog-1 post; route views never become editorial entries. Same-session and return reach include eligible collected events/community/artist routes. Newsletter signup, registration, onboarding completion, and artist profile first publication are successful server-side outcomes reported through separate direct-source and visitor-journey lenses. Automatic registration newsletter subscriptions are excluded. Missing source or visitor identity and outcome types absent from the window remain explicit coverage, never an inferred zero. Route-level destination collection is additive from issue #182 onward, so historical periods remain singular-only. Pageviews include one inactivity-gap before the lower boundary; outcomes use two bounded keyset passes ordered by created_at then row ID for ambiguity-safe visitor/user stitching and attribution. Late entries without the configured return observation period and NULL-visitor pageviews (GPC/DNT opt-out) are excluded.',
 	);
 }
 
@@ -555,7 +571,6 @@ function extrachill_analytics_conversion_outcome_types() {
 		'user_registration',
 		defined( 'EC_ANALYTICS_EVENT_ONBOARDING_COMPLETED' ) ? EC_ANALYTICS_EVENT_ONBOARDING_COMPLETED : 'onboarding_completed',
 		defined( 'EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH' ) ? EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH : 'artist_profile_first_publish',
-		defined( 'EC_ANALYTICS_EVENT_LOCAL_SCENE_PROMPT_COMPLETED' ) ? EC_ANALYTICS_EVENT_LOCAL_SCENE_PROMPT_COMPLETED : 'local_scene_prompt_completed',
 	);
 }
 
@@ -615,95 +630,193 @@ function extrachill_analytics_conversion_each_outcome_page( $table, $outcome_typ
 }
 
 /**
- * Attribute one ordered page of concrete outcome rows.
+ * Normalize one stored outcome row.
  *
- * State is passed by reference so deduplication and counts remain stable across
- * keyset pages. The first stored event for a person/outcome wins; therefore an
- * outcome before entry is never replaced by a later duplicate.
- *
- * @param object[] $rows                  Ordered outcome rows.
- * @param int      $entry_blog_id         Editorial blog ID.
- * @param array    $journeys_by_visitor   Eligible journeys keyed by visitor.
- * @param array    $outcome_overall       Overall buckets, by reference.
- * @param array    $outcomes_by_article   Article buckets, by reference.
- * @param array    $outcomes_by_category  Category buckets, by reference.
- * @param array    $outcome_coverage      Coverage by event type, by reference.
- * @param array    $seen_outcomes         Seen person/outcome keys, by reference.
+ * @param object $row Stored analytics event row.
+ * @return array Normalized outcome.
  */
-function extrachill_analytics_conversion_attribute_outcome_rows( $rows, $entry_blog_id, $journeys_by_visitor, &$outcome_overall, &$outcomes_by_article, &$outcomes_by_category, &$outcome_coverage, &$seen_outcomes ) {
+function extrachill_analytics_conversion_normalize_outcome( $row ) {
+	$data = json_decode( (string) $row->event_data, true );
+
+	return array(
+		'id'         => (int) $row->id,
+		'event_type' => (string) $row->event_type,
+		'event_data' => is_array( $data ) ? $data : array(),
+		'source_url' => (string) $row->source_url,
+		'user_id'    => (int) $row->user_id,
+		'visitor_id' => trim( (string) $row->visitor_id ),
+		'ts'         => (int) $row->ts,
+	);
+}
+
+/**
+ * Whether a stored event is excluded from successful outcome attribution.
+ *
+ * @param array $outcome Normalized outcome.
+ * @return bool Whether the event is excluded.
+ */
+function extrachill_analytics_conversion_outcome_is_excluded( $outcome ) {
+	return 'newsletter_signup' === $outcome['event_type']
+		&& 'registration' === (string) ( $outcome['event_data']['context'] ?? '' );
+}
+
+/**
+ * Observe visitor/user bridges in one first-pass keyset page.
+ *
+ * @param object[] $rows          Ordered outcome rows.
+ * @param array    $visitor_users Observed users keyed by visitor, by reference.
+ */
+function extrachill_analytics_conversion_observe_outcome_identities( $rows, &$visitor_users ) {
 	foreach ( $rows as $row ) {
-		$type = (string) $row->event_type;
+		$outcome = extrachill_analytics_conversion_normalize_outcome( $row );
+		if ( extrachill_analytics_conversion_outcome_is_excluded( $outcome ) ) {
+			continue;
+		}
+		$user_id    = extrachill_analytics_conversion_outcome_user_id( $outcome );
+		$visitor_id = $outcome['visitor_id'];
+		if ( $user_id > 0 && '' !== $visitor_id ) {
+			$visitor_users[ $visitor_id ][ $user_id ] = true;
+		}
+	}
+}
+
+/**
+ * Keep only unambiguous one-visitor-to-one-user bridges.
+ *
+ * @param array $visitor_users Observed users keyed by visitor.
+ * @return array<string,int> Resolved user ID keyed by visitor.
+ */
+function extrachill_analytics_conversion_resolve_outcome_identities( $visitor_users ) {
+	$visitor_to_user = array();
+	foreach ( $visitor_users as $visitor_id => $user_ids ) {
+		if ( 1 === count( $user_ids ) ) {
+			$visitor_to_user[ $visitor_id ] = (int) array_key_first( $user_ids );
+		}
+	}
+	return $visitor_to_user;
+}
+
+/**
+ * Collect one second-pass page into deduplicated person/outcome records.
+ *
+ * Later duplicate rows may fill direct-source or journey attribution that an
+ * earlier row lacked. Input order remains created_at then row ID across pages.
+ *
+ * @param object[] $rows                Ordered outcome rows.
+ * @param int      $entry_blog_id       Editorial blog ID.
+ * @param array    $journeys_by_visitor Eligible journeys keyed by visitor.
+ * @param array    $visitor_to_user     Unambiguous visitor/user bridges.
+ * @param array    $outcome_records     Records keyed by type/person, by reference.
+ * @param array    $outcome_coverage    Coverage by event type, by reference.
+ */
+function extrachill_analytics_conversion_collect_outcome_rows( $rows, $entry_blog_id, $journeys_by_visitor, $visitor_to_user, &$outcome_records, &$outcome_coverage ) {
+	foreach ( $rows as $row ) {
+		$outcome = extrachill_analytics_conversion_normalize_outcome( $row );
+		$type    = $outcome['event_type'];
 		if ( ! isset( $outcome_coverage[ $type ] ) ) {
 			continue;
 		}
 
-		$data = json_decode( (string) $row->event_data, true );
-		$data = is_array( $data ) ? $data : array();
 		++$outcome_coverage[ $type ]['stored_events'];
-
-		if ( 'newsletter_signup' === $type && 'registration' === (string) ( $data['context'] ?? '' ) ) {
+		if ( extrachill_analytics_conversion_outcome_is_excluded( $outcome ) ) {
 			++$outcome_coverage[ $type ]['automatic_registration_excluded'];
 			continue;
 		}
 
-		$outcome    = array(
-			'id'         => (int) $row->id,
-			'event_type' => $type,
-			'event_data' => $data,
-			'source_url' => (string) $row->source_url,
-			'user_id'    => (int) $row->user_id,
-			'visitor_id' => (string) $row->visitor_id,
-			'ts'         => (int) $row->ts,
-		);
-		$dedupe_key = extrachill_analytics_conversion_outcome_dedupe_key( $outcome );
-		if ( isset( $seen_outcomes[ $type ][ $dedupe_key ] ) ) {
+		$person_id = extrachill_analytics_conversion_outcome_dedupe_key( $outcome, $visitor_to_user );
+		if ( isset( $outcome_records[ $type ][ $person_id ] ) ) {
 			++$outcome_coverage[ $type ]['duplicate_events'];
-			continue;
-		}
-		$seen_outcomes[ $type ][ $dedupe_key ] = true;
-		++$outcome_coverage[ $type ]['deduplicated_outcomes'];
-
-		if ( '' === trim( $outcome['source_url'] ) ) {
-			++$outcome_coverage[ $type ]['missing_source_url'];
 		} else {
-			++$outcome_coverage[ $type ]['with_source_url'];
-			$direct_post_id = extrachill_analytics_conversion_source_article_id( $outcome['source_url'], $entry_blog_id );
+			++$outcome_coverage[ $type ]['deduplicated_outcomes'];
+			$outcome_records[ $type ][ $person_id ] = array(
+				'has_source_url'       => false,
+				'direct_post_id'       => 0,
+				'has_visitor_identity' => false,
+				'saw_journey'          => false,
+				'saw_before_entry'     => false,
+				'journey_stage'        => '',
+				'journey_post_id'      => 0,
+			);
+		}
+		$record = &$outcome_records[ $type ][ $person_id ];
+
+		// A later duplicate may still carry source instrumentation.
+		if ( '' !== trim( $outcome['source_url'] ) && 0 === $record['direct_post_id'] ) {
+			$record['has_source_url'] = true;
+			$direct_post_id           = extrachill_analytics_conversion_source_article_id( $outcome['source_url'], $entry_blog_id );
 			if ( $direct_post_id > 0 ) {
-				++$outcome_coverage[ $type ]['direct_source_attributed'];
-				extrachill_analytics_conversion_apply_outcome( $outcome_overall, $type, 'direct_source' );
-				extrachill_analytics_conversion_apply_article_outcome( $outcomes_by_article, $outcomes_by_category, $direct_post_id, $type, 'direct_source' );
-			} else {
-				++$outcome_coverage[ $type ]['unresolved_source_url'];
+				$record['direct_post_id'] = $direct_post_id;
 			}
 		}
 
-		$visitor_id = trim( $outcome['visitor_id'] );
+		$visitor_id = $outcome['visitor_id'];
 		if ( '' === $visitor_id ) {
-			++$outcome_coverage[ $type ]['missing_visitor_identity'];
+			unset( $record );
 			continue;
 		}
-		++$outcome_coverage[ $type ]['with_visitor_identity'];
+		$record['has_visitor_identity'] = true;
 
 		if ( ! isset( $journeys_by_visitor[ $visitor_id ] ) ) {
-			++$outcome_coverage[ $type ]['identity_without_eligible_journey'];
+			unset( $record );
 			continue;
 		}
+		$record['saw_journey'] = true;
 
 		$stage = extrachill_analytics_conversion_outcome_journey_stage( $outcome['ts'], $journeys_by_visitor[ $visitor_id ] );
 		if ( null === $stage ) {
-			++$outcome_coverage[ $type ]['outcome_before_entry'];
+			$record['saw_before_entry'] = true;
+			unset( $record );
 			continue;
 		}
 
-		++$outcome_coverage[ $type ]['visitor_journey_attributed'];
-		extrachill_analytics_conversion_apply_outcome( $outcome_overall, $type, $stage );
-		extrachill_analytics_conversion_apply_article_outcome(
-			$outcomes_by_article,
-			$outcomes_by_category,
-			(int) $journeys_by_visitor[ $visitor_id ]['post_id'],
-			$type,
-			$stage
-		);
+		if ( '' === $record['journey_stage'] ) {
+			$record['journey_stage']   = $stage;
+			$record['journey_post_id'] = (int) $journeys_by_visitor[ $visitor_id ]['post_id'];
+		}
+		unset( $record );
+	}
+}
+
+/**
+ * Apply collected person/outcome records and their final coverage once.
+ *
+ * @param array $records              Deduplicated records keyed by type/person.
+ * @param array $outcome_overall      Overall buckets, by reference.
+ * @param array $outcomes_by_article  Article buckets, by reference.
+ * @param array $outcomes_by_category Category buckets, by reference.
+ * @param array $outcome_coverage     Coverage by event type, by reference.
+ */
+function extrachill_analytics_conversion_apply_outcome_records( $records, &$outcome_overall, &$outcomes_by_article, &$outcomes_by_category, &$outcome_coverage ) {
+	foreach ( $records as $type => $people ) {
+		foreach ( $people as $record ) {
+			if ( $record['direct_post_id'] > 0 ) {
+				++$outcome_coverage[ $type ]['with_source_url'];
+				++$outcome_coverage[ $type ]['direct_source_attributed'];
+				extrachill_analytics_conversion_apply_outcome( $outcome_overall, $type, 'direct_source' );
+				extrachill_analytics_conversion_apply_article_outcome( $outcomes_by_article, $outcomes_by_category, $record['direct_post_id'], $type, 'direct_source' );
+			} elseif ( $record['has_source_url'] ) {
+				++$outcome_coverage[ $type ]['with_source_url'];
+				++$outcome_coverage[ $type ]['unresolved_source_url'];
+			} else {
+				++$outcome_coverage[ $type ]['missing_source_url'];
+			}
+
+			if ( '' !== $record['journey_stage'] ) {
+				++$outcome_coverage[ $type ]['with_visitor_identity'];
+				++$outcome_coverage[ $type ]['visitor_journey_attributed'];
+				extrachill_analytics_conversion_apply_outcome( $outcome_overall, $type, $record['journey_stage'] );
+				extrachill_analytics_conversion_apply_article_outcome( $outcomes_by_article, $outcomes_by_category, $record['journey_post_id'], $type, $record['journey_stage'] );
+			} elseif ( $record['has_visitor_identity'] ) {
+				++$outcome_coverage[ $type ]['with_visitor_identity'];
+				if ( $record['saw_journey'] && $record['saw_before_entry'] ) {
+					++$outcome_coverage[ $type ]['outcome_before_entry'];
+				} else {
+					++$outcome_coverage[ $type ]['identity_without_eligible_journey'];
+				}
+			} else {
+				++$outcome_coverage[ $type ]['missing_visitor_identity'];
+			}
+		}
 	}
 }
 
@@ -751,24 +864,39 @@ function extrachill_analytics_conversion_outcome_zero_coverage() {
 }
 
 /**
+ * Resolve the strongest stored user identity for an outcome.
+ *
+ * @param array $outcome Normalized outcome row.
+ * @return int Positive user ID, or zero when unavailable.
+ */
+function extrachill_analytics_conversion_outcome_user_id( $outcome ) {
+	$data = isset( $outcome['event_data'] ) && is_array( $outcome['event_data'] ) ? $outcome['event_data'] : array();
+	return (int) ( $data['user_id'] ?? ( $outcome['user_id'] ?? 0 ) );
+}
+
+/**
  * Deduplicate an outcome by its strongest available person identity.
  *
  * Registration user IDs live in event_data because the account is created
- * before the request becomes authenticated. Visitor identity is the fallback;
- * identity-free events remain individually observable rather than collapsed.
+ * before the request becomes authenticated. An anonymous visitor resolves to a
+ * user only through an unambiguous bridge observed in the same bounded window.
+ * Identity-free events remain individually observable rather than collapsed.
  *
- * @param array $outcome Normalized outcome row.
+ * @param array $outcome        Normalized outcome row.
+ * @param array $visitor_to_user Unambiguous user IDs keyed by visitor.
  * @return string Stable type-local deduplication key.
  */
-function extrachill_analytics_conversion_outcome_dedupe_key( $outcome ) {
-	$data    = isset( $outcome['event_data'] ) && is_array( $outcome['event_data'] ) ? $outcome['event_data'] : array();
-	$user_id = (int) ( $data['user_id'] ?? ( $outcome['user_id'] ?? 0 ) );
+function extrachill_analytics_conversion_outcome_dedupe_key( $outcome, $visitor_to_user = array() ) {
+	$user_id = extrachill_analytics_conversion_outcome_user_id( $outcome );
 	if ( $user_id > 0 ) {
 		return 'user:' . $user_id;
 	}
 
 	$visitor_id = trim( (string) ( $outcome['visitor_id'] ?? '' ) );
 	if ( '' !== $visitor_id ) {
+		if ( isset( $visitor_to_user[ $visitor_id ] ) ) {
+			return 'user:' . (int) $visitor_to_user[ $visitor_id ];
+		}
 		return 'visitor:' . $visitor_id;
 	}
 

--- a/tests/ConversionMapOutcomesTest.php
+++ b/tests/ConversionMapOutcomesTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for conversion-map newsletter and registration outcome attribution.
+ * Tests for conversion-map concrete outcome attribution.
  *
  * @package ExtraChill\Analytics
  */
@@ -13,6 +13,22 @@ require_once dirname( __DIR__ ) . '/inc/core/abilities/get-conversion-map.php';
  * Protect outcome deduplication, attribution boundaries, and coverage semantics.
  */
 final class ConversionMapOutcomesTest extends TestCase {
+	/**
+	 * The outcome lens preserves concrete canonical lifecycle event names.
+	 */
+	public function test_outcome_types_include_proven_lifecycle_completions(): void {
+		$this->assertSame(
+			array(
+				'newsletter_signup',
+				'user_registration',
+				'onboarding_completed',
+				'artist_profile_first_publish',
+				'local_scene_prompt_completed',
+			),
+			extrachill_analytics_conversion_outcome_types()
+		);
+	}
+
 	/**
 	 * Registration deduplication uses the created user ID stored in event_data.
 	 */
@@ -119,5 +135,123 @@ final class ConversionMapOutcomesTest extends TestCase {
 		$this->assertSame( 'partial', $finalized['visitor_journey_status'] );
 		$this->assertSame( 2, $finalized['missing_source_url'] );
 		$this->assertSame( 1, $finalized['missing_visitor_identity'] );
+	}
+
+	/**
+	 * Identified lifecycle outcomes retain same/later-session attribution and dedupe.
+	 */
+	public function test_lifecycle_outcome_fixtures_preserve_identity_dedupe_and_order(): void {
+		$types    = array(
+			'onboarding_completed',
+			'artist_profile_first_publish',
+			'local_scene_prompt_completed',
+		);
+		$rows     = array(
+			$this->outcome_row( 1, 'local_scene_prompt_completed', 21, 'visitor-c', 900 ),
+			$this->outcome_row( 2, 'artist_profile_first_publish', 11, 'visitor-a', 1200 ),
+			$this->outcome_row( 3, 'local_scene_prompt_completed', 21, 'visitor-c', 1200 ),
+			$this->outcome_row( 4, 'artist_profile_first_publish', 11, 'visitor-a', 1300 ),
+			$this->outcome_row( 5, 'onboarding_completed', 31, '', 1400 ),
+			$this->outcome_row( 6, 'artist_profile_first_publish', 12, 'visitor-b', 3000 ),
+		);
+		$journeys = array(
+			'visitor-a' => array(
+				'post_id'              => 0,
+				'entry_ts'             => 1000,
+				'same_session_through' => 2000,
+			),
+			'visitor-b' => array(
+				'post_id'              => 0,
+				'entry_ts'             => 1000,
+				'same_session_through' => 2000,
+			),
+			'visitor-c' => array(
+				'post_id'              => 0,
+				'entry_ts'             => 1000,
+				'same_session_through' => 2000,
+			),
+		);
+
+		$overall     = extrachill_analytics_conversion_outcome_zero_bucket( $types );
+		$coverage    = array_fill_keys( $types, extrachill_analytics_conversion_outcome_zero_coverage() );
+		$by_article  = array();
+		$by_category = array();
+		$seen        = array();
+
+		extrachill_analytics_conversion_attribute_outcome_rows(
+			$rows,
+			1,
+			$journeys,
+			$overall,
+			$by_article,
+			$by_category,
+			$coverage,
+			$seen
+		);
+
+		$this->assertSame( 1, $overall['artist_profile_first_publish']['same_session'] );
+		$this->assertSame( 1, $overall['artist_profile_first_publish']['later_session'] );
+		$this->assertSame( 1, $coverage['artist_profile_first_publish']['duplicate_events'] );
+		$this->assertSame( 1, $coverage['onboarding_completed']['missing_visitor_identity'] );
+		$this->assertSame( 1, $coverage['local_scene_prompt_completed']['outcome_before_entry'] );
+		$this->assertSame( 1, $coverage['local_scene_prompt_completed']['duplicate_events'] );
+		$this->assertSame( 0, $overall['local_scene_prompt_completed']['same_session'] );
+	}
+
+	/**
+	 * An outcome with no stored instrumentation is not projected as measured zero.
+	 */
+	public function test_absent_lifecycle_instrumentation_projects_null_counts(): void {
+		$type        = 'onboarding_completed';
+		$coverage    = extrachill_analytics_conversion_finalize_outcome_coverage( extrachill_analytics_conversion_outcome_zero_coverage(), true );
+		$outcome_row = extrachill_analytics_conversion_outcome_row(
+			extrachill_analytics_conversion_outcome_zero_bucket( array( $type ) ),
+			array( $type => $coverage )
+		);
+
+		$this->assertSame( 'not_observed', $coverage['instrumentation_status'] );
+		$this->assertSame( 'not_instrumented', $outcome_row[ $type ]['direct_source']['coverage_status'] );
+		$this->assertNull( $outcome_row[ $type ]['direct_source']['count'] );
+		$this->assertNull( $outcome_row[ $type ]['visitor_journey']['same_session_count'] );
+		$this->assertNull( $outcome_row[ $type ]['visitor_journey']['later_session_count'] );
+	}
+
+	/**
+	 * Existing outcome zero semantics remain backward compatible.
+	 */
+	public function test_absent_established_outcome_remains_measured_zero(): void {
+		$type        = 'newsletter_signup';
+		$coverage    = extrachill_analytics_conversion_finalize_outcome_coverage( extrachill_analytics_conversion_outcome_zero_coverage() );
+		$outcome_row = extrachill_analytics_conversion_outcome_row(
+			extrachill_analytics_conversion_outcome_zero_bucket( array( $type ) ),
+			array( $type => $coverage )
+		);
+
+		$this->assertSame( 'measured', $outcome_row[ $type ]['direct_source']['coverage_status'] );
+		$this->assertSame( 0, $outcome_row[ $type ]['direct_source']['count'] );
+		$this->assertSame( 0, $outcome_row[ $type ]['visitor_journey']['same_session_count'] );
+		$this->assertSame( 0, $outcome_row[ $type ]['visitor_journey']['later_session_count'] );
+	}
+
+	/**
+	 * Build a stored outcome fixture.
+	 *
+	 * @param int    $id         Event row ID.
+	 * @param string $event_type Concrete outcome event name.
+	 * @param int    $user_id    Payload and stored user identity.
+	 * @param string $visitor_id Anonymous visitor identity.
+	 * @param int    $timestamp  Event timestamp.
+	 * @return object Outcome row.
+	 */
+	private function outcome_row( int $id, string $event_type, int $user_id, string $visitor_id, int $timestamp ): object {
+		return (object) array(
+			'id'         => $id,
+			'event_type' => $event_type,
+			'event_data' => wp_json_encode( array( 'user_id' => $user_id ) ),
+			'source_url' => '',
+			'user_id'    => $user_id,
+			'visitor_id' => $visitor_id,
+			'ts'         => $timestamp,
+		);
 	}
 }

--- a/tests/ConversionMapOutcomesTest.php
+++ b/tests/ConversionMapOutcomesTest.php
@@ -23,7 +23,6 @@ final class ConversionMapOutcomesTest extends TestCase {
 				'user_registration',
 				'onboarding_completed',
 				'artist_profile_first_publish',
-				'local_scene_prompt_completed',
 			),
 			extrachill_analytics_conversion_outcome_types()
 		);
@@ -138,21 +137,15 @@ final class ConversionMapOutcomesTest extends TestCase {
 	}
 
 	/**
-	 * Identified lifecycle outcomes retain same/later-session attribution and dedupe.
+	 * Visitor-only and identified duplicates stitch to one person.
 	 */
-	public function test_lifecycle_outcome_fixtures_preserve_identity_dedupe_and_order(): void {
-		$types    = array(
-			'onboarding_completed',
-			'artist_profile_first_publish',
-			'local_scene_prompt_completed',
-		);
-		$rows     = array(
-			$this->outcome_row( 1, 'local_scene_prompt_completed', 21, 'visitor-c', 900 ),
-			$this->outcome_row( 2, 'artist_profile_first_publish', 11, 'visitor-a', 1200 ),
-			$this->outcome_row( 3, 'local_scene_prompt_completed', 21, 'visitor-c', 1200 ),
-			$this->outcome_row( 4, 'artist_profile_first_publish', 11, 'visitor-a', 1300 ),
-			$this->outcome_row( 5, 'onboarding_completed', 31, '', 1400 ),
-			$this->outcome_row( 6, 'artist_profile_first_publish', 12, 'visitor-b', 3000 ),
+	public function test_mixed_identity_duplicates_stitch_and_later_row_can_attribute(): void {
+		$type     = 'artist_profile_first_publish';
+		$pages    = array(
+			array(
+				$this->outcome_row( 1, $type, 0, 'visitor-a', 900 ),
+				$this->outcome_row( 2, $type, 11, 'visitor-a', 1200 ),
+			),
 		);
 		$journeys = array(
 			'visitor-a' => array(
@@ -160,42 +153,112 @@ final class ConversionMapOutcomesTest extends TestCase {
 				'entry_ts'             => 1000,
 				'same_session_through' => 2000,
 			),
-			'visitor-b' => array(
+		);
+		$result   = $this->run_outcome_pages( $pages, $journeys, array( $type ) );
+
+		$this->assertSame( array( 'visitor-a' => 11 ), $result['visitor_to_user'] );
+		$this->assertSame( 1, $result['coverage'][ $type ]['deduplicated_outcomes'] );
+		$this->assertSame( 1, $result['coverage'][ $type ]['duplicate_events'] );
+		$this->assertSame( 1, $result['coverage'][ $type ]['visitor_journey_attributed'] );
+		$this->assertSame( 1, $result['overall'][ $type ]['same_session'] );
+	}
+
+	/**
+	 * A visitor observed with multiple users remains an independent identity.
+	 */
+	public function test_ambiguous_visitor_mapping_does_not_stitch(): void {
+		$type   = 'artist_profile_first_publish';
+		$pages  = array(
+			array(
+				$this->outcome_row( 1, $type, 0, 'visitor-a', 1200 ),
+				$this->outcome_row( 2, $type, 11, 'visitor-a', 1300 ),
+				$this->outcome_row( 3, $type, 12, 'visitor-a', 1400 ),
+			),
+		);
+		$result = $this->run_outcome_pages( $pages, array(), array( $type ) );
+
+		$this->assertSame( array(), $result['visitor_to_user'] );
+		$this->assertSame( 3, $result['coverage'][ $type ]['deduplicated_outcomes'] );
+		$this->assertSame( 0, $result['coverage'][ $type ]['duplicate_events'] );
+	}
+
+	/**
+	 * Equal timestamps use row-ID order across pages and retain later attribution.
+	 */
+	public function test_cross_page_equal_timestamp_rows_are_deterministic(): void {
+		$type     = 'artist_profile_first_publish';
+		$pages    = array(
+			array( $this->outcome_row( 499, $type, 21, 'visitor-before', 1000 ) ),
+			array( $this->outcome_row( 500, $type, 21, 'visitor-after', 1000 ) ),
+		);
+		$journeys = array(
+			'visitor-before' => array(
 				'post_id'              => 0,
-				'entry_ts'             => 1000,
+				'entry_ts'             => 1100,
 				'same_session_through' => 2000,
 			),
-			'visitor-c' => array(
+			'visitor-after'  => array(
 				'post_id'              => 0,
-				'entry_ts'             => 1000,
+				'entry_ts'             => 900,
 				'same_session_through' => 2000,
 			),
 		);
+		$result   = $this->run_outcome_pages( $pages, $journeys, array( $type ) );
 
-		$overall     = extrachill_analytics_conversion_outcome_zero_bucket( $types );
-		$coverage    = array_fill_keys( $types, extrachill_analytics_conversion_outcome_zero_coverage() );
-		$by_article  = array();
-		$by_category = array();
-		$seen        = array();
+		$this->assertSame( 1, $result['coverage'][ $type ]['deduplicated_outcomes'] );
+		$this->assertSame( 1, $result['coverage'][ $type ]['duplicate_events'] );
+		$this->assertSame( 1, $result['coverage'][ $type ]['visitor_journey_attributed'] );
+		$this->assertSame( 0, $result['coverage'][ $type ]['outcome_before_entry'] );
+		$this->assertSame( 1, $result['overall'][ $type ]['same_session'] );
+	}
 
-		extrachill_analytics_conversion_attribute_outcome_rows(
-			$rows,
-			1,
-			$journeys,
-			$overall,
-			$by_article,
-			$by_category,
-			$coverage,
-			$seen
+	/**
+	 * The bounded reader advances equal-timestamp pages with the event ID cursor.
+	 */
+	public function test_outcome_reader_keyset_pages_equal_timestamps_by_id(): void {
+		$type = 'artist_profile_first_publish';
+		$rows = array();
+		for ( $id = 1; $id <= 501; ++$id ) {
+			$rows[]                      = $this->outcome_row( $id, $type, $id, 'visitor-' . $id, 1000 );
+			$rows[ $id - 1 ]->created_at = '2026-01-01 00:00:00';
+		}
+		$db       = $this->install_outcome_database( array( array_slice( $rows, 0, 500 ), array_slice( $rows, 500 ) ) );
+		$consumed = array();
+
+		extrachill_analytics_conversion_each_outcome_page(
+			'wp_extrachill_analytics_events',
+			array( $type ),
+			'2025-12-01 00:00:00',
+			'2026-01-02 00:00:00',
+			static function ( $page ) use ( &$consumed ) {
+				$consumed = array_merge( $consumed, array_map( static fn( $row ) => (int) $row->id, $page ) );
+			}
 		);
 
-		$this->assertSame( 1, $overall['artist_profile_first_publish']['same_session'] );
-		$this->assertSame( 1, $overall['artist_profile_first_publish']['later_session'] );
-		$this->assertSame( 1, $coverage['artist_profile_first_publish']['duplicate_events'] );
-		$this->assertSame( 1, $coverage['onboarding_completed']['missing_visitor_identity'] );
-		$this->assertSame( 1, $coverage['local_scene_prompt_completed']['outcome_before_entry'] );
-		$this->assertSame( 1, $coverage['local_scene_prompt_completed']['duplicate_events'] );
-		$this->assertSame( 0, $overall['local_scene_prompt_completed']['same_session'] );
+		$this->assertCount( 501, $consumed );
+		$this->assertSame( 501, end( $consumed ) );
+		$this->assertCount( 2, $db->prepared_queries );
+		$this->assertStringContainsString( 'ORDER BY created_at ASC, id ASC', $db->prepared_queries[0]['query'] );
+		$this->assertStringContainsString( 'id > %d', $db->prepared_queries[1]['query'] );
+		$this->assertSame( 500, end( $db->prepared_queries[1]['args'] ) );
+	}
+
+	/**
+	 * Identity-free rows remain distinct outcomes through both passes.
+	 */
+	public function test_identity_free_fixture_rows_remain_distinct(): void {
+		$type   = 'onboarding_completed';
+		$pages  = array(
+			array(
+				$this->outcome_row( 1, $type, 0, '', 1200 ),
+				$this->outcome_row( 2, $type, 0, '', 1300 ),
+			),
+		);
+		$result = $this->run_outcome_pages( $pages, array(), array( $type ) );
+
+		$this->assertSame( 2, $result['coverage'][ $type ]['deduplicated_outcomes'] );
+		$this->assertSame( 0, $result['coverage'][ $type ]['duplicate_events'] );
+		$this->assertSame( 2, $result['coverage'][ $type ]['missing_visitor_identity'] );
 	}
 
 	/**
@@ -238,7 +301,7 @@ final class ConversionMapOutcomesTest extends TestCase {
 	 *
 	 * @param int    $id         Event row ID.
 	 * @param string $event_type Concrete outcome event name.
-	 * @param int    $user_id    Payload and stored user identity.
+	 * @param int    $user_id    Payload user identity.
 	 * @param string $visitor_id Anonymous visitor identity.
 	 * @param int    $timestamp  Event timestamp.
 	 * @return object Outcome row.
@@ -247,11 +310,116 @@ final class ConversionMapOutcomesTest extends TestCase {
 		return (object) array(
 			'id'         => $id,
 			'event_type' => $event_type,
-			'event_data' => wp_json_encode( array( 'user_id' => $user_id ) ),
+			'event_data' => wp_json_encode( $user_id > 0 ? array( 'user_id' => $user_id ) : array() ),
 			'source_url' => '',
-			'user_id'    => $user_id,
+			'user_id'    => 0,
 			'visitor_id' => $visitor_id,
 			'ts'         => $timestamp,
 		);
+	}
+
+	/**
+	 * Run production's two-pass outcome logic over explicit keyset pages.
+	 *
+	 * @param array $pages                Ordered pages of outcome rows.
+	 * @param array $journeys_by_visitor Eligible journeys keyed by visitor.
+	 * @param array $types                Concrete outcome types.
+	 * @return array Aggregated fixture result.
+	 */
+	private function run_outcome_pages( array $pages, array $journeys_by_visitor, array $types ): array {
+		$visitor_users = array();
+		foreach ( $pages as $page ) {
+			extrachill_analytics_conversion_observe_outcome_identities( $page, $visitor_users );
+		}
+		$visitor_to_user = extrachill_analytics_conversion_resolve_outcome_identities( $visitor_users );
+		$records         = array();
+		$coverage        = array_fill_keys( $types, extrachill_analytics_conversion_outcome_zero_coverage() );
+		foreach ( $pages as $page ) {
+			extrachill_analytics_conversion_collect_outcome_rows( $page, 1, $journeys_by_visitor, $visitor_to_user, $records, $coverage );
+		}
+
+		$overall     = extrachill_analytics_conversion_outcome_zero_bucket( $types );
+		$by_article  = array();
+		$by_category = array();
+		extrachill_analytics_conversion_apply_outcome_records( $records, $overall, $by_article, $by_category, $coverage );
+
+		return array(
+			'visitor_to_user' => $visitor_to_user,
+			'overall'         => $overall,
+			'coverage'        => $coverage,
+		);
+	}
+
+	/**
+	 * Install a paged database fixture for the bounded outcome reader.
+	 *
+	 * @param array $pages Ordered result pages.
+	 * @return object Database fixture.
+	 */
+	private function install_outcome_database( array $pages ): object {
+		$db              = new class( $pages ) {
+			/**
+			 * Captured prepared queries.
+			 *
+			 * @var array
+			 */
+			public $prepared_queries = array();
+
+			/**
+			 * Ordered result pages.
+			 *
+			 * @var array
+			 */
+			private $pages;
+
+			/**
+			 * Current page index.
+			 *
+			 * @var int
+			 */
+			private $page_index = 0;
+
+			/**
+			 * Set fixture pages.
+			 *
+			 * @param array $fixture_pages Ordered result pages.
+			 */
+			public function __construct( $fixture_pages ) {
+				$this->pages = $fixture_pages;
+			}
+
+			/**
+			 * Capture a prepared query.
+			 *
+			 * @param string $query SQL query.
+			 * @param mixed  ...$args Prepared values.
+			 * @return string Unchanged query.
+			 */
+			public function prepare( $query, ...$args ) {
+				if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+					$args = $args[0];
+				}
+				$this->prepared_queries[] = array(
+					'query' => $query,
+					'args'  => $args,
+				);
+				return $query;
+			}
+
+			/**
+			 * Return the next result page.
+			 *
+			 * @param string $query SQL query.
+			 * @return array Next result page.
+			 */
+			public function get_results( $query ) {
+				unset( $query );
+				$page = $this->pages[ $this->page_index ] ?? array();
+				++$this->page_index;
+				return $page;
+			}
+		};
+		$GLOBALS['wpdb'] = $db;
+		return $db;
 	}
 }


### PR DESCRIPTION
## Summary
- extend the existing conversion-map outcome lens with the authoritative `onboarding_completed` and `artist_profile_first_publish` lifecycle events
- preserve independent direct-source and visitor-journey attribution with bounded two-pass, ambiguity-safe visitor/user stitching
- deduplicate each resolved person/outcome while allowing a later duplicate to supply valid attribution missing from an earlier row
- read both outcome passes in deterministic 500-row `(created_at, id)` keyset pages and expose absent instrumentation as coverage rather than measured zero

## Included outcomes and proof

- `onboarding_completed`: the persisted production emitter writes payload `user_id` plus bounded onboarding fields through the canonical analytics ability; the analytics writer inherits the existing visitor cookie when available. No rows are currently observed in production, so this outcome reports `not_observed` and null lens counts until instrumentation is seen.
- `artist_profile_first_publish`: the persisted link-page creation emitter writes payload `user_id`, `artist_id`, and `link_page_id` and explicitly supplies analytics visitor identity. Production evidence currently contains 6 rows: 6/6 with user identity, 5/6 with visitor identity, and 0/6 with source URL.

`local_scene_prompt_completed` is intentionally excluded because its client fire-and-forget event is not an authoritative persisted lifecycle emitter and production has no evidence for it.

The included lifecycle emitters do not supply `source_url`. Their direct-source lens therefore remains explicitly `not_instrumented`; this change does not infer source from user or visitor identity.

## Identity, dedupe, and order semantics

- pass one reads the bounded outcome stream and observes real visitor/user bridges using `event_data.user_id`, then stored `user_id`, matching `get-activation-funnel.php`
- a visitor stitches to a user only when the report window observes exactly one user for that visitor; ambiguous multi-user visitors remain independent and are never merged
- pass two resolves person identity as user, unambiguously stitched visitor, raw visitor, or identity-free event ID
- visitor-only followed by user-plus-visitor rows deduplicate to one person/outcome when the bridge is unambiguous
- duplicate rows aggregate coverage candidates instead of being discarded immediately, so a pre-entry or unidentified row cannot suppress a later attributable duplicate
- direct-source and visitor-journey candidates remain independent; each person/outcome contributes at most once to each lens
- both passes use `created_at ASC, id ASC` with `(created_at, id)` keyset cursors, including deterministic equal-timestamp ordering across page boundaries
- same-session remains inclusive through the configured pageview-session boundary; later-session begins immediately after it

## Coverage and compatibility

- existing `newsletter_signup` and `user_registration` keys, shapes, and empty-window measured-zero behavior are preserved
- `onboarding_completed` and `artist_profile_first_publish` are added to overall, article, category, and per-outcome coverage output
- coverage adds `instrumentation_status` (`observed` or `not_observed`); new lifecycle outcomes absent from the reporting window return null counts with `not_instrumented` lens status
- identified, unidentified, ambiguous, unresolved journey, duplicate, pre-entry, direct-source, same-session, and later-session conditions remain explicit
- no storage, emitters, generic conversion wrapper, or identity infrastructure were added

## Fixtures

- visitor-only then user-plus-visitor mixed identity deduplication
- later attributable duplicate after an earlier pre-entry row
- ambiguous visitor mapped to multiple users
- cross-page duplicate aggregation
- equal-timestamp row-ID ordering and a 501-row keyset cursor boundary
- identity-free outcomes remaining distinct
- absent lifecycle instrumentation and established-outcome backward compatibility

## Verification

- `vendor/bin/phpunit tests/ConversionMapOutcomesTest.php tests/ConversionMapScopeTest.php` (14 tests, 47 assertions)
- `vendor/bin/phpunit` (309 tests, 1,140 assertions)
- `php -l inc/core/abilities/get-conversion-map.php`
- `php -l tests/ConversionMapOutcomesTest.php`
- `vendor/bin/phpcs --standard=WordPress inc/core/abilities/get-conversion-map.php tests/ConversionMapOutcomesTest.php`
- `git diff --check`

Closes #189