### PR TITLE
fix: report independent bridge event counts

### DIFF
--- a/inc/core/abilities/get-bridge-ctr.php
+++ b/inc/core/abilities/get-bridge-ctr.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Get Bridge Exposure Report Ability
+ * Get Bridge Stored Event Ratio Ability
  *
- * Reports stored bridge clicks against observed viewport exposure evidence.
- * The ability name and legacy output aliases remain for existing consumers.
+ * Reports independently persisted bridge click and impression event counts.
+ * Current impressions are attempted at 50% viewport exposure, but historical
+ * rows include the former render-opportunity contract and carry no version.
  *
  * @package ExtraChill\Analytics
  * @since 0.9.0
@@ -18,8 +19,8 @@ function extrachill_analytics_register_bridge_ctr_ability() {
 	wp_register_ability(
 		'extrachill/get-bridge-ctr',
 		array(
-			'label'               => __( 'Get Bridge Exposure Report', 'extrachill-analytics' ),
-			'description'         => __( 'Returns bridge clicks and observed viewport exposures under the shipped best-effort delivery contract.', 'extrachill-analytics' ),
+			'label'               => __( 'Get Bridge Stored Event Ratio', 'extrachill-analytics' ),
+			'description'         => __( 'Returns independently stored, bot-filtered bridge click and impression event counts and their potentially unbounded ratio.', 'extrachill-analytics' ),
 			'category'            => 'extrachill-analytics',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -36,14 +37,14 @@ function extrachill_analytics_register_bridge_ctr_ability() {
 					),
 					'max_events' => array(
 						'type'        => 'integer',
-						'description' => __( 'Maximum stored bridge rows to aggregate.', 'extrachill-analytics' ),
+						'description' => __( 'Maximum stored bridge rows to inspect.', 'extrachill-analytics' ),
 						'default'     => 50000,
 					),
 				),
 			),
 			'output_schema'       => array(
 				'type'        => 'object',
-				'description' => __( 'Bridge clicks, viewport exposure evidence, bounded click-to-observed-exposure ratio, destination aggregates, and coverage diagnostics.', 'extrachill-analytics' ),
+				'description' => __( 'Stored bridge click and impression counts, their ratio, destination aggregates, and coverage diagnostics.', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_bridge_ctr',
 			'permission_callback' => function () {
@@ -62,93 +63,37 @@ function extrachill_analytics_register_bridge_ctr_ability() {
 }
 
 /**
- * Normalize nested event data before building an exact-row signature.
- *
- * @param mixed $value Value to normalize.
- * @return mixed Normalized value.
- */
-function extrachill_analytics_bridge_signature_value( $value ) {
-	if ( ! is_array( $value ) ) {
-		return $value;
-	}
-
-	foreach ( $value as $key => $item ) {
-		$value[ $key ] = extrachill_analytics_bridge_signature_value( $item );
-	}
-
-	if ( array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
-		ksort( $value );
-	}
-
-	return $value;
-}
-
-/**
- * Build the strongest retry-dedupe signature supported by canonical rows.
- *
- * Row IDs are deliberately excluded because an ambiguous retry creates a new
- * ID. No element or page-load identifier is stored, so this only collapses
- * otherwise exact rows; it cannot reconstruct exact client opportunities.
- *
- * @param object $row Canonical analytics event row.
- * @param array  $data Decoded event data.
- * @return string Row signature.
- */
-function extrachill_analytics_bridge_row_signature( $row, $data ) {
-	$signature = array(
-		'event_type' => isset( $row->event_type ) ? (string) $row->event_type : '',
-		'event_data' => extrachill_analytics_bridge_signature_value( $data ),
-		'source_url' => isset( $row->source_url ) ? (string) $row->source_url : '',
-		'blog_id'    => isset( $row->blog_id ) ? (int) $row->blog_id : 0,
-		'user_id'    => isset( $row->user_id ) ? (int) $row->user_id : 0,
-		'visitor_id' => isset( $row->visitor_id ) ? (string) $row->visitor_id : '',
-		'created_at' => isset( $row->created_at ) ? (string) $row->created_at : '',
-	);
-
-	return hash( 'sha256', wp_json_encode( $signature ) );
-}
-
-/**
- * Initialize one report aggregate bucket.
+ * Initialize one stored bridge-event count bucket.
  *
  * @return array<string,int>
  */
 function extrachill_analytics_bridge_bucket() {
 	return array(
-		'click_events'             => 0,
-		'viewport_exposure_events' => 0,
+		'clicks'      => 0,
+		'impressions' => 0,
 	);
 }
 
 /**
- * Finalize counts under the lossy exposure contract.
+ * Calculate the independently stored click/impression ratio.
  *
- * A stored click proves browser exposure even when its independently delivered
- * exposure event is missing. The maximum is therefore the smallest honest
- * observed-exposure denominator supported by the stored aggregate evidence.
+ * Independent best-effort writes can make clicks exceed impressions. A zero
+ * denominator retains the ability's legacy 0.0 result type.
  *
- * @param array $counts Aggregate event counts.
- * @return array<string,int|float|null>
+ * @param array $counts Stored event counts.
+ * @return float Stored click/impression ratio.
  */
-function extrachill_analytics_bridge_finalize_counts( $counts ) {
-	$clicks          = (int) $counts['click_events'];
-	$exposure_events = (int) $counts['viewport_exposure_events'];
-	$exposures       = max( $exposure_events, $clicks );
+function extrachill_analytics_bridge_stored_ratio( $counts ) {
+	$impressions = (int) $counts['impressions'];
 
-	return array(
-		'clicks'                           => $clicks,
-		'viewport_exposure_events'         => $exposure_events,
-		'click_proven_missing_exposures'   => max( 0, $clicks - $exposure_events ),
-		'observed_exposures'               => $exposures,
-		'click_to_observed_exposure_ratio' => $exposures > 0 ? round( $clicks / $exposures, 4 ) : null,
-	);
+	return $impressions > 0 ? round( (int) $counts['clicks'] / $impressions, 4 ) : 0.0;
 }
 
 /**
  * Execute callback for get-bridge-ctr ability.
  *
  * @param array $input Input parameters.
- * @return array Bridge exposure summary.
+ * @return array Stored bridge event summary.
  */
 function extrachill_analytics_ability_get_bridge_ctr( $input ) {
 	$days       = isset( $input['days'] ) ? max( 0, (int) $input['days'] ) : 28;
@@ -160,7 +105,6 @@ function extrachill_analytics_ability_get_bridge_ctr( $input ) {
 	$query_args = array(
 		'event_type' => array( 'bridge_click', 'bridge_impression' ),
 		'limit'      => $page_size,
-		'offset'     => 0,
 		'orderby'    => 'id',
 		'order'      => 'DESC',
 	);
@@ -173,21 +117,24 @@ function extrachill_analytics_ability_get_bridge_ctr( $input ) {
 		$query_args['blog_id'] = $blog_id;
 	}
 
-	$raw_counts   = extrachill_analytics_bridge_bucket();
 	$counts       = extrachill_analytics_bridge_bucket();
 	$by_dest      = array();
-	$seen         = array();
 	$loaded       = 0;
-	$duplicates   = 0;
+	$bot_rows     = 0;
 	$identified   = 0;
 	$anonymous    = 0;
 	$missing_dest = 0;
 	$truncated    = false;
+	$before_id    = 0;
 
 	while ( $loaded <= $max_events ) {
 		$query_args['limit'] = min( $page_size, $max_events + 1 - $loaded );
-		$page                = (array) extrachill_get_analytics_events( $query_args );
-		$page_count          = count( $page );
+		if ( $before_id > 0 ) {
+			$query_args['before_id'] = $before_id;
+		}
+
+		$page       = (array) extrachill_get_analytics_events( $query_args );
+		$page_count = count( $page );
 		if ( 0 === $page_count ) {
 			break;
 		}
@@ -199,17 +146,14 @@ function extrachill_analytics_ability_get_bridge_ctr( $input ) {
 				break 2;
 			}
 
-			$data     = isset( $row->event_data ) && is_array( $row->event_data ) ? $row->event_data : array();
-			$is_click = isset( $row->event_type ) && 'bridge_click' === $row->event_type;
-			$key      = $is_click ? 'click_events' : 'viewport_exposure_events';
-			++$raw_counts[ $key ];
-
-			$signature = extrachill_analytics_bridge_row_signature( $row, $data );
-			if ( isset( $seen[ $signature ] ) ) {
-				++$duplicates;
+			$data = isset( $row->event_data ) && is_array( $row->event_data ) ? $row->event_data : array();
+			if ( ! empty( $data['is_bot'] ) ) {
+				++$bot_rows;
 				continue;
 			}
-			$seen[ $signature ] = true;
+
+			$is_click = isset( $row->event_type ) && 'bridge_click' === $row->event_type;
+			$key      = $is_click ? 'clicks' : 'impressions';
 			++$counts[ $key ];
 
 			if ( isset( $row->visitor_id ) && '' !== (string) $row->visitor_id ) {
@@ -228,31 +172,30 @@ function extrachill_analytics_ability_get_bridge_ctr( $input ) {
 			++$by_dest[ $dest_site ][ $key ];
 		}
 
-		$query_args['offset'] += $page_count;
-		if ( $page_count < $query_args['limit'] ) {
+		$last_row  = $page[ $page_count - 1 ];
+		$before_id = isset( $last_row->id ) ? (int) $last_row->id : 0;
+		if ( $page_count < $query_args['limit'] || $before_id < 1 ) {
 			break;
 		}
 	}
 
-	$total        = extrachill_analytics_bridge_finalize_counts( $counts );
-	$deduplicated = $counts['click_events'] + $counts['viewport_exposure_events'];
-	$dest_rows    = array();
+	$by_dest_site = array();
 	foreach ( $by_dest as $dest => $dest_counts ) {
-		$row              = extrachill_analytics_bridge_finalize_counts( $dest_counts );
-		$row['dest_site'] = '' === $dest ? '(unknown)' : $dest;
-		if ( '' === $dest ) {
-			$row['click_to_observed_exposure_ratio'] = null;
-		}
-		$row['ctr']         = $row['click_to_observed_exposure_ratio'];
-		$row['impressions'] = $row['observed_exposures'];
-		$dest_rows[]        = $row;
+		$by_dest_site[] = array(
+			'dest_site'                => '' === $dest ? '(unknown)' : $dest,
+			'clicks'                   => (int) $dest_counts['clicks'],
+			'impressions'              => (int) $dest_counts['impressions'],
+			'ctr'                      => extrachill_analytics_bridge_stored_ratio( $dest_counts ),
+			'stored_event_ratio'       => extrachill_analytics_bridge_stored_ratio( $dest_counts ),
+			'measurement_grain_notice' => 'Aggregate stored event ratio only; no page-load or DOM-element identifier exists for exact opportunity or per-card CTR.',
+		);
 	}
 
 	usort(
-		$dest_rows,
+		$by_dest_site,
 		static function ( $a, $b ) {
-			if ( $a['observed_exposures'] !== $b['observed_exposures'] ) {
-				return $b['observed_exposures'] <=> $a['observed_exposures'];
+			if ( $a['impressions'] !== $b['impressions'] ) {
+				return $b['impressions'] <=> $a['impressions'];
 			}
 			if ( $a['clicks'] !== $b['clicks'] ) {
 				return $b['clicks'] <=> $a['clicks'];
@@ -261,63 +204,61 @@ function extrachill_analytics_ability_get_bridge_ctr( $input ) {
 		}
 	);
 
+	$eligible_rows      = $counts['clicks'] + $counts['impressions'];
 	$destination_status = 'not_observed';
-	if ( $deduplicated > 0 ) {
-		$destination_status = 0 === $missing_dest ? 'measured' : ( $missing_dest === $deduplicated ? 'not_instrumented' : 'partial' );
+	if ( $eligible_rows > 0 ) {
+		$destination_status = 0 === $missing_dest ? 'measured' : ( $missing_dest === $eligible_rows ? 'not_instrumented' : 'partial' );
 	}
 	$identity_status = 'not_observed';
-	if ( $deduplicated > 0 ) {
+	if ( $eligible_rows > 0 ) {
 		$identity_status = 0 === $anonymous ? 'complete' : ( 0 === $identified ? 'unavailable' : 'partial' );
 	}
+	$ratio = extrachill_analytics_bridge_stored_ratio( $counts );
 
-	$ratio = $total['click_to_observed_exposure_ratio'];
-
-	return array_merge(
-		$total,
-		array(
-			// Compatibility aliases retain the ability's existing shape while the
-			// explicit fields above define the corrected semantics.
-			'impressions'   => $total['observed_exposures'],
-			'ctr'           => $ratio,
-			'by_dest_site'  => $dest_rows,
-			'stored'        => array(
-				'click_rows'             => $raw_counts['click_events'],
-				'viewport_exposure_rows' => $raw_counts['viewport_exposure_events'],
+	return array(
+		'clicks'                        => (int) $counts['clicks'],
+		'impressions'                   => (int) $counts['impressions'],
+		'ctr'                           => $ratio,
+		'stored_click_events'           => (int) $counts['clicks'],
+		'stored_impression_events'      => (int) $counts['impressions'],
+		'stored_click_impression_ratio' => $ratio,
+		'by_dest_site'                  => $by_dest_site,
+		'coverage'                      => array(
+			'status'                     => 0 === $loaded ? 'not_observed' : ( $truncated ? 'truncated' : 'observed' ),
+			'measurement_contract'       => 0 === $loaded ? 'not_observed' : 'historically_mixed_unmarked',
+			'destination_status'         => $destination_status,
+			'rows_missing_dest_site'     => $missing_dest,
+			'identity_status'            => $identity_status,
+			'identified_rows'            => $identified,
+			'anonymous_rows'             => $anonymous,
+			'bot_rows_excluded'          => $bot_rows,
+			'eligible_rows'              => $eligible_rows,
+			'truncated'                  => $truncated,
+			'loaded_rows'                => min( $loaded, $max_events ),
+			'historical_contract_notice' => 'Stored bridge_impression rows carry no instrumentation version. Windows may mix legacy render-opportunity impressions with current 50%-viewport exposure attempts, so the eras cannot be separated exactly.',
+			'privacy_notice'             => 'GPC/DNT and visitors without a usable first-party cookie remain anonymous. Aggregate stored event counts remain eligible, but visitor-level attribution is unavailable for those rows.',
+			'bot_filter_notice'          => 'Rows with a truthy canonical event_data.is_bot stamp are excluded before totals and destination aggregation. Missing legacy stamps remain eligible.',
+		),
+		'compatibility'                 => array(
+			'ability' => 'extrachill/get-bridge-ctr',
+			'aliases' => array(
+				'clicks'      => 'stored_click_events',
+				'impressions' => 'stored_impression_events',
+				'ctr'         => 'stored_click_impression_ratio',
 			),
-			'dedupe'        => array(
-				'unit'                   => 'exact_canonical_row_fields_except_id',
-				'duplicate_rows_removed' => $duplicates,
-				'limitation'             => 'No page-load or DOM-element identifier is stored. Exact retries can be collapsed, but indistinguishable legitimate opportunities and non-identical ambiguous retries cannot be separated.',
-			),
-			'coverage'      => array(
-				'status'                     => 0 === $deduplicated ? 'not_observed' : ( $truncated ? 'truncated' : 'observed' ),
-				'measurement_contract'       => 0 === $deduplicated ? 'not_observed' : 'historically_mixed_unmarked',
-				'destination_status'         => $destination_status,
-				'rows_missing_dest_site'     => $missing_dest,
-				'identity_status'            => $identity_status,
-				'identified_rows'            => $identified,
-				'anonymous_rows'             => $anonymous,
-				'truncated'                  => $truncated,
-				'loaded_rows'                => min( $loaded, $max_events ),
-				'historical_contract_notice' => 'Stored rows do not carry an instrumentation version. Windows may mix legacy render-opportunity impressions with current 50%-viewport exposure attempts, so the two eras cannot be separated exactly.',
-				'privacy_notice'             => 'GPC/DNT and visitors without a usable first-party cookie remain anonymous. Aggregate exposure evidence is retained, but visitor-level dedupe or attribution is unavailable for those rows.',
-			),
-			'compatibility' => array(
-				'ability' => 'extrachill/get-bridge-ctr',
-				'aliases' => array(
-					'clicks'      => 'deduplicated stored click rows',
-					'impressions' => 'observed_exposures',
-					'ctr'         => 'click_to_observed_exposure_ratio',
-				),
-				'notice'  => 'The legacy ability and keys remain, but impressions and ctr now use the bounded observed-exposure denominator. Use the explicit viewport_exposure_events and click_to_observed_exposure_ratio fields in new consumers.',
-			),
-			'days'          => $days,
-			'blog_id'       => $blog_id,
-			'max_events'    => $max_events,
-			'period'        => $days > 0
-				? gmdate( 'Y-m-d', (int) strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
-				: 'all time',
-			'note'          => 'A bridge impression is currently attempted once when an eligible initial link reaches at least 50% viewport visibility; a first click attempts any missing exposure first. Exposure and click persist independently through best-effort beacon/fetch delivery, so stored rows may be missing or duplicated. observed_exposures is the lower-bound aggregate evidence max(viewport_exposure_events, clicks), which prevents impossible ratios without claiming exact per-card reconstruction. JavaScript execution filters non-JS crawlers and inert prefetches, but does not prove human identity or exclude JS-capable automation.',
-		)
+			'notice'  => 'Legacy keys retain their original independently stored count and ratio meanings and scalar types. New consumers should use the explicit stored_* fields.',
+		),
+		'pagination'                    => array(
+			'order'      => 'id DESC',
+			'cursor'     => 'id < before_id',
+			'max_events' => $max_events,
+		),
+		'days'                          => $days,
+		'blog_id'                       => $blog_id,
+		'max_events'                    => $max_events,
+		'period'                        => $days > 0
+			? gmdate( 'Y-m-d', (int) strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
+			: 'all time',
+		'note'                          => 'This is a ratio of independently stored, bot-filtered event rows, not an atomic opportunity conversion rate. Current bridge_impression events are attempted at 50% viewport exposure and first click attempts missing exposure before click, but each request is delivered independently and may be lost or duplicated. Ratios can exceed 100% under asymmetric loss or ambiguous retries. JavaScript execution filters non-JS crawlers and inert prefetches but does not prove human identity; truthy canonical is_bot stamps are excluded.',
 	);
 }

--- a/inc/core/events.php
+++ b/inc/core/events.php
@@ -126,6 +126,7 @@ function extrachill_track_analytics_event( $event_type, $event_data = array(), $
  *                    - date_from (string): Start date (Y-m-d format).
  *                    - date_to (string): End date (Y-m-d format).
  *                    - search (string): Search within event_data JSON.
+ *                    - before_id (int): Return rows with IDs below this cursor.
  *                    - limit (int): Number of results (default 100).
  *                    - offset (int): Offset for pagination.
  *                    - orderby (string): Column to order by (default 'created_at').
@@ -142,6 +143,7 @@ function extrachill_get_analytics_events( $args = array() ) {
 		'date_from'  => '',
 		'date_to'    => '',
 		'search'     => '',
+		'before_id'  => 0,
 		'limit'      => 100,
 		'offset'     => 0,
 		'orderby'    => 'created_at',
@@ -189,6 +191,11 @@ function extrachill_get_analytics_events( $args = array() ) {
 		$values[] = '%' . $wpdb->esc_like( sanitize_text_field( $args['search'] ) ) . '%';
 	}
 
+	if ( ! empty( $args['before_id'] ) ) {
+		$where[]  = 'id < %d';
+		$values[] = absint( $args['before_id'] );
+	}
+
 	$where_clause = implode( ' AND ', $where );
 
 	$allowed_orderby = array( 'id', 'event_type', 'blog_id', 'user_id', 'created_at' );
@@ -203,15 +210,20 @@ function extrachill_get_analytics_events( $args = array() ) {
 	// whitelisted through in_array() and $order is hard-coded ASC/DESC. No
 	// request input reaches the query unprepared.
 	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-	$sql = "SELECT * FROM {$table_name} WHERE {$where_clause} ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
-
-	$values[] = $limit;
-	$values[] = $offset;
-
-	if ( count( $values ) > 2 ) {
-		$query = $wpdb->prepare( $sql, $values );
+	if ( ! empty( $args['before_id'] ) ) {
+		$sql      = "SELECT * FROM {$table_name} WHERE {$where_clause} ORDER BY {$orderby} {$order} LIMIT %d";
+		$values[] = $limit;
+		$query    = $wpdb->prepare( $sql, $values );
 	} else {
-		$query = $wpdb->prepare( $sql, $limit, $offset );
+		$sql      = "SELECT * FROM {$table_name} WHERE {$where_clause} ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
+		$values[] = $limit;
+		$values[] = $offset;
+
+		if ( count( $values ) > 2 ) {
+			$query = $wpdb->prepare( $sql, $values );
+		} else {
+			$query = $wpdb->prepare( $sql, $limit, $offset );
+		}
 	}
 
 	$results = $wpdb->get_results( $query );

--- a/tests/GetBridgeCtrTest.php
+++ b/tests/GetBridgeCtrTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Behavioral tests for the bridge exposure report (issue #191).
+ * Behavioral tests for the bridge stored-event report (issues #191 and #201).
  *
  * @package ExtraChill\Analytics
  */
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-bridge-ctr.php';
 
 /**
- * Verify bridge reporting follows the shipped lossy exposure contract.
+ * Verify bridge reporting follows the shipped lossy storage contract.
  */
 final class GetBridgeCtrTest extends TestCase {
 
@@ -18,42 +18,49 @@ final class GetBridgeCtrTest extends TestCase {
 	 * Clear fixture state after each test.
 	 */
 	protected function tearDown(): void {
-		unset( $GLOBALS['extrachill_analytics_bridge_fixture_rows'] );
+		unset(
+			$GLOBALS['extrachill_analytics_bridge_fixture_rows'],
+			$GLOBALS['extrachill_analytics_bridge_query_args']
+		);
 	}
 
 	/**
 	 * Build one canonical event fixture.
 	 *
-	 * @param int    $id           Row ID.
-	 * @param string $type         Event type.
-	 * @param string $dest         Destination site.
-	 * @param string $created_at   Stored UTC time.
-	 * @param string $visitor_id   Optional visitor ID.
-	 * @param string $source_url   Source path.
+	 * @param int       $id         Row ID.
+	 * @param string    $type       Event type.
+	 * @param string    $dest       Destination site.
+	 * @param bool|null $is_bot     Optional canonical bot stamp.
+	 * @param string    $visitor_id Optional visitor ID.
 	 * @return object
 	 */
-	private function event( $id, $type, $dest = 'events', $created_at = '2026-07-18 01:00:00', $visitor_id = '00000000-0000-4000-8000-000000000001', $source_url = '/story/' ) {
+	private function event( $id, $type, $dest = 'events', $is_bot = null, $visitor_id = '00000000-0000-4000-8000-000000000001' ) {
+		$data = array(
+			'dest_site'   => $dest,
+			'source_post' => 42,
+			'source_site' => 'main',
+			'term'        => 'Upcoming Events',
+		);
+		if ( null !== $is_bot ) {
+			$data['is_bot'] = $is_bot;
+		}
+
 		return (object) array(
 			'id'         => $id,
 			'event_type' => $type,
-			'event_data' => array(
-				'dest_site'   => $dest,
-				'source_post' => 42,
-				'source_site' => 'main',
-				'term'        => 'Upcoming Events',
-			),
-			'source_url' => $source_url,
+			'event_data' => $data,
+			'source_url' => '/story/',
 			'blog_id'    => 1,
 			'user_id'    => null,
 			'visitor_id' => $visitor_id,
-			'created_at' => $created_at,
+			'created_at' => '2026-07-18 01:00:00',
 		);
 	}
 
 	/**
-	 * Exact ambiguous-retry rows are removed without using their unique IDs.
+	 * Duplicate-looking rows remain independent without an opportunity ID.
 	 */
-	public function test_duplicate_lossy_impressions_are_deduplicated(): void {
+	public function test_duplicate_lossy_impressions_are_not_deduplicated(): void {
 		$GLOBALS['extrachill_analytics_bridge_fixture_rows'] = array(
 			$this->event( 1, 'bridge_impression' ),
 			$this->event( 2, 'bridge_impression' ),
@@ -62,111 +69,183 @@ final class GetBridgeCtrTest extends TestCase {
 
 		$report = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
 
-		$this->assertSame( 2, $report['stored']['viewport_exposure_rows'] );
-		$this->assertSame( 1, $report['viewport_exposure_events'] );
-		$this->assertSame( 1, $report['dedupe']['duplicate_rows_removed'] );
-		$this->assertSame( 1.0, $report['click_to_observed_exposure_ratio'] );
+		$this->assertSame( 2, $report['stored_impression_events'] );
+		$this->assertSame( 1, $report['stored_click_events'] );
+		$this->assertSame( 0.5, $report['stored_click_impression_ratio'] );
+		$this->assertArrayNotHasKey( 'dedupe', $report );
 	}
 
 	/**
-	 * Independently delivered clicks provide lower-bound exposure evidence.
+	 * Independent writes may produce an honest ratio over 100 percent.
 	 */
-	public function test_clicks_exceeding_stored_exposure_remain_bounded(): void {
+	public function test_clicks_exceeding_impressions_are_not_clamped(): void {
 		$GLOBALS['extrachill_analytics_bridge_fixture_rows'] = array(
 			$this->event( 1, 'bridge_impression' ),
-			$this->event( 2, 'bridge_click', 'events', '2026-07-18 01:00:01' ),
-			$this->event( 3, 'bridge_click', 'events', '2026-07-18 01:00:02' ),
+			$this->event( 2, 'bridge_click' ),
+			$this->event( 3, 'bridge_click' ),
 		);
 
 		$report = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
 
-		$this->assertSame( 1, $report['viewport_exposure_events'] );
 		$this->assertSame( 2, $report['clicks'] );
-		$this->assertSame( 1, $report['click_proven_missing_exposures'] );
-		$this->assertSame( 2, $report['observed_exposures'] );
-		$this->assertSame( 2, $report['impressions'] );
-		$this->assertSame( 1.0, $report['ctr'] );
+		$this->assertSame( 1, $report['impressions'] );
+		$this->assertSame( 2.0, $report['ctr'] );
+		$this->assertStringContainsString( 'exceed 100%', $report['note'] );
 	}
 
 	/**
-	 * Legacy destination-less rows stay visible but receive no invented ratio.
+	 * Truthy bot stamps are excluded before totals and destinations.
+	 */
+	public function test_bot_stamped_rows_are_excluded_and_unstamped_rows_remain(): void {
+		$bot_click                     = $this->event( 4, 'bridge_click', 'etcpasswd', true, '' );
+		$bot_click->event_data['term'] = 'scanner payload';
+		$GLOBALS['extrachill_analytics_bridge_fixture_rows'] = array(
+			$bot_click,
+			$this->event( 3, 'bridge_impression', 'events', 1, '' ),
+			$this->event( 2, 'bridge_impression', 'events', false ),
+			$this->event( 1, 'bridge_click', 'events' ),
+		);
+
+		$report = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
+
+		$this->assertSame( 1, $report['clicks'] );
+		$this->assertSame( 1, $report['impressions'] );
+		$this->assertSame( 2, $report['coverage']['bot_rows_excluded'] );
+		$this->assertSame( 'events', $report['by_dest_site'][0]['dest_site'] );
+		$this->assertCount( 1, $report['by_dest_site'] );
+	}
+
+	/**
+	 * Legacy destination-less rows remain visible with mixed coverage.
 	 */
 	public function test_legacy_mixed_rows_have_partial_destination_coverage(): void {
 		$GLOBALS['extrachill_analytics_bridge_fixture_rows'] = array(
-			$this->event( 1, 'bridge_impression', '' ),
-			$this->event( 2, 'bridge_click', '', '2026-07-18 01:00:01' ),
-			$this->event( 3, 'bridge_impression', 'events', '2026-07-18 01:00:02' ),
+			$this->event( 3, 'bridge_impression', '' ),
+			$this->event( 2, 'bridge_click', '' ),
+			$this->event( 1, 'bridge_impression', 'events' ),
 		);
 
-		$report  = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
-		$unknown = array_values(
-			array_filter(
-				$report['by_dest_site'],
-				static function ( $row ) {
-					return '(unknown)' === $row['dest_site'];
-				}
-			)
-		)[0];
+		$report = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
 
 		$this->assertSame( 'historically_mixed_unmarked', $report['coverage']['measurement_contract'] );
 		$this->assertSame( 'partial', $report['coverage']['destination_status'] );
 		$this->assertSame( 2, $report['coverage']['rows_missing_dest_site'] );
-		$this->assertNull( $unknown['click_to_observed_exposure_ratio'] );
 		$this->assertStringContainsString( 'render-opportunity', $report['coverage']['historical_contract_notice'] );
+		$this->assertStringContainsString( 'no page-load or DOM-element identifier', $report['by_dest_site'][0]['measurement_grain_notice'] );
 	}
 
 	/**
-	 * A missing denominator is unknown rather than a fabricated zero ratio.
+	 * Legacy zero-denominator keys retain numeric scalar types.
 	 */
-	public function test_zero_exposure_has_null_ratio(): void {
-		$GLOBALS['extrachill_analytics_bridge_fixture_rows'] = array();
-
-		$report = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
-
-		$this->assertSame( 0, $report['observed_exposures'] );
-		$this->assertNull( $report['click_to_observed_exposure_ratio'] );
-		$this->assertNull( $report['ctr'] );
-		$this->assertSame( 'not_observed', $report['coverage']['status'] );
-	}
-
-	/**
-	 * Destination aggregates use only each destination's observed evidence.
-	 */
-	public function test_multiple_destinations_are_aggregated_independently(): void {
+	public function test_zero_impressions_preserve_legacy_types(): void {
 		$GLOBALS['extrachill_analytics_bridge_fixture_rows'] = array(
-			$this->event( 1, 'bridge_impression', 'events' ),
-			$this->event( 2, 'bridge_click', 'events', '2026-07-18 01:00:01' ),
-			$this->event( 3, 'bridge_click', 'artist', '2026-07-18 01:00:02', '00000000-0000-4000-8000-000000000002', '/other/' ),
+			$this->event( 1, 'bridge_click' ),
 		);
 
 		$report = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
 
-		$this->assertSame( 'artist', $report['by_dest_site'][0]['dest_site'] );
-		$this->assertSame( 1, $report['by_dest_site'][0]['click_proven_missing_exposures'] );
-		$this->assertSame( 'events', $report['by_dest_site'][1]['dest_site'] );
-		$this->assertSame( 1.0, $report['by_dest_site'][1]['click_to_observed_exposure_ratio'] );
-		$this->assertSame( 'measured', $report['coverage']['destination_status'] );
+		$this->assertSame( 1, $report['clicks'] );
+		$this->assertSame( 0, $report['impressions'] );
+		$this->assertSame( 0.0, $report['ctr'] );
+		$this->assertIsInt( $report['clicks'] );
+		$this->assertIsInt( $report['impressions'] );
+		$this->assertIsFloat( $report['ctr'] );
 	}
 
 	/**
-	 * Coverage reports anonymity and the bounded query status explicitly.
+	 * Multiple destinations retain independent stored ratios.
 	 */
-	public function test_coverage_status_discloses_anonymous_and_truncated_rows(): void {
+	public function test_multiple_destinations_are_aggregated_independently(): void {
 		$GLOBALS['extrachill_analytics_bridge_fixture_rows'] = array(
-			$this->event( 1, 'bridge_impression', 'events', '2026-07-18 01:00:00', '' ),
-			$this->event( 2, 'bridge_click', 'events', '2026-07-18 01:00:01' ),
+			$this->event( 4, 'bridge_click', 'artist' ),
+			$this->event( 3, 'bridge_click', 'events' ),
+			$this->event( 2, 'bridge_impression', 'events' ),
+			$this->event( 1, 'bridge_impression', 'events' ),
+		);
+
+		$report = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
+
+		$this->assertSame( 'events', $report['by_dest_site'][0]['dest_site'] );
+		$this->assertSame( 0.5, $report['by_dest_site'][0]['stored_event_ratio'] );
+		$this->assertSame( 'artist', $report['by_dest_site'][1]['dest_site'] );
+		$this->assertSame( 0.0, $report['by_dest_site'][1]['stored_event_ratio'] );
+	}
+
+	/**
+	 * The newest IDs are selected in true descending order before truncation.
+	 */
+	public function test_descending_id_order_and_truncation_are_stable(): void {
+		$GLOBALS['extrachill_analytics_bridge_fixture_rows'] = array(
+			$this->event( 1, 'bridge_click', 'oldest' ),
+			$this->event( 3, 'bridge_impression', 'newest' ),
+			$this->event( 2, 'bridge_click', 'middle' ),
 		);
 
 		$report = extrachill_analytics_ability_get_bridge_ctr(
 			array(
 				'days'       => 0,
-				'max_events' => 1,
+				'max_events' => 2,
 			)
 		);
 
+		$this->assertSame( 1, $report['clicks'] );
+		$this->assertSame( 1, $report['impressions'] );
 		$this->assertSame( 'truncated', $report['coverage']['status'] );
+		$this->assertSame( array( 'newest', 'middle' ), array_column( $report['by_dest_site'], 'dest_site' ) );
+		$this->assertSame( 'id DESC', $report['pagination']['order'] );
+		$this->assertArrayNotHasKey( 'offset', $GLOBALS['extrachill_analytics_bridge_query_args'][0] );
+	}
+
+	/**
+	 * Multi-page reads advance with an exclusive ID cursor, never an offset.
+	 */
+	public function test_keyset_pagination_uses_last_descending_id(): void {
+		$rows = array();
+		for ( $id = 1; $id <= 1002; ++$id ) {
+			$rows[] = $this->event( $id, 'bridge_impression' );
+		}
+		$GLOBALS['extrachill_analytics_bridge_fixture_rows'] = array_reverse( $rows );
+
+		$report = extrachill_analytics_ability_get_bridge_ctr(
+			array(
+				'days'       => 0,
+				'max_events' => 1001,
+			)
+		);
+
+		$this->assertSame( 1001, $report['impressions'] );
 		$this->assertTrue( $report['coverage']['truncated'] );
-		$this->assertSame( 'unavailable', $report['coverage']['identity_status'] );
+		$this->assertCount( 2, $GLOBALS['extrachill_analytics_bridge_query_args'] );
+		$this->assertArrayNotHasKey( 'before_id', $GLOBALS['extrachill_analytics_bridge_query_args'][0] );
+		$this->assertSame( 3, $GLOBALS['extrachill_analytics_bridge_query_args'][1]['before_id'] );
+		$this->assertArrayNotHasKey( 'offset', $GLOBALS['extrachill_analytics_bridge_query_args'][1] );
+	}
+
+	/**
+	 * The canonical query helper binds the exclusive cursor without SQL offset.
+	 */
+	public function test_canonical_query_helper_supports_keyset_cursor(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local production source.
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/events.php' );
+
+		$this->assertNotFalse( $source );
+		$this->assertStringContainsString( "'before_id'  => 0", $source );
+		$this->assertStringContainsString( "\$where[]  = 'id < %d';", $source );
+		$this->assertStringContainsString( 'ORDER BY {$orderby} {$order} LIMIT %d";', $source );
+	}
+
+	/**
+	 * Coverage discloses anonymous eligible rows and privacy limitations.
+	 */
+	public function test_coverage_status_discloses_anonymous_rows(): void {
+		$GLOBALS['extrachill_analytics_bridge_fixture_rows'] = array(
+			$this->event( 1, 'bridge_impression', 'events', null, '' ),
+			$this->event( 2, 'bridge_click' ),
+		);
+
+		$report = extrachill_analytics_ability_get_bridge_ctr( array( 'days' => 0 ) );
+
+		$this->assertSame( 'partial', $report['coverage']['identity_status'] );
 		$this->assertSame( 1, $report['coverage']['anonymous_rows'] );
 		$this->assertStringContainsString( 'GPC/DNT', $report['coverage']['privacy_notice'] );
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -228,15 +228,36 @@ if ( ! function_exists( 'extrachill_get_analytics_events' ) ) {
 	 * @return array<object> Fixture event rows.
 	 */
 	function extrachill_get_analytics_events( $args = array() ) {
+		if ( isset( $GLOBALS['extrachill_analytics_bridge_fixture_rows'] ) ) {
+			$GLOBALS['extrachill_analytics_bridge_query_args'][] = $args;
+			$rows = $GLOBALS['extrachill_analytics_bridge_fixture_rows'];
+			if ( ! empty( $args['before_id'] ) ) {
+				$rows = array_values(
+					array_filter(
+						$rows,
+						static function ( $row ) use ( $args ) {
+							return (int) $row->id < (int) $args['before_id'];
+						}
+					)
+				);
+			}
+			if ( isset( $args['orderby'], $args['order'] ) && 'id' === $args['orderby'] && 'DESC' === $args['order'] ) {
+				usort(
+					$rows,
+					static function ( $a, $b ) {
+						return (int) $b->id <=> (int) $a->id;
+					}
+				);
+			}
+
+			return array_slice( $rows, 0, isset( $args['limit'] ) ? (int) $args['limit'] : 100 );
+		}
+
 		$offset = isset( $args['offset'] ) ? (int) $args['offset'] : 0;
 		$limit  = isset( $args['limit'] ) ? (int) $args['limit'] : 100;
-		if ( isset( $GLOBALS['extrachill_analytics_bridge_fixture_rows'] ) ) {
-			$rows = $GLOBALS['extrachill_analytics_bridge_fixture_rows'];
-		} else {
-			$rows = isset( $GLOBALS['extrachill_analytics_outbound_fixture_rows'] )
-				? $GLOBALS['extrachill_analytics_outbound_fixture_rows']
-				: array();
-		}
+		$rows   = isset( $GLOBALS['extrachill_analytics_outbound_fixture_rows'] )
+			? $GLOBALS['extrachill_analytics_outbound_fixture_rows']
+			: array();
 
 		return array_slice( $rows, $offset, $limit );
 	}


### PR DESCRIPTION
## Summary
- Resolve the blocking review left on #199 by reporting independent stored click/impression counts without synthetic exposure reconstruction or unsupported retry dedupe.
- Exclude truthy canonical `event_data.is_bot` rows before totals and destinations, covering #201.
- Use mixed-contract-safe naming and bounded stable `id DESC` keyset pagination with true truncation evidence.

## Context
PR #199 was merged concurrently at its original `4ab650c` head while this requested blocker fix was being pushed. This follow-up contains only commit `51bb2a2`, the review resolution that did not enter that merge. No merge, release, deployment, or production mutation was performed by the agent.

## Stored-event semantics
`bridge_click` and `bridge_impression` remain independent best-effort writes. The report counts every eligible persisted row and computes `stored_click_impression_ratio = stored_click_events / stored_impression_events`. It does not pair rows, infer missing exposures, clamp the ratio, or collapse same-second/otherwise-identical rows.

Ratios can exceed 100% under asymmetric loss or ambiguous retry duplication. Canonical rows carry no atomic opportunity ID, idempotency key, page-load ID, or DOM-element ID, so destination output is labeled as an aggregate stored-event ratio rather than exact opportunity or per-card CTR.

## Bot filtering
Truthy canonical `event_data.is_bot` rows are excluded before total and destination aggregation. Missing legacy stamps and explicit falsey stamps remain eligible. Coverage exposes `bot_rows_excluded`, and report language no longer treats JavaScript execution as proof of humanity.

The sibling outbound report was audited but intentionally not changed. Its existing contract and regression coverage currently retain browser beacon rows stamped by the generic REST classifier, so a shared filter would change separate shipped behavior.

## Compatibility and coverage
- Adds `stored_click_events`, `stored_impression_events`, and `stored_click_impression_ratio`.
- Keeps `clicks`, `impressions`, and `ctr` as integer/integer/float aliases with their original stored-count meanings.
- Keeps the legacy zero-denominator `ctr` value `0.0`.
- Marks impression history `historically_mixed_unmarked` because rows cannot distinguish legacy render opportunity from current 50%-viewport exposure attempts.
- Discloses destination, identity, GPC/DNT, bot, loaded-row, and truncation coverage.

## Query bounds
The report inspects at most `max_events` rows, default 50,000 and capped at 100,000, plus one row to prove truncation. It reads stable `id DESC` pages and advances with exclusive `id < before_id`; keyset pages do not use SQL offset.

## Verification
- `vendor/bin/phpunit tests/GetBridgeCtrTest.php` (10 tests, 47 assertions)
- `vendor/bin/phpunit` (344 tests, 1282 assertions)
- Syntax checks for all four changed PHP files
- Changed-file WordPress PHPCS (0 errors; existing direct-database-call warnings only)
- `git diff --check`

Closes #201