### PR TITLE
fix: exclude bot-stamped bridge events from CTR

### DIFF
--- a/inc/core/abilities/get-bridge-ctr.php
+++ b/inc/core/abilities/get-bridge-ctr.php
@@ -11,14 +11,14 @@
  *
  *   The raw GA4 `network_bridge` channel counts UTM *arrivals*, which
  *   prefetch/prerender/crawler hits fake — it shows physically-impossible
- *   sub-1.0 pageviews/session. Both events read here, by contrast, are fired
- *   client-side with sendBeacon and therefore only exist for real,
- *   JS-executing browsers. Counting them is the bot filter: every click and
- *   every impression is a human-with-JS by construction.
+ *   sub-1.0 pageviews/session. The bridge events are fired client-side with
+ *   sendBeacon, but JS-executing scanners can still reach the collector. This
+ *   report therefore excludes rows whose canonical `event_data.is_bot` stamp
+ *   is truthy. Legacy rows without a stamp remain eligible.
  *
- *   CTR = clicks / impressions is therefore a deterministic, bot-free
- *   engagement signal that can demote the bot-inflated raw `network_bridge`
- *   session count to a diagnostic.
+ *   CTR = eligible clicks / eligible impressions is therefore a deterministic,
+ *   bot-filtered engagement signal that can demote the bot-inflated raw
+ *   `network_bridge` session count to a diagnostic.
  *
  * PER-DESTINATION GRAIN: both events now carry `dest_site` in event_data — the
  * click beacon always did, and the impression beacon does as of
@@ -86,9 +86,10 @@ function extrachill_analytics_register_bridge_ctr_ability() {
  * through the canonical events query helper (it owns the safe, prepared WHERE
  * building and returns event_data already JSON-decoded) and aggregate in PHP.
  * Both events now carry `dest_site` in event_data, so the same pass produces
- * the network total AND the per-destination-site breakdown. Volume is bounded
- * (these events fire only for humans-with-JS), so a paged fetch + PHP rollup is
- * clearer than GROUP-BY-on-JSON SQL — and it matches get-outbound-clicks.
+ * the network total AND the per-destination-site breakdown. The same pass
+ * excludes canonically bot-stamped rows before either aggregation. A paged
+ * fetch + PHP rollup is clearer than GROUP-BY-on-JSON SQL — and it matches
+ * get-outbound-clicks.
  *
  * @param array $input Input parameters.
  * @return array CTR summary.
@@ -132,7 +133,11 @@ function extrachill_analytics_ability_get_bridge_ctr( $input ) {
 
 	foreach ( (array) $rows as $row ) {
 		// extrachill_get_analytics_events() returns event_data already decoded.
-		$data      = is_array( $row->event_data ) ? $row->event_data : array();
+		$data = is_array( $row->event_data ) ? $row->event_data : array();
+		if ( ! empty( $data['is_bot'] ) ) {
+			continue;
+		}
+
 		$dest_site = isset( $data['dest_site'] ) ? (string) $data['dest_site'] : '';
 		$is_click  = ( 'bridge_click' === $row->event_type );
 
@@ -190,6 +195,6 @@ function extrachill_analytics_ability_get_bridge_ctr( $input ) {
 		'period'       => $days > 0
 			? gmdate( 'Y-m-d', (int) strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
 			: 'all time',
-		'note'         => 'Both events fire client-side (sendBeacon) and are humans-with-JS by construction; this CTR is bot-filtered by design, unlike the raw GA4 network_bridge channel. Clicks and impressions now share the per-destination grain (one impression per rendered card carries dest_site as of extrachill-analytics#75), so by_dest_site pairs each destination\'s clicks to its own impressions. dest_site "(unknown)" rows are legacy page-level impressions emitted before the per-card change (or untagged cards); they shrink as new per-card data accumulates.',
+		'note'         => 'This CTR excludes rows whose canonical event_data.is_bot stamp is truthy; explicit false and legacy missing-stamp rows remain eligible. Client-side sendBeacon execution is not treated as proof of humanity because JS-executing scanners can reach the collector. Clicks and impressions share the per-destination grain (one impression per rendered card carries dest_site as of extrachill-analytics#75), so by_dest_site pairs each destination\'s clicks to its own impressions. dest_site "(unknown)" rows are legacy page-level impressions emitted before the per-card change (or untagged cards); they shrink as new per-card data accumulates.',
 	);
 }

--- a/tests/GetBridgeCtrTest.php
+++ b/tests/GetBridgeCtrTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Regression tests for the bridge CTR report (issue #201).
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-bridge-ctr.php';
+
+/**
+ * Verify bridge CTR aggregation honors the canonical bot stamp.
+ */
+final class GetBridgeCtrTest extends TestCase {
+
+	/**
+	 * Clear fixture state after each test.
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['extrachill_analytics_event_fixture_rows'] );
+	}
+
+	/**
+	 * Bot-stamped scanner rows must not reach totals or destination cuts.
+	 */
+	public function test_bot_stamped_rows_are_excluded_from_all_aggregation(): void {
+		$GLOBALS['extrachill_analytics_event_fixture_rows'] = array(
+			(object) array(
+				'event_type' => 'bridge_click',
+				'event_data' => array(
+					'dest_site' => 'select198766667891',
+					'is_bot'    => true,
+				),
+			),
+			(object) array(
+				'event_type' => 'bridge_impression',
+				'event_data' => array(
+					'dest_site' => 'etcpasswd',
+					'is_bot'    => true,
+				),
+			),
+		);
+
+		$report = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
+
+		$this->assertSame( 0, $report['clicks'] );
+		$this->assertSame( 0, $report['impressions'] );
+		$this->assertSame( array(), $report['by_dest_site'] );
+	}
+
+	/**
+	 * Explicit human and legacy missing-stamp rows must remain eligible.
+	 */
+	public function test_false_and_missing_bot_stamps_remain_eligible(): void {
+		$GLOBALS['extrachill_analytics_event_fixture_rows'] = array(
+			(object) array(
+				'event_type' => 'bridge_click',
+				'event_data' => array(
+					'dest_site' => 'events',
+					'is_bot'    => false,
+				),
+			),
+			(object) array(
+				'event_type' => 'bridge_impression',
+				'event_data' => array(
+					'dest_site' => 'events',
+				),
+			),
+		);
+
+		$report = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
+
+		$this->assertSame( 1, $report['clicks'] );
+		$this->assertSame( 1, $report['impressions'] );
+		$this->assertSame( 1.0, $report['ctr'] );
+		$this->assertSame(
+			array(
+				array(
+					'dest_site'   => 'events',
+					'clicks'      => 1,
+					'impressions' => 1,
+					'ctr'         => 1.0,
+				),
+			),
+			$report['by_dest_site']
+		);
+		$this->assertStringContainsString( 'legacy missing-stamp rows remain eligible', $report['note'] );
+	}
+}

--- a/tests/GetOutboundClicksTest.php
+++ b/tests/GetOutboundClicksTest.php
@@ -19,7 +19,7 @@ final class GetOutboundClicksTest extends TestCase {
 	 * Clear fixture state after each test.
 	 */
 	protected function tearDown(): void {
-		unset( $GLOBALS['extrachill_analytics_outbound_fixture_rows'] );
+		unset( $GLOBALS['extrachill_analytics_event_fixture_rows'] );
 	}
 
 	/**
@@ -27,7 +27,7 @@ final class GetOutboundClicksTest extends TestCase {
 	 * classifier. They must still produce destination rows.
 	 */
 	public function test_recorded_outbound_events_produce_destination_rows(): void {
-		$GLOBALS['extrachill_analytics_outbound_fixture_rows'] = array(
+		$GLOBALS['extrachill_analytics_event_fixture_rows'] = array(
 			(object) array(
 				'event_data' => array(
 					'dest_host' => 'open.spotify.com',
@@ -72,7 +72,7 @@ final class GetOutboundClicksTest extends TestCase {
 	 * empty capture window.
 	 */
 	public function test_missing_destination_dimension_returns_diagnostic(): void {
-		$GLOBALS['extrachill_analytics_outbound_fixture_rows'] = array(
+		$GLOBALS['extrachill_analytics_event_fixture_rows'] = array(
 			(object) array(
 				'event_data' => array(
 					'category' => 'other',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -222,7 +222,7 @@ if ( ! function_exists( 'extrachill_analytics_events_table' ) ) {
 }
 if ( ! function_exists( 'extrachill_get_analytics_events' ) ) {
 	/**
-	 * Return a paginated outbound-report fixture when configured by a test.
+	 * Return paginated analytics event fixtures when configured by a test.
 	 *
 	 * @param array $args Event query arguments.
 	 * @return array<object> Fixture event rows.
@@ -230,8 +230,8 @@ if ( ! function_exists( 'extrachill_get_analytics_events' ) ) {
 	function extrachill_get_analytics_events( $args = array() ) {
 		$offset = isset( $args['offset'] ) ? (int) $args['offset'] : 0;
 		$limit  = isset( $args['limit'] ) ? (int) $args['limit'] : 100;
-		$rows   = isset( $GLOBALS['extrachill_analytics_outbound_fixture_rows'] )
-			? $GLOBALS['extrachill_analytics_outbound_fixture_rows']
+		$rows   = isset( $GLOBALS['extrachill_analytics_event_fixture_rows'] )
+			? $GLOBALS['extrachill_analytics_event_fixture_rows']
 			: array();
 
 		return array_slice( $rows, $offset, $limit );


### PR DESCRIPTION
## Summary

- exclude truthy canonical `event_data.is_bot` bridge rows before both total and per-destination CTR aggregation
- preserve explicit `is_bot:false` and legacy missing-stamp rows
- replace the false sendBeacon-is-human documentation and add focused regression coverage

## Production Evidence

Production `extrachill/get-bridge-ctr` reported 191 clicks / 34,241 impressions over 28 days. Direct SQL inspection found all 191 click rows had `event_data.is_bot=true`, while 33,170 of the 34,238 SQL-inspected impression rows were bot-stamped. Bot destinations included SQL injection and path traversal payloads such as `etcpasswd`, `windowswinini`, `select198766667891`, `pg_sleep`, and `waitfor delay` probes.

This disproves the report's previous claim that client-side sendBeacon events are humans-with-JS by construction.

## Filtering Semantics

The existing canonical event query returns decoded `event_data`. The bridge rollup now skips a row when its canonical `is_bot` value is truthy, before incrementing either network totals or destination counters. Explicit false and absent stamps remain eligible, preserving legacy data in line with the repository's established `IS NOT TRUE` reader semantics.

No shared query abstraction was added because the canonical helper does not currently expose bot filtering and this behavioral change is scoped to bridge CTR.

## Sibling Audit

`extrachill/get-outbound-clicks` shares the false beacon assumption and deliberately ignores `is_bot`; its regression test currently requires bot-stamped rows to be counted. Changing that report without validating and correcting its write-side classification would risk dropping legitimate historical outbound events, so it remains out of this PR and is tracked in #202.

## Tests

- `vendor/bin/phpunit tests/GetBridgeCtrTest.php` (`2 tests`, `8 assertions`)
- `vendor/bin/phpunit tests/GetOutboundClicksTest.php` (`2 tests`, `8 assertions`)
- `composer test` (`335 tests`, `1240 assertions`)
- `vendor/bin/phpcs --standard=WordPress inc/core/abilities/get-bridge-ctr.php tests/bootstrap.php tests/GetOutboundClicksTest.php tests/GetBridgeCtrTest.php`
- `git diff --check`

Closes #201