### PR TITLE
refactor: canonicalize active analytics event contracts

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -42,6 +42,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/isbot-backfill.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/link-page-analytics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/experiment-integration.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/write-integrity.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/gtm.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities.php';

--- a/inc/core/404-tracking.php
+++ b/inc/core/404-tracking.php
@@ -28,7 +28,7 @@ function extrachill_analytics_track_404() {
 		return;
 	}
 
-	$url = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( $_SERVER['REQUEST_URI'] ) : '';
+	$url = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
 	// Exclude event URLs (calendar plugin).
 	if ( preg_match( '/^\/event\//', $url ) ) {
@@ -47,7 +47,7 @@ function extrachill_analytics_track_404() {
 	$ip_address = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
 
 	extrachill_track_analytics_event(
-		'404_error',
+		EC_ANALYTICS_EVENT_404_ERROR,
 		array(
 			'requested_url' => $url,
 			'referer'       => $referer,

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -152,10 +152,10 @@ function extrachill_analytics_ability_track_event( $input ) {
 	// reclassify it as 'search_attack' so real search metrics stay clean while
 	// the attack stays visible. This catches any caller (current or future)
 	// that forgets to pre-classify, including community/forum/artist search.
-	if ( 'search' === $event_type && is_array( $event_data ) && ! empty( $event_data['search_term'] ) ) {
+	if ( EC_ANALYTICS_EVENT_SEARCH === $event_type && is_array( $event_data ) && ! empty( $event_data['search_term'] ) ) {
 		$classification = extrachill_analytics_classify_search_payload( (string) $event_data['search_term'] );
 		if ( null !== $classification ) {
-			$event_type = 'search_attack';
+			$event_type = EC_ANALYTICS_EVENT_SEARCH_ATTACK;
 			$event_data = array_merge(
 				$event_data,
 				array(

--- a/inc/core/abilities/drill-404-category.php
+++ b/inc/core/abilities/drill-404-category.php
@@ -85,8 +85,8 @@ function extrachill_analytics_ability_drill_404_category( $input ) {
 	}
 
 	$table  = extrachill_analytics_events_table();
-	$where  = array( "event_type = '404_error'" );
-	$values = array();
+	$where  = array( 'event_type = %s' );
+	$values = array( EC_ANALYTICS_EVENT_404_ERROR );
 
 	if ( $days > 0 ) {
 		$where[]  = 'created_at >= %s';

--- a/inc/core/abilities/get-404-patterns.php
+++ b/inc/core/abilities/get-404-patterns.php
@@ -69,8 +69,8 @@ function extrachill_analytics_ability_get_404_patterns( $input ) {
 	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
 
 	$table  = extrachill_analytics_events_table();
-	$where  = array( "event_type = '404_error'" );
-	$values = array();
+	$where  = array( 'event_type = %s' );
+	$values = array( EC_ANALYTICS_EVENT_404_ERROR );
 
 	if ( $days > 0 ) {
 		$where[]  = 'created_at >= %s';

--- a/inc/core/abilities/get-404-summary.php
+++ b/inc/core/abilities/get-404-summary.php
@@ -69,8 +69,8 @@ function extrachill_analytics_ability_get_404_summary( $input ) {
 	$blog_id = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
 
 	$table  = extrachill_analytics_events_table();
-	$where  = array( "event_type = '404_error'" );
-	$values = array();
+	$where  = array( 'event_type = %s' );
+	$values = array( EC_ANALYTICS_EVENT_404_ERROR );
 
 	if ( $days > 0 ) {
 		$where[]  = 'created_at >= %s';

--- a/inc/core/abilities/get-404-top-ips.php
+++ b/inc/core/abilities/get-404-top-ips.php
@@ -75,8 +75,8 @@ function extrachill_analytics_ability_get_404_top_ips( $input ) {
 	$limit   = isset( $input['limit'] ) ? (int) $input['limit'] : 15;
 
 	$table  = extrachill_analytics_events_table();
-	$where  = array( "event_type = '404_error'" );
-	$values = array();
+	$where  = array( 'event_type = %s' );
+	$values = array( EC_ANALYTICS_EVENT_404_ERROR );
 
 	if ( $days > 0 ) {
 		$where[]  = 'created_at >= %s';
@@ -111,8 +111,8 @@ function extrachill_analytics_ability_get_404_top_ips( $input ) {
 	$results = array();
 	foreach ( $rows as $row ) {
 		// Second pass: find the most common user agent for this IP.
-		$ua_values = array();
-		$ua_where  = array( "event_type = '404_error'" );
+		$ua_values = array( EC_ANALYTICS_EVENT_404_ERROR );
+		$ua_where  = array( 'event_type = %s' );
 
 		$ua_where[]  = "JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.ip_hash')) = %s";
 		$ua_values[] = $row->ip_hash;

--- a/inc/core/abilities/get-404-top-urls.php
+++ b/inc/core/abilities/get-404-top-urls.php
@@ -81,8 +81,8 @@ function extrachill_analytics_ability_get_404_top_urls( $input ) {
 	$min_hits = isset( $input['min_hits'] ) ? (int) $input['min_hits'] : 2;
 
 	$table  = extrachill_analytics_events_table();
-	$where  = array( "event_type = '404_error'" );
-	$values = array();
+	$where  = array( 'event_type = %s' );
+	$values = array( EC_ANALYTICS_EVENT_404_ERROR );
 
 	if ( $days > 0 ) {
 		$where[]  = 'created_at >= %s';

--- a/inc/core/abilities/get-attack-summary.php
+++ b/inc/core/abilities/get-attack-summary.php
@@ -106,8 +106,8 @@ function extrachill_analytics_ability_get_attack_summary( $input ) {
 	}
 
 	$table  = extrachill_analytics_events_table();
-	$where  = array( "event_type = 'search_attack'" );
-	$values = array();
+	$where  = array( 'event_type = %s' );
+	$values = array( EC_ANALYTICS_EVENT_SEARCH_ATTACK );
 
 	if ( $days > 0 ) {
 		$where[]  = 'created_at >= %s';

--- a/inc/core/abilities/get-bridge-ctr.php
+++ b/inc/core/abilities/get-bridge-ctr.php
@@ -103,7 +103,7 @@ function extrachill_analytics_ability_get_bridge_ctr( $input ) {
 	$page_size  = 1000;
 
 	$query_args = array(
-		'event_type' => array( 'bridge_click', 'bridge_impression' ),
+		'event_type' => array( EC_ANALYTICS_EVENT_BRIDGE_CLICK, EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION ),
 		'limit'      => $page_size,
 		'orderby'    => 'id',
 		'order'      => 'DESC',
@@ -152,7 +152,7 @@ function extrachill_analytics_ability_get_bridge_ctr( $input ) {
 				continue;
 			}
 
-			$is_click = isset( $row->event_type ) && 'bridge_click' === $row->event_type;
+			$is_click = isset( $row->event_type ) && EC_ANALYTICS_EVENT_BRIDGE_CLICK === $row->event_type;
 			$key      = $is_click ? 'clicks' : 'impressions';
 			++$counts[ $key ];
 

--- a/inc/core/abilities/get-conversion-map.php
+++ b/inc/core/abilities/get-conversion-map.php
@@ -469,7 +469,7 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
 	);
 
 	foreach ( $outcome_types as $outcome_type ) {
-		$is_new_lifecycle_outcome          = ! in_array( $outcome_type, array( 'newsletter_signup', 'user_registration' ), true );
+		$is_new_lifecycle_outcome          = ! in_array( $outcome_type, array( EC_ANALYTICS_EVENT_NEWSLETTER_SIGNUP, EC_ANALYTICS_EVENT_USER_REGISTRATION ), true );
 		$outcome_coverage[ $outcome_type ] = extrachill_analytics_conversion_finalize_outcome_coverage( $outcome_coverage[ $outcome_type ], $is_new_lifecycle_outcome );
 	}
 
@@ -567,8 +567,8 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
  */
 function extrachill_analytics_conversion_outcome_types() {
 	return array(
-		'newsletter_signup',
-		'user_registration',
+		EC_ANALYTICS_EVENT_NEWSLETTER_SIGNUP,
+		EC_ANALYTICS_EVENT_USER_REGISTRATION,
 		defined( 'EC_ANALYTICS_EVENT_ONBOARDING_COMPLETED' ) ? EC_ANALYTICS_EVENT_ONBOARDING_COMPLETED : 'onboarding_completed',
 		defined( 'EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH' ) ? EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH : 'artist_profile_first_publish',
 	);
@@ -656,7 +656,7 @@ function extrachill_analytics_conversion_normalize_outcome( $row ) {
  * @return bool Whether the event is excluded.
  */
 function extrachill_analytics_conversion_outcome_is_excluded( $outcome ) {
-	return 'newsletter_signup' === $outcome['event_type']
+	return EC_ANALYTICS_EVENT_NEWSLETTER_SIGNUP === $outcome['event_type']
 		&& 'registration' === (string) ( $outcome['event_data']['context'] ?? '' );
 }
 

--- a/inc/core/abilities/get-outbound-clicks.php
+++ b/inc/core/abilities/get-outbound-clicks.php
@@ -40,13 +40,6 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * The canonical event_type for an outbound (off-network) click.
- */
-if ( ! defined( 'EC_ANALYTICS_EVENT_OUTBOUND_CLICK' ) ) {
-	define( 'EC_ANALYTICS_EVENT_OUTBOUND_CLICK', 'outbound_click' );
-}
-
-/**
  * Register the get-outbound-clicks ability.
  */
 function extrachill_analytics_register_outbound_clicks_ability() {
@@ -128,7 +121,7 @@ function extrachill_analytics_ability_get_outbound_clicks( $input ) {
 	$blog_id    = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
 	$category   = isset( $input['category'] ) ? sanitize_key( (string) $input['category'] ) : '';
 	$limit      = isset( $input['limit'] ) ? max( 1, (int) $input['limit'] ) : 25;
-	$event_type = defined( 'EC_ANALYTICS_EVENT_OUTBOUND_CLICK' ) ? EC_ANALYTICS_EVENT_OUTBOUND_CLICK : 'outbound_click';
+	$event_type = EC_ANALYTICS_EVENT_OUTBOUND_CLICK;
 
 	// Read the in-window outbound_click rows through the canonical events query
 	// helper (it owns the safe, prepared WHERE building) rather than re-rolling

--- a/inc/core/abilities/get-scanner-404-summary.php
+++ b/inc/core/abilities/get-scanner-404-summary.php
@@ -117,8 +117,8 @@ function extrachill_analytics_ability_get_scanner_404_summary( $input ) {
 	}
 
 	$table  = extrachill_analytics_events_table();
-	$where  = array( "event_type = '404_error'" );
-	$values = array();
+	$where  = array( 'event_type = %s' );
+	$values = array( EC_ANALYTICS_EVENT_404_ERROR );
 
 	if ( $days > 0 ) {
 		$where[]  = 'created_at >= %s';

--- a/inc/core/abilities/get-search-gaps.php
+++ b/inc/core/abilities/get-search-gaps.php
@@ -144,8 +144,8 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 	$blog_id     = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
 
 	$table  = extrachill_analytics_events_table();
-	$where  = array( "event_type = 'search'" );
-	$values = array();
+	$where  = array( 'event_type = %s' );
+	$values = array( EC_ANALYTICS_EVENT_SEARCH );
 
 	// Reproducible UTC window — created_at is stored in UTC, so bound in UTC too.
 	$now_utc = gmdate( 'Y-m-d H:i:s' );
@@ -201,7 +201,7 @@ function extrachill_analytics_ability_get_search_gaps( $input ) {
 	// 'search', created_at >= 2026-05-30): old predicate 271,548 rows vs new
 	// 241,666 — the 29,883 explicitly-true bots are now dropped, and all 227,175
 	// NULL/no-flag legacy rows are retained. (`CAST('true' AS JSON)` errored on
-	// this server, so it is intentionally avoided.)
+	// this server, so it is intentionally avoided).
 	$where[] = "JSON_EXTRACT(event_data, '$.is_bot') IS NOT TRUE";
 
 	// Defense-in-depth for legacy-contaminated rows. The OLD search rule

--- a/inc/core/abilities/list-404-events.php
+++ b/inc/core/abilities/list-404-events.php
@@ -73,7 +73,7 @@ function extrachill_analytics_ability_list_404_events( $input ) {
 	$limit   = isset( $input['limit'] ) ? (int) $input['limit'] : 50;
 
 	$args = array(
-		'event_type' => '404_error',
+		'event_type' => EC_ANALYTICS_EVENT_404_ERROR,
 		'limit'      => $limit,
 		'orderby'    => 'created_at',
 		'order'      => 'DESC',

--- a/inc/core/abilities/purge-404-events.php
+++ b/inc/core/abilities/purge-404-events.php
@@ -75,8 +75,8 @@ function extrachill_analytics_ability_purge_404_events( $input ) {
 	$dry_run = isset( $input['dry_run'] ) ? (bool) $input['dry_run'] : true;
 
 	$table  = extrachill_analytics_events_table();
-	$where  = array( "event_type = '404_error'" );
-	$values = array();
+	$where  = array( 'event_type = %s' );
+	$values = array( EC_ANALYTICS_EVENT_404_ERROR );
 
 	if ( $days > 0 ) {
 		$where[]  = 'created_at < %s';

--- a/inc/core/email-tracking.php
+++ b/inc/core/email-tracking.php
@@ -63,7 +63,7 @@ function extrachill_analytics_normalize_email_context( $context ) {
  */
 function extrachill_analytics_log_email_sent( $mail_data ) {
 	extrachill_track_analytics_event(
-		'email_sent',
+		EC_ANALYTICS_EVENT_EMAIL_SENT,
 		array(
 			'recipient_count' => extrachill_analytics_email_recipient_count( $mail_data['to'] ?? array() ),
 			'context'         => extrachill_analytics_normalize_email_context( extrachill_analytics_detect_email_context() ),
@@ -86,7 +86,7 @@ function extrachill_analytics_log_email_failed( $error ) {
 	$error_code = sanitize_key( (string) $error->get_error_code() );
 
 	extrachill_track_analytics_event(
-		'email_failed',
+		EC_ANALYTICS_EVENT_EMAIL_FAILED,
 		array(
 			'recipient_count' => extrachill_analytics_email_recipient_count( $recipients ),
 			'error_code'      => substr( $error_code ? $error_code : 'unknown', 0, 64 ),
@@ -150,8 +150,8 @@ function extrachill_analytics_run_email_cleanup_batch() {
 	$expired       = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded maintenance query against the plugin-owned analytics table.
 		$wpdb->prepare(
 			"DELETE FROM {$table} WHERE event_type IN (%s, %s) AND created_at < %s ORDER BY id ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Code-defined table name; values are prepared.
-			'email_sent',
-			'email_failed',
+			EC_ANALYTICS_EVENT_EMAIL_SENT,
+			EC_ANALYTICS_EVENT_EMAIL_FAILED,
 			$cutoff,
 			EXTRACHILL_ANALYTICS_EMAIL_CLEANUP_BATCH_SIZE
 		)
@@ -161,8 +161,8 @@ function extrachill_analytics_run_email_cleanup_batch() {
 	$scrubbed       = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded maintenance query against the plugin-owned analytics table.
 		$wpdb->prepare(
 			"UPDATE {$table} SET event_data = JSON_REMOVE(event_data, '$.to', '$.subject', '$.error') WHERE event_type IN (%s, %s) AND JSON_VALID(event_data) = 1 AND (JSON_EXTRACT(event_data, '$.to') IS NOT NULL OR JSON_EXTRACT(event_data, '$.subject') IS NOT NULL OR JSON_EXTRACT(event_data, '$.error') IS NOT NULL) ORDER BY id ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Code-defined table name; values are prepared.
-			'email_sent',
-			'email_failed',
+			EC_ANALYTICS_EVENT_EMAIL_SENT,
+			EC_ANALYTICS_EVENT_EMAIL_FAILED,
 			EXTRACHILL_ANALYTICS_EMAIL_CLEANUP_BATCH_SIZE
 		)
 	);
@@ -172,8 +172,8 @@ function extrachill_analytics_run_email_cleanup_batch() {
 	$invalid       = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded maintenance query against the plugin-owned analytics table.
 		$wpdb->prepare(
 			"DELETE FROM {$table} WHERE event_type IN (%s, %s) AND JSON_VALID(event_data) = 0 ORDER BY id ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Code-defined table name; values are prepared.
-			'email_sent',
-			'email_failed',
+			EC_ANALYTICS_EVENT_EMAIL_SENT,
+			EC_ANALYTICS_EVENT_EMAIL_FAILED,
 			EXTRACHILL_ANALYTICS_EMAIL_CLEANUP_BATCH_SIZE
 		)
 	);
@@ -345,8 +345,8 @@ function extrachill_analytics_email_event_exporter( $email_address, $page = 1 ) 
 			$wpdb->prepare(
 				"SELECT MAX(id) FROM {$table} WHERE user_id = %d AND event_type IN (%s, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Code-defined table name; values are prepared.
 				$user->ID,
-				'email_sent',
-				'email_failed'
+				EC_ANALYTICS_EVENT_EMAIL_SENT,
+				EC_ANALYTICS_EVENT_EMAIL_FAILED
 			)
 		);
 		$state  = array(
@@ -367,8 +367,8 @@ function extrachill_analytics_email_event_exporter( $email_address, $page = 1 ) 
 		$wpdb->prepare(
 			"SELECT id, blog_id, event_type, event_data, created_at FROM {$table} WHERE user_id = %d AND event_type IN (%s, %s) AND id > %d AND id <= %d ORDER BY id ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Code-defined table name; values are prepared.
 			$user->ID,
-			'email_sent',
-			'email_failed',
+			EC_ANALYTICS_EVENT_EMAIL_SENT,
+			EC_ANALYTICS_EVENT_EMAIL_FAILED,
 			$cursor,
 			(int) $state['max_id'],
 			EXTRACHILL_ANALYTICS_EMAIL_PRIVACY_BATCH_SIZE
@@ -383,7 +383,7 @@ function extrachill_analytics_email_event_exporter( $email_address, $page = 1 ) 
 		$fields     = array(
 			array(
 				'name'  => __( 'Delivery result', 'extrachill-analytics' ),
-				'value' => 'email_sent' === $row->event_type ? __( 'Sent', 'extrachill-analytics' ) : __( 'Failed', 'extrachill-analytics' ),
+				'value' => EC_ANALYTICS_EVENT_EMAIL_SENT === $row->event_type ? __( 'Sent', 'extrachill-analytics' ) : __( 'Failed', 'extrachill-analytics' ),
 			),
 			array(
 				'name'  => __( 'Recorded at', 'extrachill-analytics' ),
@@ -486,8 +486,8 @@ function extrachill_analytics_email_event_eraser( $email_address, $page = 1 ) {
 		$wpdb->prepare(
 			"DELETE FROM {$table} WHERE user_id = %d AND event_type IN (%s, %s) ORDER BY id ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Code-defined table name; values are prepared.
 			$user->ID,
-			'email_sent',
-			'email_failed',
+			EC_ANALYTICS_EVENT_EMAIL_SENT,
+			EC_ANALYTICS_EVENT_EMAIL_FAILED,
 			EXTRACHILL_ANALYTICS_EMAIL_PRIVACY_BATCH_SIZE
 		)
 	);

--- a/inc/core/event-types.php
+++ b/inc/core/event-types.php
@@ -81,16 +81,25 @@ const EC_ANALYTICS_EVENT_REDIRECT_FIRE     = 'redirect_fire';
  * - share_click: destination, share_url.
  * - bridge_click / bridge_impression: dest_site, source_post, source_site, term.
  * - outbound_click: dest_host, dest_url, category.
- * - experiment_assignment / experiment_exposure: experiment_key, variant,
- *   surface. Assignment records allocation; exposure records actual viewport
- *   visibility. They are distinct events and neither implies the other.
  */
-const EC_ANALYTICS_EVENT_SHARE_CLICK           = 'share_click';
-const EC_ANALYTICS_EVENT_BRIDGE_CLICK          = 'bridge_click';
-const EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION     = 'bridge_impression';
-const EC_ANALYTICS_EVENT_OUTBOUND_CLICK        = 'outbound_click';
-const EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT = 'experiment_assignment';
-const EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE   = 'experiment_exposure';
+const EC_ANALYTICS_EVENT_SHARE_CLICK       = 'share_click';
+const EC_ANALYTICS_EVENT_BRIDGE_CLICK      = 'bridge_click';
+const EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION = 'bridge_impression';
+const EC_ANALYTICS_EVENT_OUTBOUND_CLICK    = 'outbound_click';
+
+/**
+ * First-consumer experiment contract.
+ *
+ * Network owns assignment and validates its code-owned definition before
+ * firing bounded server-side hooks. Analytics persists only these exact names
+ * and fields. Assignment records allocation; exposure records actual 50%
+ * viewport visibility. Neither event implies the other.
+ */
+const EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT           = 'experiment_assignment';
+const EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE             = 'experiment_exposure';
+const EC_ANALYTICS_EXPERIMENT_GEO_BRIDGE_HOLDOUT         = 'geo-bridge-holdout';
+const EC_ANALYTICS_EXPERIMENT_SURFACE_SINGLE_POST_BRIDGE = 'single-post-bridge';
+const EC_ANALYTICS_EXPERIMENT_VARIANTS                   = array( 'control', 'treatment' );
 
 /**
  * Browser-originated events admitted by the public adapter boundary.
@@ -102,8 +111,6 @@ const EC_ANALYTICS_PUBLIC_BROWSER_EVENTS = array(
 	EC_ANALYTICS_EVENT_BRIDGE_CLICK,
 	EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION,
 	EC_ANALYTICS_EVENT_OUTBOUND_CLICK,
-	EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT,
-	EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE,
 );
 
 /** Team-experience events (team membership + Studio + Roadie usage). */

--- a/inc/core/event-types.php
+++ b/inc/core/event-types.php
@@ -33,11 +33,78 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Pageview event — one row per real (non-bot) front-end singular view, carrying
- * the anonymous first-party visitor_id when present. This is the deterministic
- * per-visitor history the retention rollups read.
+ * Pageview event — one row per real (non-bot) front-end view, carrying the
+ * anonymous first-party visitor_id when present. Payload fields are post_id,
+ * route_family, view_kind, referrer_host, and the server-owned is_bot verdict.
+ * This is the deterministic per-visitor history the retention rollups read.
  */
 const EC_ANALYTICS_EVENT_PAGEVIEW = 'pageview';
+
+/**
+ * Active platform event contracts.
+ *
+ * These names are emitted in production and consumed by first-party reports.
+ * Server-owned emitters keep using the flexible track-event ability, but MUST
+ * limit payloads to the documented fields and preserve the existing privacy
+ * behavior:
+ *
+ * - user_registration: user_id, source, method, referrer, utm.
+ * - newsletter_signup: context, list_id.
+ * - search: search_term, result_count; source and is_bot are server stamps.
+ * - search_attack: the search fields plus classification, pattern_family,
+ *   matched_token, ip, user_agent, and is_bot security diagnostics.
+ * - 404_error: requested_url, referer, user_agent, ip_hash, is_bot.
+ * - email_sent: recipient_count, context, is_bot.
+ * - email_failed: recipient_count, context, error_code, is_bot.
+ * - redirect_fire: rule_id, from_url, to_url, dest_host, dest_path, is_bot.
+ *
+ * Registration and newsletter payloads are intentionally documented rather
+ * than enforced here: their trusted server emitters need the existing flexible
+ * ability contract, including additive attribution fields.
+ */
+const EC_ANALYTICS_EVENT_USER_REGISTRATION = 'user_registration';
+const EC_ANALYTICS_EVENT_NEWSLETTER_SIGNUP = 'newsletter_signup';
+const EC_ANALYTICS_EVENT_SEARCH            = 'search';
+const EC_ANALYTICS_EVENT_SEARCH_ATTACK     = 'search_attack';
+const EC_ANALYTICS_EVENT_404_ERROR         = '404_error';
+const EC_ANALYTICS_EVENT_EMAIL_SENT        = 'email_sent';
+const EC_ANALYTICS_EVENT_EMAIL_FAILED      = 'email_failed';
+const EC_ANALYTICS_EVENT_REDIRECT_FIRE     = 'redirect_fire';
+
+/**
+ * Public browser-adapter event contracts.
+ *
+ * These payloads cross unauthenticated REST adapters before reaching the
+ * track-event ability, so write-integrity.php enforces the listed fields and
+ * bounds. `is_bot` is always server-owned and removed from browser input.
+ *
+ * - share_click: destination, share_url.
+ * - bridge_click / bridge_impression: dest_site, source_post, source_site, term.
+ * - outbound_click: dest_host, dest_url, category.
+ * - experiment_assignment / experiment_exposure: experiment_key, variant,
+ *   surface. Assignment records allocation; exposure records actual viewport
+ *   visibility. They are distinct events and neither implies the other.
+ */
+const EC_ANALYTICS_EVENT_SHARE_CLICK           = 'share_click';
+const EC_ANALYTICS_EVENT_BRIDGE_CLICK          = 'bridge_click';
+const EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION     = 'bridge_impression';
+const EC_ANALYTICS_EVENT_OUTBOUND_CLICK        = 'outbound_click';
+const EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT = 'experiment_assignment';
+const EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE   = 'experiment_exposure';
+
+/**
+ * Browser-originated events admitted by the public adapter boundary.
+ *
+ * @var string[]
+ */
+const EC_ANALYTICS_PUBLIC_BROWSER_EVENTS = array(
+	EC_ANALYTICS_EVENT_SHARE_CLICK,
+	EC_ANALYTICS_EVENT_BRIDGE_CLICK,
+	EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION,
+	EC_ANALYTICS_EVENT_OUTBOUND_CLICK,
+	EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT,
+	EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE,
+);
 
 /** Team-experience events (team membership + Studio + Roadie usage). */
 const EC_ANALYTICS_EVENT_TEAM_MEMBER_ADDED        = 'team_member_added';

--- a/inc/core/events.php
+++ b/inc/core/events.php
@@ -84,7 +84,7 @@ function extrachill_track_analytics_event( $event_type, $event_data = array(), $
 	// for `search` events, only when the caller hasn't already supplied an
 	// explicit source (a future upstream caller threading its own surface
 	// still wins), and only when the classifier is loaded.
-	if ( 'search' === $event_type
+	if ( EC_ANALYTICS_EVENT_SEARCH === $event_type
 		&& is_array( $event_data )
 		&& ! array_key_exists( 'source', $event_data )
 		&& function_exists( 'extrachill_analytics_classify_search_source' )

--- a/inc/core/experiment-integration.php
+++ b/inc/core/experiment-integration.php
@@ -60,15 +60,23 @@ add_filter( 'extrachill_experiment_measurement_eligible', 'extrachill_analytics_
  * signal against that assignment. This callback accepts no browser request and
  * persists only the three bounded scalar dimensions supplied by those hooks.
  *
- * @param string $event_type     Canonical assignment or exposure event name.
- * @param string $experiment_key Network-validated experiment key.
- * @param string $variant        Network-validated assigned variant.
- * @param string $surface        Network-validated experiment surface.
+ * @param string $event_type Canonical assignment or exposure event name.
+ * @param array  $metadata   Network-validated experiment metadata.
  * @return int|false Event ID, or false when the contract/privacy check fails.
  */
-function extrachill_analytics_record_experiment_event( $event_type, $experiment_key, $variant, $surface ) {
+function extrachill_analytics_record_experiment_event( $event_type, $metadata ) {
+	if ( ! is_array( $metadata ) || array( 'experiment_key', 'variant', 'surface' ) !== array_keys( $metadata ) ) {
+		return false;
+	}
+
+	$experiment_key = $metadata['experiment_key'];
+	$variant        = $metadata['variant'];
+	$surface        = $metadata['surface'];
 	if (
 		! in_array( $event_type, array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE ), true )
+		|| ! is_string( $experiment_key )
+		|| ! is_string( $variant )
+		|| ! is_string( $surface )
 		|| EC_ANALYTICS_EXPERIMENT_GEO_BRIDGE_HOLDOUT !== $experiment_key
 		|| EC_ANALYTICS_EXPERIMENT_SURFACE_SINGLE_POST_BRIDGE !== $surface
 		|| ! in_array( $variant, EC_ANALYTICS_EXPERIMENT_VARIANTS, true )
@@ -85,11 +93,7 @@ function extrachill_analytics_record_experiment_event( $event_type, $experiment_
 
 	return extrachill_track_analytics_event(
 		$event_type,
-		array(
-			'experiment_key' => $experiment_key,
-			'variant'        => $variant,
-			'surface'        => $surface,
-		),
+		$metadata,
 		'',
 		$visitor_id
 	);
@@ -98,23 +102,19 @@ function extrachill_analytics_record_experiment_event( $event_type, $experiment_
 /**
  * Persist a measured assignment resolved by Network.
  *
- * @param string $experiment_key Experiment key.
- * @param string $variant        Assigned variant.
- * @param string $surface        Experiment surface.
+ * @param array $metadata Bounded assignment metadata.
  */
-function extrachill_analytics_record_experiment_assignment( $experiment_key, $variant, $surface ) {
-	extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, $experiment_key, $variant, $surface );
+function extrachill_analytics_record_experiment_assignment( $metadata ) {
+	extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, $metadata );
 }
-add_action( 'extrachill_experiment_assignment_recorded', 'extrachill_analytics_record_experiment_assignment', 10, 3 );
+add_action( 'extrachill_experiment_assignment', 'extrachill_analytics_record_experiment_assignment', 10, 1 );
 
 /**
  * Persist a measured viewport exposure validated by Network.
  *
- * @param string $experiment_key Experiment key.
- * @param string $variant        Assigned variant.
- * @param string $surface        Experiment surface.
+ * @param array $metadata Bounded exposure metadata.
  */
-function extrachill_analytics_record_experiment_exposure( $experiment_key, $variant, $surface ) {
-	extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $experiment_key, $variant, $surface );
+function extrachill_analytics_record_experiment_exposure( $metadata ) {
+	extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $metadata );
 }
-add_action( 'extrachill_experiment_exposure_recorded', 'extrachill_analytics_record_experiment_exposure', 10, 3 );
+add_action( 'extrachill_experiment_exposure', 'extrachill_analytics_record_experiment_exposure', 10, 1 );

--- a/inc/core/experiment-integration.php
+++ b/inc/core/experiment-integration.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Analytics integration for Network-owned experiment assignment.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Contribute Analytics' existing identity without minting a new subject.
+ *
+ * Network supplies authenticated WordPress subjects before this filter. Keep
+ * those intact; anonymous requests receive the existing privacy-aware ec_vid.
+ *
+ * @param string $subject_key    Existing subject key.
+ * @param string $experiment_key Experiment key (unused; identity is generic).
+ * @param string $surface        Surface (unused; identity is generic).
+ * @param array  $context        Consumer context (unused; identity is generic).
+ * @return string Subject key, or an empty string when no identity exists.
+ */
+function extrachill_analytics_experiment_subject_key( $subject_key, $experiment_key = '', $surface = '', $context = array() ) {
+	unset( $experiment_key, $surface, $context );
+	$subject_key = trim( (string) $subject_key );
+	if ( '' !== $subject_key ) {
+		return $subject_key;
+	}
+
+	$visitor_id = function_exists( 'extrachill_analytics_read_visitor_id' ) ? extrachill_analytics_read_visitor_id() : '';
+
+	return '' !== $visitor_id ? 'ec-vid:' . $visitor_id : '';
+}
+add_filter( 'extrachill_experiment_subject_key', 'extrachill_analytics_experiment_subject_key', 10, 4 );
+
+/**
+ * Contribute Analytics' established GPC/DNT measurement policy.
+ *
+ * Identity availability remains Network's separate subject-key check. This
+ * filter answers only whether this request opted out of measured assignment.
+ *
+ * @param bool   $eligible       Existing provider decision.
+ * @param string $experiment_key Experiment key (unused; privacy is generic).
+ * @param string $surface        Surface (unused; privacy is generic).
+ * @param array  $context        Consumer context (unused; privacy is generic).
+ * @return bool Whether experiment measurement is privacy-eligible.
+ */
+function extrachill_analytics_experiment_measurement_eligible( $eligible, $experiment_key = '', $surface = '', $context = array() ) {
+	unset( $eligible, $experiment_key, $surface, $context );
+
+	return function_exists( 'extrachill_analytics_visitor_opted_out' )
+		&& ! extrachill_analytics_visitor_opted_out();
+}
+add_filter( 'extrachill_experiment_measurement_eligible', 'extrachill_analytics_experiment_measurement_eligible', 10, 4 );
+
+/**
+ * Persist a Network-validated first-consumer experiment event.
+ *
+ * Network fires the assignment hook only after a measured assignment resolves,
+ * and the exposure hook only after re-validating the browser's 50%-viewport
+ * signal against that assignment. This callback accepts no browser request and
+ * persists only the three bounded scalar dimensions supplied by those hooks.
+ *
+ * @param string $event_type     Canonical assignment or exposure event name.
+ * @param string $experiment_key Network-validated experiment key.
+ * @param string $variant        Network-validated assigned variant.
+ * @param string $surface        Network-validated experiment surface.
+ * @return int|false Event ID, or false when the contract/privacy check fails.
+ */
+function extrachill_analytics_record_experiment_event( $event_type, $experiment_key, $variant, $surface ) {
+	if (
+		! in_array( $event_type, array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE ), true )
+		|| EC_ANALYTICS_EXPERIMENT_GEO_BRIDGE_HOLDOUT !== $experiment_key
+		|| EC_ANALYTICS_EXPERIMENT_SURFACE_SINGLE_POST_BRIDGE !== $surface
+		|| ! in_array( $variant, EC_ANALYTICS_EXPERIMENT_VARIANTS, true )
+		|| ( function_exists( 'extrachill_analytics_visitor_opted_out' ) && extrachill_analytics_visitor_opted_out() )
+	) {
+		return false;
+	}
+
+	$visitor_id = function_exists( 'extrachill_analytics_read_visitor_id' ) ? extrachill_analytics_read_visitor_id() : '';
+	$user_id    = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+	if ( '' === $visitor_id && $user_id <= 0 ) {
+		return false;
+	}
+
+	return extrachill_track_analytics_event(
+		$event_type,
+		array(
+			'experiment_key' => $experiment_key,
+			'variant'        => $variant,
+			'surface'        => $surface,
+		),
+		'',
+		$visitor_id
+	);
+}
+
+/**
+ * Persist a measured assignment resolved by Network.
+ *
+ * @param string $experiment_key Experiment key.
+ * @param string $variant        Assigned variant.
+ * @param string $surface        Experiment surface.
+ */
+function extrachill_analytics_record_experiment_assignment( $experiment_key, $variant, $surface ) {
+	extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, $experiment_key, $variant, $surface );
+}
+add_action( 'extrachill_experiment_assignment_recorded', 'extrachill_analytics_record_experiment_assignment', 10, 3 );
+
+/**
+ * Persist a measured viewport exposure validated by Network.
+ *
+ * @param string $experiment_key Experiment key.
+ * @param string $variant        Assigned variant.
+ * @param string $surface        Experiment surface.
+ */
+function extrachill_analytics_record_experiment_exposure( $experiment_key, $variant, $surface ) {
+	extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $experiment_key, $variant, $surface );
+}
+add_action( 'extrachill_experiment_exposure_recorded', 'extrachill_analytics_record_experiment_exposure', 10, 3 );

--- a/inc/core/write-integrity.php
+++ b/inc/core/write-integrity.php
@@ -332,14 +332,6 @@ function extrachill_analytics_validate_public_event_data( $event_type, $event_da
 				'category'  => array( 'string', 32 ),
 			);
 			break;
-		case EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT:
-		case EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE:
-			$fields = array(
-				'experiment_key' => array( 'string', 64 ),
-				'variant'        => array( 'string', 16 ),
-				'surface'        => array( 'string', 64 ),
-			);
-			break;
 		default:
 			return true;
 	}
@@ -360,31 +352,6 @@ function extrachill_analytics_validate_public_event_data( $event_type, $event_da
 		$valid = extrachill_analytics_validate_public_event_field( $event_data, $field, $contract[0], $contract[1] );
 		if ( is_wp_error( $valid ) ) {
 			return $valid;
-		}
-	}
-
-	if ( in_array( $event_type, array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE ), true ) ) {
-		foreach ( array( 'experiment_key', 'variant', 'surface' ) as $required_field ) {
-			if ( empty( $event_data[ $required_field ] ) || ! preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $event_data[ $required_field ] ) ) {
-				return new WP_Error(
-					'invalid_event_field',
-					__( 'Experiment fields must be non-empty bounded identifiers.', 'extrachill-analytics' ),
-					array(
-						'status' => 400,
-						'field'  => $required_field,
-					)
-				);
-			}
-		}
-		if ( ! in_array( $event_data['variant'], array( 'control', 'treatment' ), true ) ) {
-			return new WP_Error(
-				'invalid_event_field',
-				__( 'Experiment variant must be control or treatment.', 'extrachill-analytics' ),
-				array(
-					'status' => 400,
-					'field'  => 'variant',
-				)
-			);
 		}
 	}
 

--- a/inc/core/write-integrity.php
+++ b/inc/core/write-integrity.php
@@ -249,7 +249,146 @@ function extrachill_analytics_validate_pageview_write( $post_id, $source_path, $
  * @return string[]
  */
 function extrachill_analytics_public_browser_event_types() {
-	return array( 'bridge_click', 'bridge_impression', 'outbound_click', 'share_click' );
+	return EC_ANALYTICS_PUBLIC_BROWSER_EVENTS;
+}
+
+/**
+ * Reject a public payload field that is not a bounded scalar of the expected type.
+ *
+ * @param array  $event_data Event dimensions.
+ * @param string $field      Field name.
+ * @param string $type       Expected scalar type.
+ * @param int    $max_length Maximum string length.
+ * @return true|WP_Error
+ */
+function extrachill_analytics_validate_public_event_field( $event_data, $field, $type, $max_length = 0 ) {
+	if ( ! array_key_exists( $field, $event_data ) ) {
+		return true;
+	}
+
+	$value = $event_data[ $field ];
+	if ( null === $value ) {
+		return true;
+	}
+	if ( 'integer' === $type ) {
+		if ( ! is_int( $value ) && ! ( is_string( $value ) && preg_match( '/^\d+$/', $value ) ) ) {
+			return new WP_Error(
+				'invalid_event_field',
+				__( 'Event data contains an invalid field value.', 'extrachill-analytics' ),
+				array(
+					'status' => 400,
+					'field'  => $field,
+				)
+			);
+		}
+		return true;
+	}
+
+	if ( ! is_string( $value ) || ( $max_length > 0 && strlen( $value ) > $max_length ) ) {
+		return new WP_Error(
+			'invalid_event_field',
+			__( 'Event data contains an invalid or unbounded field value.', 'extrachill-analytics' ),
+			array(
+				'status' => 400,
+				'field'  => $field,
+			)
+		);
+	}
+
+	return true;
+}
+
+/**
+ * Validate the event-specific dimensions accepted from public adapters.
+ *
+ * This intentionally remains a narrow switch over the six browser events. It
+ * is not a schema registry and does not constrain trusted server-owned events.
+ *
+ * @param string $event_type Event type.
+ * @param array  $event_data Event dimensions.
+ * @return true|WP_Error
+ */
+function extrachill_analytics_validate_public_event_data( $event_type, $event_data ) {
+	switch ( $event_type ) {
+		case EC_ANALYTICS_EVENT_SHARE_CLICK:
+			$fields = array(
+				'destination' => array( 'string', 64 ),
+				'share_url'   => array( 'string', 2048 ),
+			);
+			break;
+		case EC_ANALYTICS_EVENT_BRIDGE_CLICK:
+		case EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION:
+			$fields = array(
+				'dest_site'   => array( 'string', 64 ),
+				'source_post' => array( 'integer', 0 ),
+				'source_site' => array( 'string', 64 ),
+				'term'        => array( 'string', 200 ),
+			);
+			break;
+		case EC_ANALYTICS_EVENT_OUTBOUND_CLICK:
+			$fields = array(
+				'dest_host' => array( 'string', 253 ),
+				'dest_url'  => array( 'string', 2048 ),
+				'category'  => array( 'string', 32 ),
+			);
+			break;
+		case EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT:
+		case EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE:
+			$fields = array(
+				'experiment_key' => array( 'string', 64 ),
+				'variant'        => array( 'string', 16 ),
+				'surface'        => array( 'string', 64 ),
+			);
+			break;
+		default:
+			return true;
+	}
+
+	$unknown_fields = array_diff( array_keys( $event_data ), array_keys( $fields ), array( 'is_bot' ) );
+	if ( ! empty( $unknown_fields ) ) {
+		return new WP_Error(
+			'invalid_event_field',
+			__( 'Event data contains an unsupported field.', 'extrachill-analytics' ),
+			array(
+				'status' => 400,
+				'field'  => reset( $unknown_fields ),
+			)
+		);
+	}
+
+	foreach ( $fields as $field => $contract ) {
+		$valid = extrachill_analytics_validate_public_event_field( $event_data, $field, $contract[0], $contract[1] );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+	}
+
+	if ( in_array( $event_type, array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE ), true ) ) {
+		foreach ( array( 'experiment_key', 'variant', 'surface' ) as $required_field ) {
+			if ( empty( $event_data[ $required_field ] ) || ! preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $event_data[ $required_field ] ) ) {
+				return new WP_Error(
+					'invalid_event_field',
+					__( 'Experiment fields must be non-empty bounded identifiers.', 'extrachill-analytics' ),
+					array(
+						'status' => 400,
+						'field'  => $required_field,
+					)
+				);
+			}
+		}
+		if ( ! in_array( $event_data['variant'], array( 'control', 'treatment' ), true ) ) {
+			return new WP_Error(
+				'invalid_event_field',
+				__( 'Experiment variant must be control or treatment.', 'extrachill-analytics' ),
+				array(
+					'status' => 400,
+					'field'  => 'variant',
+				)
+			);
+		}
+	}
+
+	return true;
 }
 
 /**
@@ -291,6 +430,11 @@ function extrachill_analytics_validate_public_event_write( $event_type, $event_d
 
 	if ( ! is_array( $event_data ) ) {
 		return new WP_Error( 'invalid_event_data', __( 'Event data must be an object.', 'extrachill-analytics' ), array( 'status' => 400 ) );
+	}
+
+	$valid_event_data = extrachill_analytics_validate_public_event_data( $event_type, $event_data );
+	if ( is_wp_error( $valid_event_data ) ) {
+		return $valid_event_data;
 	}
 
 	$source_post = isset( $event_data['source_post'] ) ? (int) $event_data['source_post'] : 0;

--- a/tests/EventContractsTest.php
+++ b/tests/EventContractsTest.php
@@ -117,8 +117,20 @@ final class EventContractsTest extends TestCase {
 	 * Network hooks persist distinct canonical events with exact bounded fields.
 	 */
 	public function test_network_hooks_persist_exact_assignment_and_exposure_payloads(): void {
-		extrachill_analytics_record_experiment_assignment( 'geo-bridge-holdout', 'control', 'single-post-bridge' );
-		extrachill_analytics_record_experiment_exposure( 'geo-bridge-holdout', 'treatment', 'single-post-bridge' );
+		extrachill_analytics_record_experiment_assignment(
+			array(
+				'experiment_key' => 'geo-bridge-holdout',
+				'variant'        => 'control',
+				'surface'        => 'single-post-bridge',
+			)
+		);
+		extrachill_analytics_record_experiment_exposure(
+			array(
+				'experiment_key' => 'geo-bridge-holdout',
+				'variant'        => 'treatment',
+				'surface'        => 'single-post-bridge',
+			)
+		);
 
 		$this->assertCount( 2, $GLOBALS['extrachill_analytics_test_events'] );
 		$this->assertSame( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, $GLOBALS['extrachill_analytics_test_events'][0][0] );
@@ -135,15 +147,88 @@ final class EventContractsTest extends TestCase {
 	}
 
 	/**
+	 * Analytics stays aligned to Network's exact one-array action contract.
+	 */
+	public function test_network_hook_names_and_accepted_payload_shape_do_not_drift(): void {
+		$experiment_actions = array_values(
+			array_filter(
+				$GLOBALS['extrachill_analytics_test_registered_actions'],
+				static function ( $registration ) {
+					return isset( $registration[0] ) && 0 === strpos( $registration[0], 'extrachill_experiment_' );
+				}
+			)
+		);
+
+		$this->assertContains(
+			array( 'extrachill_experiment_assignment', 'extrachill_analytics_record_experiment_assignment', 10, 1 ),
+			$experiment_actions
+		);
+		$this->assertContains(
+			array( 'extrachill_experiment_exposure', 'extrachill_analytics_record_experiment_exposure', 10, 1 ),
+			$experiment_actions
+		);
+		$this->assertNotContains( 'extrachill_experiment_assignment_recorded', array_column( $experiment_actions, 0 ) );
+		$this->assertNotContains( 'extrachill_experiment_exposure_recorded', array_column( $experiment_actions, 0 ) );
+
+		$this->assertFalse(
+			extrachill_analytics_record_experiment_event(
+				EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT,
+				array(
+					'experiment_key' => 'geo-bridge-holdout',
+					'variant'        => 'control',
+					'surface'        => 'single-post-bridge',
+					'extra'          => 'rejected',
+				)
+			)
+		);
+	}
+
+	/**
 	 * The persistence listener rejects drift and privacy exclusion.
 	 */
 	public function test_experiment_listener_rejects_unregistered_contract_values(): void {
-		$this->assertFalse( extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, 'other', 'control', 'single-post-bridge' ) );
-		$this->assertFalse( extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, 'geo-bridge-holdout', 'challenger', 'single-post-bridge' ) );
-		$this->assertFalse( extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, 'geo-bridge-holdout', 'treatment', 'other' ) );
+		$this->assertFalse(
+			extrachill_analytics_record_experiment_event(
+				EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT,
+				array(
+					'experiment_key' => 'other',
+					'variant'        => 'control',
+					'surface'        => 'single-post-bridge',
+				)
+			)
+		);
+		$this->assertFalse(
+			extrachill_analytics_record_experiment_event(
+				EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT,
+				array(
+					'experiment_key' => 'geo-bridge-holdout',
+					'variant'        => 'challenger',
+					'surface'        => 'single-post-bridge',
+				)
+			)
+		);
+		$this->assertFalse(
+			extrachill_analytics_record_experiment_event(
+				EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE,
+				array(
+					'experiment_key' => 'geo-bridge-holdout',
+					'variant'        => 'treatment',
+					'surface'        => 'other',
+				)
+			)
+		);
 
 		$_SERVER['HTTP_SEC_GPC'] = '1';
-		$this->assertFalse( extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, 'geo-bridge-holdout', 'treatment', 'single-post-bridge' ) );
+		$this->assertFalse(
+			extrachill_analytics_record_experiment_event(
+				EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE,
+				array(
+					'experiment_key' => 'geo-bridge-holdout',
+					'variant'        => 'treatment',
+					'surface'        => 'single-post-bridge',
+				)
+			)
+		);
 		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_events'] );
 	}
 }

--- a/tests/EventContractsTest.php
+++ b/tests/EventContractsTest.php
@@ -8,11 +8,31 @@
 use PHPUnit\Framework\TestCase;
 
 require_once dirname( __DIR__ ) . '/inc/core/event-types.php';
+require_once dirname( __DIR__ ) . '/inc/core/assets.php';
+require_once dirname( __DIR__ ) . '/inc/core/experiment-integration.php';
+require_once dirname( __DIR__ ) . '/inc/core/write-integrity.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities.php';
 
 /**
  * Keep active emitters and report readers on canonical names.
  */
 final class EventContractsTest extends TestCase {
+	/**
+	 * Establish identified, privacy-eligible experiment fixtures.
+	 */
+	protected function setUp(): void {
+		$_COOKIE[ EXTRACHILL_ANALYTICS_VISITOR_COOKIE ] = '123e4567-e89b-42d3-a456-426614174000';
+		unset( $_SERVER['HTTP_SEC_GPC'], $_SERVER['HTTP_DNT'] );
+		$GLOBALS['extrachill_analytics_test_events'] = array();
+	}
+
+	/**
+	 * Restore privacy and identity fixtures.
+	 */
+	protected function tearDown(): void {
+		unset( $_COOKIE[ EXTRACHILL_ANALYTICS_VISITOR_COOKIE ], $_SERVER['HTTP_SEC_GPC'], $_SERVER['HTTP_DNT'] );
+	}
+
 	/**
 	 * Active cross-plugin and report-critical names remain exact.
 	 */
@@ -32,29 +52,98 @@ final class EventContractsTest extends TestCase {
 		$this->assertSame( 'experiment_assignment', EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT );
 		$this->assertSame( 'experiment_exposure', EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE );
 		$this->assertNotSame( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE );
+		$this->assertSame( 'geo-bridge-holdout', EC_ANALYTICS_EXPERIMENT_GEO_BRIDGE_HOLDOUT );
+		$this->assertSame( 'single-post-bridge', EC_ANALYTICS_EXPERIMENT_SURFACE_SINGLE_POST_BRIDGE );
 	}
 
 	/**
-	 * Real Analytics-owned emitters and critical readers reference constants.
+	 * Experiment events never enter the generic public browser event boundary.
 	 */
-	public function test_emitters_and_readers_do_not_redescribe_contract_names(): void {
-		$expectations = array(
-			'inc/core/404-tracking.php'                  => 'EC_ANALYTICS_EVENT_404_ERROR',
-			'inc/core/email-tracking.php'                => 'EC_ANALYTICS_EVENT_EMAIL_SENT',
-			'inc/core/abilities.php'                     => 'EC_ANALYTICS_EVENT_SEARCH_ATTACK',
-			'inc/core/abilities/get-search-gaps.php'     => 'EC_ANALYTICS_EVENT_SEARCH',
-			'inc/core/abilities/get-attack-summary.php'  => 'EC_ANALYTICS_EVENT_SEARCH_ATTACK',
-			'inc/core/abilities/get-bridge-ctr.php'      => 'EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION',
-			'inc/core/abilities/get-outbound-clicks.php' => 'EC_ANALYTICS_EVENT_OUTBOUND_CLICK',
-			'inc/core/abilities/get-conversion-map.php'  => 'EC_ANALYTICS_EVENT_USER_REGISTRATION',
-			'inc/core/abilities/get-404-summary.php'     => 'EC_ANALYTICS_EVENT_404_ERROR',
-		);
+	public function test_experiment_events_are_not_public_browser_events(): void {
+		$this->assertNotContains( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, extrachill_analytics_public_browser_event_types() );
+		$this->assertNotContains( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, extrachill_analytics_public_browser_event_types() );
+	}
 
-		foreach ( $expectations as $relative_path => $constant ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source contract fixture.
-			$source = file_get_contents( dirname( __DIR__ ) . '/' . $relative_path );
-			$this->assertIsString( $source );
-			$this->assertStringContainsString( $constant, $source, $relative_path );
-		}
+	/**
+	 * The flexible event ability remains internal and absent from public REST.
+	 */
+	public function test_flexible_event_ability_remains_private(): void {
+		$GLOBALS['extrachill_analytics_registered_abilities'] = array();
+		extrachill_analytics_register_abilities();
+
+		$ability = $GLOBALS['extrachill_analytics_registered_abilities']['extrachill/track-analytics-event'];
+		$this->assertFalse( $ability['meta']['show_in_rest'] );
+		$this->assertSame( '__return_true', $ability['permission_callback'] );
+	}
+
+	/**
+	 * Analytics contributes the existing read-only visitor subject.
+	 */
+	public function test_subject_provider_preserves_authenticated_subject_and_falls_back_to_ec_vid(): void {
+		$this->assertSame( 'wp-user:42', extrachill_analytics_experiment_subject_key( 'wp-user:42' ) );
+		$this->assertSame(
+			'ec-vid:123e4567-e89b-42d3-a456-426614174000',
+			extrachill_analytics_experiment_subject_key( '' )
+		);
+	}
+
+	/**
+	 * Analytics' provider denies measurement under either established opt-out.
+	 *
+	 * @dataProvider privacy_header_provider
+	 *
+	 * @param string $header Privacy header.
+	 */
+	public function test_measurement_provider_honors_privacy_headers( $header ): void {
+		$this->assertTrue( extrachill_analytics_experiment_measurement_eligible( false ) );
+		$_SERVER[ $header ] = '1';
+		$this->assertFalse( extrachill_analytics_experiment_measurement_eligible( true ) );
+		$this->assertSame( '', extrachill_analytics_experiment_subject_key( '' ) );
+	}
+
+	/**
+	 * Supported privacy headers.
+	 *
+	 * @return array<string,array{string}>
+	 */
+	public function privacy_header_provider() {
+		return array(
+			'global privacy control' => array( 'HTTP_SEC_GPC' ),
+			'do not track'           => array( 'HTTP_DNT' ),
+		);
+	}
+
+	/**
+	 * Network hooks persist distinct canonical events with exact bounded fields.
+	 */
+	public function test_network_hooks_persist_exact_assignment_and_exposure_payloads(): void {
+		extrachill_analytics_record_experiment_assignment( 'geo-bridge-holdout', 'control', 'single-post-bridge' );
+		extrachill_analytics_record_experiment_exposure( 'geo-bridge-holdout', 'treatment', 'single-post-bridge' );
+
+		$this->assertCount( 2, $GLOBALS['extrachill_analytics_test_events'] );
+		$this->assertSame( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, $GLOBALS['extrachill_analytics_test_events'][0][0] );
+		$this->assertSame( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $GLOBALS['extrachill_analytics_test_events'][1][0] );
+		$this->assertSame(
+			array(
+				'experiment_key' => 'geo-bridge-holdout',
+				'variant'        => 'control',
+				'surface'        => 'single-post-bridge',
+			),
+			$GLOBALS['extrachill_analytics_test_events'][0][1]
+		);
+		$this->assertSame( array( 'experiment_key', 'variant', 'surface' ), array_keys( $GLOBALS['extrachill_analytics_test_events'][1][1] ) );
+	}
+
+	/**
+	 * The persistence listener rejects drift and privacy exclusion.
+	 */
+	public function test_experiment_listener_rejects_unregistered_contract_values(): void {
+		$this->assertFalse( extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, 'other', 'control', 'single-post-bridge' ) );
+		$this->assertFalse( extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, 'geo-bridge-holdout', 'challenger', 'single-post-bridge' ) );
+		$this->assertFalse( extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, 'geo-bridge-holdout', 'treatment', 'other' ) );
+
+		$_SERVER['HTTP_SEC_GPC'] = '1';
+		$this->assertFalse( extrachill_analytics_record_experiment_event( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, 'geo-bridge-holdout', 'treatment', 'single-post-bridge' ) );
+		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_events'] );
 	}
 }

--- a/tests/EventContractsTest.php
+++ b/tests/EventContractsTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Drift tests for canonical analytics event contracts.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/event-types.php';
+
+/**
+ * Keep active emitters and report readers on canonical names.
+ */
+final class EventContractsTest extends TestCase {
+	/**
+	 * Active cross-plugin and report-critical names remain exact.
+	 */
+	public function test_canonical_active_event_names(): void {
+		$this->assertSame( 'user_registration', EC_ANALYTICS_EVENT_USER_REGISTRATION );
+		$this->assertSame( 'newsletter_signup', EC_ANALYTICS_EVENT_NEWSLETTER_SIGNUP );
+		$this->assertSame( 'search', EC_ANALYTICS_EVENT_SEARCH );
+		$this->assertSame( 'search_attack', EC_ANALYTICS_EVENT_SEARCH_ATTACK );
+		$this->assertSame( 'share_click', EC_ANALYTICS_EVENT_SHARE_CLICK );
+		$this->assertSame( 'bridge_click', EC_ANALYTICS_EVENT_BRIDGE_CLICK );
+		$this->assertSame( 'bridge_impression', EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION );
+		$this->assertSame( 'outbound_click', EC_ANALYTICS_EVENT_OUTBOUND_CLICK );
+		$this->assertSame( '404_error', EC_ANALYTICS_EVENT_404_ERROR );
+		$this->assertSame( 'email_sent', EC_ANALYTICS_EVENT_EMAIL_SENT );
+		$this->assertSame( 'email_failed', EC_ANALYTICS_EVENT_EMAIL_FAILED );
+		$this->assertSame( 'redirect_fire', EC_ANALYTICS_EVENT_REDIRECT_FIRE );
+		$this->assertSame( 'experiment_assignment', EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT );
+		$this->assertSame( 'experiment_exposure', EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE );
+		$this->assertNotSame( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE );
+	}
+
+	/**
+	 * Real Analytics-owned emitters and critical readers reference constants.
+	 */
+	public function test_emitters_and_readers_do_not_redescribe_contract_names(): void {
+		$expectations = array(
+			'inc/core/404-tracking.php'                  => 'EC_ANALYTICS_EVENT_404_ERROR',
+			'inc/core/email-tracking.php'                => 'EC_ANALYTICS_EVENT_EMAIL_SENT',
+			'inc/core/abilities.php'                     => 'EC_ANALYTICS_EVENT_SEARCH_ATTACK',
+			'inc/core/abilities/get-search-gaps.php'     => 'EC_ANALYTICS_EVENT_SEARCH',
+			'inc/core/abilities/get-attack-summary.php'  => 'EC_ANALYTICS_EVENT_SEARCH_ATTACK',
+			'inc/core/abilities/get-bridge-ctr.php'      => 'EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION',
+			'inc/core/abilities/get-outbound-clicks.php' => 'EC_ANALYTICS_EVENT_OUTBOUND_CLICK',
+			'inc/core/abilities/get-conversion-map.php'  => 'EC_ANALYTICS_EVENT_USER_REGISTRATION',
+			'inc/core/abilities/get-404-summary.php'     => 'EC_ANALYTICS_EVENT_404_ERROR',
+		);
+
+		foreach ( $expectations as $relative_path => $constant ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source contract fixture.
+			$source = file_get_contents( dirname( __DIR__ ) . '/' . $relative_path );
+			$this->assertIsString( $source );
+			$this->assertStringContainsString( $constant, $source, $relative_path );
+		}
+	}
+}

--- a/tests/PublicWriteIntegrityTest.php
+++ b/tests/PublicWriteIntegrityTest.php
@@ -250,41 +250,6 @@ final class PublicWriteIntegrityTest extends TestCase {
 	}
 
 	/**
-	 * Assignment and actual viewport exposure remain separate accepted events.
-	 *
-	 * @dataProvider experiment_event_provider
-	 *
-	 * @param string $event_type Canonical experiment event.
-	 * @param string $variant    Canonical experiment variant.
-	 */
-	public function test_experiment_contract_accepts_control_and_treatment( $event_type, $variant ): void {
-		$result = extrachill_analytics_validate_public_event_write(
-			$event_type,
-			array(
-				'experiment_key' => 'geographic_bridge',
-				'variant'        => $variant,
-				'surface'        => 'single_post_bridge',
-			),
-			'/story/'
-		);
-
-		$this->assertIsArray( $result );
-		$this->assertSame( $variant, $result['event_data']['variant'] );
-	}
-
-	/**
-	 * Canonical experiment event/variant pairs.
-	 *
-	 * @return array<string,array{string,string}>
-	 */
-	public function experiment_event_provider() {
-		return array(
-			'assigned control'  => array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, 'control' ),
-			'exposed treatment' => array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, 'treatment' ),
-		);
-	}
-
-	/**
 	 * Public adapters reject fields that could create unbounded dimensions.
 	 *
 	 * @dataProvider unbounded_public_payload_provider
@@ -305,18 +270,9 @@ final class PublicWriteIntegrityTest extends TestCase {
 	 * @return array<string,array{string,array}>
 	 */
 	public function unbounded_public_payload_provider() {
-		$experiment = array(
-			'experiment_key' => 'geographic_bridge',
-			'variant'        => 'control',
-			'surface'        => 'single_post_bridge',
-		);
-
 		return array(
-			'unbounded experiment key' => array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, array_merge( $experiment, array( 'experiment_key' => str_repeat( 'x', 65 ) ) ) ),
-			'unknown variant'          => array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, array_merge( $experiment, array( 'variant' => 'challenger' ) ) ),
-			'unbounded surface'        => array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, array_merge( $experiment, array( 'surface' => str_repeat( 'x', 65 ) ) ) ),
-			'unbounded bridge term'    => array( EC_ANALYTICS_EVENT_BRIDGE_CLICK, array( 'term' => str_repeat( 'x', 201 ) ) ),
-			'unknown browser field'    => array(
+			'unbounded bridge term' => array( EC_ANALYTICS_EVENT_BRIDGE_CLICK, array( 'term' => str_repeat( 'x', 201 ) ) ),
+			'unknown browser field' => array(
 				EC_ANALYTICS_EVENT_SHARE_CLICK,
 				array(
 					'destination' => 'facebook',

--- a/tests/PublicWriteIntegrityTest.php
+++ b/tests/PublicWriteIntegrityTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once dirname( __DIR__ ) . '/inc/core/route-classifier.php';
 require_once dirname( __DIR__ ) . '/inc/core/assets.php';
+require_once dirname( __DIR__ ) . '/inc/core/event-types.php';
 require_once dirname( __DIR__ ) . '/inc/core/write-integrity.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/track-page-view.php';
@@ -159,6 +160,24 @@ final class PublicWriteIntegrityTest extends TestCase {
 	}
 
 	/**
+	 * Optional adapter fields retain their existing null compatibility.
+	 */
+	public function test_public_event_accepts_null_optional_field(): void {
+		$result = extrachill_analytics_validate_public_event_write(
+			EC_ANALYTICS_EVENT_OUTBOUND_CLICK,
+			array(
+				'dest_host' => 'tickets.example',
+				'dest_url'  => null,
+				'category'  => 'ticketing',
+			),
+			'/story/'
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertNull( $result['event_data']['dest_url'] );
+	}
+
+	/**
 	 * A source post cannot be attached to a different page path.
 	 */
 	public function test_public_event_rejects_source_post_mismatch(): void {
@@ -228,6 +247,83 @@ final class PublicWriteIntegrityTest extends TestCase {
 		$result = extrachill_analytics_validate_public_event_write( 'user_registration', array( 'method' => 'form' ), '/register/' );
 
 		$this->assertSame( '/register/', $result['source_url'] );
+	}
+
+	/**
+	 * Assignment and actual viewport exposure remain separate accepted events.
+	 *
+	 * @dataProvider experiment_event_provider
+	 *
+	 * @param string $event_type Canonical experiment event.
+	 * @param string $variant    Canonical experiment variant.
+	 */
+	public function test_experiment_contract_accepts_control_and_treatment( $event_type, $variant ): void {
+		$result = extrachill_analytics_validate_public_event_write(
+			$event_type,
+			array(
+				'experiment_key' => 'geographic_bridge',
+				'variant'        => $variant,
+				'surface'        => 'single_post_bridge',
+			),
+			'/story/'
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $variant, $result['event_data']['variant'] );
+	}
+
+	/**
+	 * Canonical experiment event/variant pairs.
+	 *
+	 * @return array<string,array{string,string}>
+	 */
+	public function experiment_event_provider() {
+		return array(
+			'assigned control'  => array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, 'control' ),
+			'exposed treatment' => array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, 'treatment' ),
+		);
+	}
+
+	/**
+	 * Public adapters reject fields that could create unbounded dimensions.
+	 *
+	 * @dataProvider unbounded_public_payload_provider
+	 *
+	 * @param string $event_type Event type.
+	 * @param array  $event_data Public dimensions.
+	 */
+	public function test_public_event_rejects_unbounded_or_unknown_values( $event_type, $event_data ): void {
+		$result = extrachill_analytics_validate_public_event_write( $event_type, $event_data, '/story/' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_event_field', $result->code );
+	}
+
+	/**
+	 * Invalid public dimensions.
+	 *
+	 * @return array<string,array{string,array}>
+	 */
+	public function unbounded_public_payload_provider() {
+		$experiment = array(
+			'experiment_key' => 'geographic_bridge',
+			'variant'        => 'control',
+			'surface'        => 'single_post_bridge',
+		);
+
+		return array(
+			'unbounded experiment key' => array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, array_merge( $experiment, array( 'experiment_key' => str_repeat( 'x', 65 ) ) ) ),
+			'unknown variant'          => array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, array_merge( $experiment, array( 'variant' => 'challenger' ) ) ),
+			'unbounded surface'        => array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, array_merge( $experiment, array( 'surface' => str_repeat( 'x', 65 ) ) ) ),
+			'unbounded bridge term'    => array( EC_ANALYTICS_EVENT_BRIDGE_CLICK, array( 'term' => str_repeat( 'x', 201 ) ) ),
+			'unknown browser field'    => array(
+				EC_ANALYTICS_EVENT_SHARE_CLICK,
+				array(
+					'destination' => 'facebook',
+					'free_form'   => 'nope',
+				),
+			),
+		);
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -49,6 +49,7 @@ if ( ! function_exists( 'add_action' ) ) {
 	 * @param mixed ...$args Hook name, callback, and optional priority/args.
 	 */
 	function add_action( ...$args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		$GLOBALS['extrachill_analytics_test_registered_actions'][] = $args;
 		return true;
 	}
 }


### PR DESCRIPTION
## Summary
- centralize active, report-critical event names and bounded payload documentation in `event-types.php`, then move Analytics-owned emitters/readers off duplicated literals
- validate existing share, bridge, and outbound public adapter payloads while keeping the flexible server-owned track-event ability private
- integrate with Network #137 through generic identity/privacy filters and its exact one-array assignment/exposure action contract

## Proven production contracts
- `user_registration`: `extrachill-users/inc/core/abilities/create-user.php`; fields `user_id`, `source`, `method`, optional `referrer`/`utm`
- `newsletter_signup`: `extrachill-newsletter/inc/core/abilities/subscribe.php`; fields `context`, `list_id`
- `search`: `extrachill-search/extrachill-search.php`; fields `search_term`, `result_count`, with Analytics-owned `source`/`is_bot` stamps and `search_attack` reclassification diagnostics
- `share_click`, `bridge_click`, `outbound_click`: `extrachill-api/inc/routes/analytics/click.php`; browser payloads originate in existing share/bridge/outbound instrumentation
- `bridge_impression`: `extrachill-api/inc/routes/analytics/impression.php`, emitted by `extrachill-network/assets/js/bridge-instrumentation.js`
- `pageview`, `404_error`, `email_sent`, and `email_failed`: Analytics-owned production emitters and their retention, route, 404, security, and privacy readers
- `redirect_fire`: `extrachill-seo/inc/core/redirects-db.php`, consumed by the redirect conversion report

## Experiment integration
- registers `extrachill_experiment_subject_key` using Network's existing authenticated subject or Analytics' read-only `ec_vid` resolver
- registers `extrachill_experiment_measurement_eligible` using Analytics' existing GPC/DNT opt-out semantics
- listens to `extrachill_experiment_assignment` and `extrachill_experiment_exposure`, each with one bounded metadata array
- requires the exact metadata shape `experiment_key`, `variant`, `surface`; missing, extra, reordered, or non-string values are rejected
- allowlists the approved first-consumer contract: `geo-bridge-holdout`, `single-post-bridge`, and `control|treatment`
- persists assignment and 50%-viewport exposure as distinct canonical events
- does not expose or route browser experiment data through `extrachill/track-analytics-event`; that flexible ability remains `show_in_rest: false`
- exact Network coordination: https://github.com/Extra-Chill/extrachill-network/pull/137#issuecomment-5009514590

## Rebase and bridge behavior
- rebased onto current `origin/main` after #207
- preserved #207's independent stored click/impression counts, truthy-bot exclusion, potentially greater-than-100% ratio, bounded `id DESC` keyset pagination, and coverage semantics
- applied canonical constants only; no event pairing, synthetic impressions, retry dedupe, or ratio clamping was restored

## Boundary and compatibility
- existing public browser payloads reject unknown fields, wrong scalar types, oversized strings/URLs/hosts, and preserve optional-null compatibility
- existing source-post/site/destination checks, source-path normalization, server-owned `is_bot`, and visitor privacy behavior remain intact
- no registry, event bus, storage, assignment logic, generic experiment API, public event endpoint, version bump, or changelog change was added

## Verification
- `vendor/bin/phpunit --filter 'EventContractsTest|GetBridgeCtrTest|PublicWriteIntegrityTest'` (36 tests, 146 assertions)
- `vendor/bin/phpunit` (356 tests, 1340 assertions)
- changed-file PHP syntax checks
- full PR-scope WordPress PHPCS (0 errors; existing direct-database-query warnings only)
- `git diff --check`
- JavaScript checks not run because no JavaScript files changed

Closes #190