### PR TITLE
feat: report geographic bridge experiment

### DIFF
--- a/docs/geo-bridge-experiment.md
+++ b/docs/geo-bridge-experiment.md
@@ -8,8 +8,11 @@ is a private, read-only ability and is not a general experimentation API.
 
 - `experiment_assignment` enters an identified person into a variant denominator.
 - `experiment_exposure` records actual server-validated 50% viewport exposure.
-- `bridge_click` remains an independently lossy stored event. Click events are
-  neither deduplicated nor clamped, while unique clickers are reported separately.
+- `bridge_click` remains an independently lossy stored event. Its contract does
+  not identify the rendered card or taxonomy, so it is reported only as broad
+  `any_bridge_click_after_assignment` and `any_bridge_click_after_exposure`
+  intent-to-treat network engagement. Click events are neither deduplicated nor
+  clamped, while unique clickers are reported separately.
 - `pageview` supplies the first identified cross-blog route transition after each
   assignment and exposure anchor.
 - `newsletter_signup`, `user_registration`, `onboarding_completed`, and
@@ -24,14 +27,16 @@ pageviews never synthesize either event.
 
 Rows are ordered by `created_at ASC, id ASC`. The first valid assignment fixes a
 person's variant; duplicate and conflicting rows are diagnostics. Exposure must
-strictly follow a matching assignment. Bridge clicks, route transitions, and
-outcomes must strictly follow the applicable anchor, so pre-assignment outcomes
-never attribute.
+strictly follow a matching assignment. Any-bridge clicks, route transitions,
+and outcomes must strictly follow the applicable anchor, so pre-assignment
+outcomes never attribute. A later artist or festival card click remains in the
+broad any-bridge outcome and is never presented as a geographic-card click.
 
-Identity resolves from payload `user_id`, stored `user_id`, then `visitor_id`.
-A visitor stitches to a user only when the bounded window observes exactly one
-user for that visitor. Ambiguous visitors remain separate. Lifecycle outcomes
-deduplicate once per person, event type, and assignment/exposure lens.
+Bot-stamped rows are removed before identity observation. Remaining identity
+resolves from payload `user_id`, stored `user_id`, then `visitor_id`. A visitor
+stitches to a user only when the bounded window observes exactly one user for
+that visitor. Ambiguous visitors remain separate. Lifecycle outcomes deduplicate
+once per person, event type, and assignment/exposure lens.
 
 Same-session attribution extends while identified pageviews remain within the
 configured inactivity gap. The first later cross-blog pageview is classified as
@@ -51,3 +56,7 @@ rows, bot-stamped rows, ambiguous visitor mappings, rejected contract rows, and
 unattributed exposures remain explicit diagnostics. GPC/DNT requests emit no
 measured assignment or exposure and may omit visitor identity, so their excluded
 population is intentionally not inferable from stored rows.
+
+`card_specific_click_instrumented` is always `false`. The current event contract
+cannot isolate the geographic treatment card, and the report states that gap
+next to every broad any-bridge click count.

--- a/docs/geo-bridge-experiment.md
+++ b/docs/geo-bridge-experiment.md
@@ -10,9 +10,10 @@ is a private, read-only ability and is not a general experimentation API.
 - `experiment_exposure` records actual server-validated 50% viewport exposure.
 - `bridge_click` remains an independently lossy stored event. Its contract does
   not identify the rendered card or taxonomy, so it is reported only as broad
-  `any_bridge_click_after_assignment` and `any_bridge_click_after_exposure`
-  intent-to-treat network engagement. Click events are neither deduplicated nor
-  clamped, while unique clickers are reported separately.
+  `any_bridge_click_after_assignment` as intent-to-treat network engagement.
+  `any_bridge_click_after_exposure` is descriptive and exposure-conditioned,
+  not intent-to-treat. Click events are neither deduplicated nor clamped, while
+  unique clickers are reported separately.
 - `pageview` supplies the first identified cross-blog route transition after each
   assignment and exposure anchor.
 - `newsletter_signup`, `user_registration`, `onboarding_completed`, and

--- a/docs/geo-bridge-experiment.md
+++ b/docs/geo-bridge-experiment.md
@@ -1,0 +1,53 @@
+# Geographic Bridge Holdout Report
+
+`extrachill/get-geo-bridge-experiment` reports only `geo-bridge-holdout` on
+`single-post-bridge`, with the declared `control` and `treatment` variants. It
+is a private, read-only ability and is not a general experimentation API.
+
+## Event Contract
+
+- `experiment_assignment` enters an identified person into a variant denominator.
+- `experiment_exposure` records actual server-validated 50% viewport exposure.
+- `bridge_click` remains an independently lossy stored event. Click events are
+  neither deduplicated nor clamped, while unique clickers are reported separately.
+- `pageview` supplies the first identified cross-blog route transition after each
+  assignment and exposure anchor.
+- `newsletter_signup`, `user_registration`, `onboarding_completed`, and
+  `artist_profile_first_publish` are the only authoritative lifecycle outcomes.
+  Automatic registration newsletter subscriptions remain excluded.
+
+Every experiment row must carry exactly the canonical experiment key, surface,
+and one declared variant. Assignment never implies exposure, and clicks or
+pageviews never synthesize either event.
+
+## Attribution
+
+Rows are ordered by `created_at ASC, id ASC`. The first valid assignment fixes a
+person's variant; duplicate and conflicting rows are diagnostics. Exposure must
+strictly follow a matching assignment. Bridge clicks, route transitions, and
+outcomes must strictly follow the applicable anchor, so pre-assignment outcomes
+never attribute.
+
+Identity resolves from payload `user_id`, stored `user_id`, then `visitor_id`.
+A visitor stitches to a user only when the bounded window observes exactly one
+user for that visitor. Ambiguous visitors remain separate. Lifecycle outcomes
+deduplicate once per person, event type, and assignment/exposure lens.
+
+Same-session attribution extends while identified pageviews remain within the
+configured inactivity gap. The first later cross-blog pageview is classified as
+a later-session transition. The report does not claim adjacency to an
+unobserved browser action.
+
+## Bounds And Coverage
+
+The reader scans one explicit UTC window with stable `(created_at, id)` keyset
+pagination, 500 rows per page, and a configurable hard `max_events` ceiling.
+One extra row is used only as a truncation sentinel. Truncated output retains
+observed counts and labels them truncated.
+
+Each signal has independent instrumentation coverage. Missing event types and a
+missing assignment cohort produce `null` rather than measured zero. Unidentified
+rows, bot-stamped rows, ambiguous visitor mappings, rejected contract rows, and
+unattributed exposures remain explicit diagnostics. GPC/DNT requests emit no
+measured assignment or exposure and may omit visitor identity, so their excluded
+population is intentionally not inferable from stored rows.

--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -68,6 +68,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-g
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-demand-drill.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-conversion-map.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-route-transitions.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-geo-bridge-experiment.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-crosslink-targets.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/revenue-ad-policy.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-stickiness.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -30,6 +30,7 @@ add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_surface_grow
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_demand_drill_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_conversion_map_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_route_transitions_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_geo_bridge_experiment_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_crosslink_targets_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_surface_stickiness_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_activation_funnel_ability' );

--- a/inc/core/abilities/get-geo-bridge-experiment.php
+++ b/inc/core/abilities/get-geo-bridge-experiment.php
@@ -385,23 +385,25 @@ function extrachill_analytics_geo_bridge_variant_row( $variant, $bucket, $covera
 		'exposure'           => array(
 			'people'          => $exposure_ready ? $exposed : null,
 			'stored_events'   => $exposure_ready ? (int) $bucket['exposure_events'] : null,
-			'rate'            => $exposure_ready && $assigned > 0 ? round( $exposed / $assigned, 4 ) : ( $exposure_ready ? 0.0 : null ),
+			'rate'            => $exposure_ready && $assigned > 0 ? round( $exposed / $assigned, 4 ) : null,
 			'coverage_status' => $exposure_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
 		),
 		'network_engagement' => array(
 			'any_bridge_click_after_assignment' => array(
 				'events'                => $click_ready ? (int) $bucket['bridge_click_events_assignment'] : null,
 				'people'                => $click_ready ? count( $bucket['bridge_clickers_assignment'] ) : null,
-				'events_per_assignment' => $click_ready && $assigned > 0 ? round( $bucket['bridge_click_events_assignment'] / $assigned, 4 ) : ( $click_ready ? 0.0 : null ),
+				'events_per_assignment' => $click_ready && $assigned > 0 ? round( $bucket['bridge_click_events_assignment'] / $assigned, 4 ) : null,
+				'analysis_lens'         => 'intent_to_treat',
 			),
 			'any_bridge_click_after_exposure'   => array(
 				'events'              => $click_ready && $exposure_ready ? (int) $bucket['bridge_click_events_exposure'] : null,
 				'people'              => $click_ready && $exposure_ready ? count( $bucket['bridge_clickers_exposure'] ) : null,
-				'events_per_exposure' => $click_ready && $exposure_ready && $exposed > 0 ? round( $bucket['bridge_click_events_exposure'] / $exposed, 4 ) : ( $click_ready && $exposure_ready ? 0.0 : null ),
+				'events_per_exposure' => $click_ready && $exposure_ready && $exposed > 0 ? round( $bucket['bridge_click_events_exposure'] / $exposed, 4 ) : null,
+				'analysis_lens'       => 'descriptive_exposure_conditioned',
 			),
 			'card_specific_click_instrumented'  => false,
 			'coverage_status'                   => $click_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
-			'caveat'                            => 'The bridge_click contract identifies no rendered card or taxonomy. These are intent-to-treat counts of any bridge card clicked after the anchor, including unrelated artist or festival cards; they are not geographic-card click attribution.',
+			'caveat'                            => 'The assignment lens is intent-to-treat. The exposure lens is descriptive and exposure-conditioned, so it may be selection-biased. The bridge_click contract identifies no rendered card or taxonomy; both include unrelated artist or festival cards and are not geographic-card click attribution.',
 		),
 		'route_transitions'  => array(
 			'after_assignment' => $route_ready ? extrachill_analytics_geo_bridge_transition_rows( $bucket['transitions_assignment'] ) : null,
@@ -656,7 +658,7 @@ function extrachill_analytics_build_geo_bridge_experiment_report( $rows, $option
 		'contract'       => array(
 			'assignment'        => 'One person enters the denominator at their first valid experiment_assignment ordered by created_at then ID. Duplicate rows do not add people; a conflicting later variant is disclosed and does not reassign the person.',
 			'exposure'          => 'One person is exposed only after a matching-variant experiment_exposure strictly after assignment. Exposure is never inferred from assignment, bridge clicks, impressions, or pageviews.',
-			'any_bridge_clicks' => 'Stored non-bot bridge_click rows are broad intent-to-treat network-engagement outcomes after assignment and exposure. The contract cannot identify the geographic treatment card, so unrelated artist/festival card clicks remain included and are never labeled card-specific attribution. Event counts are not deduplicated, synthesized, or clamped; people counts are separate.',
+			'any_bridge_clicks' => 'Stored non-bot bridge_click rows are broad network-engagement outcomes. The assignment lens is intent-to-treat; the exposure lens is descriptive and exposure-conditioned. The contract cannot identify the geographic treatment card, so unrelated artist/festival card clicks remain included and are never labeled card-specific attribution. Event counts are not deduplicated, synthesized, or clamped; people counts are separate.',
 			'route_transition'  => 'The first identified cross-blog pageview strictly after each anchor is a transition. Its destination is blog_id plus route_family; same/later session follows the configured pageview inactivity gap.',
 			'outcomes'          => 'Only newsletter_signup, user_registration, onboarding_completed, and artist_profile_first_publish are eligible. Automatic registration newsletter rows are excluded. Each person/outcome counts once per anchor; pre-assignment rows never attribute.',
 			'identity'          => 'Bot-stamped rows are excluded before identity observation. For remaining rows identity is payload user_id, then stored user_id, then visitor_id. A visitor stitches to a user only when the bounded window observes exactly one user for that visitor; ambiguous visitors remain unmerged.',

--- a/inc/core/abilities/get-geo-bridge-experiment.php
+++ b/inc/core/abilities/get-geo-bridge-experiment.php
@@ -376,33 +376,39 @@ function extrachill_analytics_geo_bridge_variant_row( $variant, $bucket, $covera
 	}
 
 	return array(
-		'variant'           => $variant,
-		'assignment'        => array(
+		'variant'            => $variant,
+		'assignment'         => array(
 			'people'          => $assignment_ready ? $assigned : null,
 			'stored_events'   => $assignment_ready ? (int) $bucket['assignment_events'] : null,
 			'coverage_status' => $assignment_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
 		),
-		'exposure'          => array(
+		'exposure'           => array(
 			'people'          => $exposure_ready ? $exposed : null,
 			'stored_events'   => $exposure_ready ? (int) $bucket['exposure_events'] : null,
 			'rate'            => $exposure_ready && $assigned > 0 ? round( $exposed / $assigned, 4 ) : ( $exposure_ready ? 0.0 : null ),
 			'coverage_status' => $exposure_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
 		),
-		'bridge_clicks'     => array(
-			'after_assignment_events' => $click_ready ? (int) $bucket['bridge_click_events_assignment'] : null,
-			'after_assignment_people' => $click_ready ? count( $bucket['bridge_clickers_assignment'] ) : null,
-			'after_exposure_events'   => $click_ready && $exposure_ready ? (int) $bucket['bridge_click_events_exposure'] : null,
-			'after_exposure_people'   => $click_ready && $exposure_ready ? count( $bucket['bridge_clickers_exposure'] ) : null,
-			'events_per_assignment'   => $click_ready && $assigned > 0 ? round( $bucket['bridge_click_events_assignment'] / $assigned, 4 ) : ( $click_ready ? 0.0 : null ),
-			'events_per_exposure'     => $click_ready && $exposure_ready && $exposed > 0 ? round( $bucket['bridge_click_events_exposure'] / $exposed, 4 ) : ( $click_ready && $exposure_ready ? 0.0 : null ),
-			'coverage_status'         => $click_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
+		'network_engagement' => array(
+			'any_bridge_click_after_assignment' => array(
+				'events'                => $click_ready ? (int) $bucket['bridge_click_events_assignment'] : null,
+				'people'                => $click_ready ? count( $bucket['bridge_clickers_assignment'] ) : null,
+				'events_per_assignment' => $click_ready && $assigned > 0 ? round( $bucket['bridge_click_events_assignment'] / $assigned, 4 ) : ( $click_ready ? 0.0 : null ),
+			),
+			'any_bridge_click_after_exposure'   => array(
+				'events'              => $click_ready && $exposure_ready ? (int) $bucket['bridge_click_events_exposure'] : null,
+				'people'              => $click_ready && $exposure_ready ? count( $bucket['bridge_clickers_exposure'] ) : null,
+				'events_per_exposure' => $click_ready && $exposure_ready && $exposed > 0 ? round( $bucket['bridge_click_events_exposure'] / $exposed, 4 ) : ( $click_ready && $exposure_ready ? 0.0 : null ),
+			),
+			'card_specific_click_instrumented'  => false,
+			'coverage_status'                   => $click_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
+			'caveat'                            => 'The bridge_click contract identifies no rendered card or taxonomy. These are intent-to-treat counts of any bridge card clicked after the anchor, including unrelated artist or festival cards; they are not geographic-card click attribution.',
 		),
-		'route_transitions' => array(
+		'route_transitions'  => array(
 			'after_assignment' => $route_ready ? extrachill_analytics_geo_bridge_transition_rows( $bucket['transitions_assignment'] ) : null,
 			'after_exposure'   => $route_ready && $exposure_ready ? extrachill_analytics_geo_bridge_transition_rows( $bucket['transitions_exposure'] ) : null,
 			'coverage_status'  => $route_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
 		),
-		'outcomes'          => $outcomes,
+		'outcomes'           => $outcomes,
 	);
 }
 
@@ -425,6 +431,9 @@ function extrachill_analytics_build_geo_bridge_experiment_report( $rows, $option
 
 	$visitor_users = array();
 	foreach ( $events as $event ) {
+		if ( ! empty( $event['event_data']['is_bot'] ) ) {
+			continue;
+		}
 		$user_id = extrachill_analytics_geo_bridge_event_user_id( $event );
 		if ( $user_id > 0 && '' !== $event['visitor_id'] ) {
 			$visitor_users[ $event['visitor_id'] ][ $user_id ] = true;
@@ -645,12 +654,12 @@ function extrachill_analytics_build_geo_bridge_experiment_report( $rows, $option
 			)
 		),
 		'contract'       => array(
-			'assignment'       => 'One person enters the denominator at their first valid experiment_assignment ordered by created_at then ID. Duplicate rows do not add people; a conflicting later variant is disclosed and does not reassign the person.',
-			'exposure'         => 'One person is exposed only after a matching-variant experiment_exposure strictly after assignment. Exposure is never inferred from assignment, bridge clicks, impressions, or pageviews.',
-			'bridge_clicks'    => 'Stored non-bot bridge_click rows are counted independently after assignment and exposure. Event counts are not deduplicated, synthesized, or clamped; people counts are separate.',
-			'route_transition' => 'The first identified cross-blog pageview strictly after each anchor is a transition. Its destination is blog_id plus route_family; same/later session follows the configured pageview inactivity gap.',
-			'outcomes'         => 'Only newsletter_signup, user_registration, onboarding_completed, and artist_profile_first_publish are eligible. Automatic registration newsletter rows are excluded. Each person/outcome counts once per anchor; pre-assignment rows never attribute.',
-			'identity'         => 'Payload user_id, then stored user_id, then visitor_id. A visitor stitches to a user only when the bounded window observes exactly one user for that visitor; ambiguous visitors remain unmerged.',
+			'assignment'        => 'One person enters the denominator at their first valid experiment_assignment ordered by created_at then ID. Duplicate rows do not add people; a conflicting later variant is disclosed and does not reassign the person.',
+			'exposure'          => 'One person is exposed only after a matching-variant experiment_exposure strictly after assignment. Exposure is never inferred from assignment, bridge clicks, impressions, or pageviews.',
+			'any_bridge_clicks' => 'Stored non-bot bridge_click rows are broad intent-to-treat network-engagement outcomes after assignment and exposure. The contract cannot identify the geographic treatment card, so unrelated artist/festival card clicks remain included and are never labeled card-specific attribution. Event counts are not deduplicated, synthesized, or clamped; people counts are separate.',
+			'route_transition'  => 'The first identified cross-blog pageview strictly after each anchor is a transition. Its destination is blog_id plus route_family; same/later session follows the configured pageview inactivity gap.',
+			'outcomes'          => 'Only newsletter_signup, user_registration, onboarding_completed, and artist_profile_first_publish are eligible. Automatic registration newsletter rows are excluded. Each person/outcome counts once per anchor; pre-assignment rows never attribute.',
+			'identity'          => 'Bot-stamped rows are excluded before identity observation. For remaining rows identity is payload user_id, then stored user_id, then visitor_id. A visitor stitches to a user only when the bounded window observes exactly one user for that visitor; ambiguous visitors remain unmerged.',
 		),
 		'window'         => array(
 			'since'            => (string) $options['since'],

--- a/inc/core/abilities/get-geo-bridge-experiment.php
+++ b/inc/core/abilities/get-geo-bridge-experiment.php
@@ -1,0 +1,670 @@
+<?php
+/**
+ * Bounded geographic bridge holdout report.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the one approved contextual-bridge experiment report.
+ */
+function extrachill_analytics_register_geo_bridge_experiment_ability() {
+	wp_register_ability(
+		'extrachill/get-geo-bridge-experiment',
+		array(
+			'label'               => __( 'Get Geographic Bridge Experiment', 'extrachill-analytics' ),
+			'description'         => __( 'Report the bounded geo-bridge-holdout assignment, viewport exposure, bridge click, route transition, and lifecycle outcome experiment.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'             => array(
+						'type'        => 'integer',
+						'description' => __( 'UTC assignment and attribution lookback, clamped to 1-90 days. Default 28.', 'extrachill-analytics' ),
+						'default'     => 28,
+					),
+					'session_gap_mins' => array(
+						'type'        => 'integer',
+						'description' => __( 'Pageview inactivity gap separating same and later sessions, clamped to 1-120 minutes. Default 30.', 'extrachill-analytics' ),
+						'default'     => 30,
+					),
+					'max_events'       => array(
+						'type'        => 'integer',
+						'description' => __( 'Maximum relevant event rows inspected, clamped to 100-100000. Default 50000.', 'extrachill-analytics' ),
+						'default'     => 50000,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'Control and treatment results with explicit attribution, coverage, privacy, and query bounds.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_geo_bridge_experiment',
+			'permission_callback' => 'extrachill_analytics_can_read_reports',
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute the bounded geographic bridge experiment report.
+ *
+ * @param array $input Ability input.
+ * @return array Machine-readable report.
+ */
+function extrachill_analytics_ability_get_geo_bridge_experiment( $input ) {
+	$days         = min( 90, max( 1, (int) ( $input['days'] ?? 28 ) ) );
+	$gap_mins     = min( 120, max( 1, (int) ( $input['session_gap_mins'] ?? 30 ) ) );
+	$max_events   = min( 100000, max( 100, (int) ( $input['max_events'] ?? 50000 ) ) );
+	$as_of        = gmdate( 'Y-m-d H:i:s' );
+	$since        = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+	$event_types  = extrachill_analytics_geo_bridge_event_types();
+	$query        = extrachill_analytics_geo_bridge_read_events( $event_types, $since, $as_of, $max_events );
+	$instrumented = function_exists( 'extrachill_get_analytics_event_types' )
+		? extrachill_get_analytics_event_types()
+		: array_values( array_unique( array_map( static fn( $row ) => (string) $row->event_type, $query['rows'] ) ) );
+
+	return extrachill_analytics_build_geo_bridge_experiment_report(
+		$query['rows'],
+		array(
+			'since'              => $since,
+			'as_of'              => $as_of,
+			'days'               => $days,
+			'session_gap_mins'   => $gap_mins,
+			'max_events'         => $max_events,
+			'truncated'          => $query['truncated'],
+			'instrumented_types' => $instrumented,
+		)
+	);
+}
+
+/**
+ * Return the exact event set admitted by this report.
+ *
+ * @return string[] Canonical event names.
+ */
+function extrachill_analytics_geo_bridge_event_types() {
+	return array_values(
+		array_unique(
+			array_merge(
+				array(
+					EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT,
+					EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE,
+					EC_ANALYTICS_EVENT_BRIDGE_CLICK,
+					EC_ANALYTICS_EVENT_PAGEVIEW,
+				),
+				extrachill_analytics_conversion_outcome_types()
+			)
+		)
+	);
+}
+
+/**
+ * Read relevant rows with a stable ascending time/ID keyset and hard ceiling.
+ *
+ * @param string[] $event_types Canonical event names.
+ * @param string   $since       Inclusive UTC lower bound.
+ * @param string   $as_of       Inclusive UTC upper bound.
+ * @param int      $max_events  Hard row ceiling.
+ * @return array{rows:array,truncated:bool}
+ */
+function extrachill_analytics_geo_bridge_read_events( $event_types, $since, $as_of, $max_events ) {
+	global $wpdb;
+
+	$table        = extrachill_analytics_events_table();
+	$page_size    = 500;
+	$rows         = array();
+	$cursor_time  = null;
+	$cursor_id    = 0;
+	$placeholders = implode( ', ', array_fill( 0, count( $event_types ), '%s' ) );
+
+	do {
+		$remaining = $max_events + 1 - count( $rows );
+		if ( $remaining <= 0 ) {
+			break;
+		}
+		$limit  = min( $page_size, $remaining );
+		$where  = array(
+			"event_type IN ({$placeholders})",
+			'created_at >= %s',
+			'created_at <= %s',
+		);
+		$values = array_merge( array_map( 'sanitize_key', $event_types ), array( $since, $as_of ) );
+		if ( null !== $cursor_time ) {
+			$where[]  = '(created_at > %s OR (created_at = %s AND id > %d))';
+			$values[] = $cursor_time;
+			$values[] = $cursor_time;
+			$values[] = $cursor_id;
+		}
+		$values[]     = $limit;
+		$where_clause = implode( ' AND ', $where );
+
+		// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery -- Bounded report; identifiers are code-defined and values are prepared.
+		$sql  = "SELECT id, event_type, event_data, source_url, blog_id, user_id, visitor_id, created_at, UNIX_TIMESTAMP(created_at) AS ts
+			FROM {$table}
+			WHERE {$where_clause}
+			ORDER BY created_at ASC, id ASC
+			LIMIT %d";
+		$page = (array) $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+		// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery
+
+		if ( empty( $page ) ) {
+			break;
+		}
+		$rows        = array_merge( $rows, $page );
+		$page_count  = count( $page );
+		$last        = end( $page );
+		$cursor_time = (string) $last->created_at;
+		$cursor_id   = (int) $last->id;
+		$row_count   = count( $rows );
+	} while ( $page_count === $limit && $row_count <= $max_events );
+
+	$truncated = count( $rows ) > $max_events;
+	if ( $truncated ) {
+		array_pop( $rows );
+	}
+
+	return array(
+		'rows'      => $rows,
+		'truncated' => $truncated,
+	);
+}
+
+/**
+ * Normalize a stored event row for deterministic aggregation.
+ *
+ * @param object|array $row Stored row.
+ * @return array Normalized event.
+ */
+function extrachill_analytics_geo_bridge_normalize_event( $row ) {
+	$row  = (array) $row;
+	$data = $row['event_data'] ?? array();
+	if ( is_string( $data ) ) {
+		$data = json_decode( $data, true );
+	}
+	$data = is_array( $data ) ? $data : array();
+	$ts   = isset( $row['ts'] ) ? (int) $row['ts'] : strtotime( (string) ( $row['created_at'] ?? '' ) . ' UTC' );
+
+	return array(
+		'id'         => (int) ( $row['id'] ?? 0 ),
+		'event_type' => (string) ( $row['event_type'] ?? '' ),
+		'event_data' => $data,
+		'blog_id'    => (int) ( $row['blog_id'] ?? 0 ),
+		'user_id'    => (int) ( $row['user_id'] ?? 0 ),
+		'visitor_id' => trim( (string) ( $row['visitor_id'] ?? '' ) ),
+		'ts'         => max( 0, (int) $ts ),
+	);
+}
+
+/**
+ * Resolve an event's strongest user identity, including lifecycle payloads.
+ *
+ * @param array $event Normalized event.
+ * @return int Positive user ID or zero.
+ */
+function extrachill_analytics_geo_bridge_event_user_id( $event ) {
+	return (int) ( $event['event_data']['user_id'] ?? $event['user_id'] ?? 0 );
+}
+
+/**
+ * Resolve only ambiguity-safe identities.
+ *
+ * @param array $event           Normalized event.
+ * @param array $visitor_to_user One-to-one visitor/user bridges.
+ * @return string Person key, or empty when unidentified.
+ */
+function extrachill_analytics_geo_bridge_person_key( $event, $visitor_to_user ) {
+	$user_id = extrachill_analytics_geo_bridge_event_user_id( $event );
+	if ( $user_id > 0 ) {
+		return 'user:' . $user_id;
+	}
+	$visitor_id = (string) $event['visitor_id'];
+	if ( '' === $visitor_id ) {
+		return '';
+	}
+	if ( isset( $visitor_to_user[ $visitor_id ] ) ) {
+		return 'user:' . (int) $visitor_to_user[ $visitor_id ];
+	}
+	return 'visitor:' . $visitor_id;
+}
+
+/**
+ * Check strict event ordering using created_at then ID.
+ *
+ * @param array $event  Candidate event.
+ * @param array $anchor Earlier anchor.
+ * @return bool Whether event is strictly later.
+ */
+function extrachill_analytics_geo_bridge_is_after( $event, $anchor ) {
+	return (int) $event['ts'] > (int) $anchor['ts']
+		|| ( (int) $event['ts'] === (int) $anchor['ts'] && (int) $event['id'] > (int) $anchor['id'] );
+}
+
+/**
+ * Whether an experiment row matches the one approved contract.
+ *
+ * @param array $event Normalized event.
+ * @return bool Whether dimensions are exact.
+ */
+function extrachill_analytics_geo_bridge_contract_matches( $event ) {
+	$data = $event['event_data'];
+	return EC_ANALYTICS_EXPERIMENT_GEO_BRIDGE_HOLDOUT === (string) ( $data['experiment_key'] ?? '' )
+		&& EC_ANALYTICS_EXPERIMENT_SURFACE_SINGLE_POST_BRIDGE === (string) ( $data['surface'] ?? '' )
+		&& in_array( (string) ( $data['variant'] ?? '' ), EC_ANALYTICS_EXPERIMENT_VARIANTS, true );
+}
+
+/**
+ * Create an empty variant accumulator.
+ *
+ * @param string[] $outcome_types Lifecycle outcomes.
+ * @return array Accumulator.
+ */
+function extrachill_analytics_geo_bridge_variant_bucket( $outcome_types ) {
+	$outcomes = array();
+	foreach ( $outcome_types as $type ) {
+		$outcomes[ $type ] = array(
+			'same_session'  => 0,
+			'later_session' => 0,
+		);
+	}
+	return array(
+		'assigned_people'                => 0,
+		'assignment_events'              => 0,
+		'exposed_people'                 => 0,
+		'exposure_events'                => 0,
+		'bridge_click_events_assignment' => 0,
+		'bridge_clickers_assignment'     => array(),
+		'bridge_click_events_exposure'   => 0,
+		'bridge_clickers_exposure'       => array(),
+		'transitions_assignment'         => array(),
+		'transitions_exposure'           => array(),
+		'outcomes_assignment'            => $outcomes,
+		'outcomes_exposure'              => $outcomes,
+	);
+}
+
+/**
+ * Increment a deterministic destination transition bucket.
+ *
+ * @param array  $buckets Transition buckets by reference.
+ * @param array  $event   Destination pageview.
+ * @param string $stage   same_session or later_session.
+ */
+function extrachill_analytics_geo_bridge_add_transition( &$buckets, $event, $stage ) {
+	$route = sanitize_key( (string) ( $event['event_data']['route_family'] ?? '' ) );
+	if ( '' === $route ) {
+		$route = ! empty( $event['event_data']['post_id'] ) ? 'singular' : 'unclassified';
+	}
+	$key = (int) $event['blog_id'] . ':' . $route . ':' . $stage;
+	if ( ! isset( $buckets[ $key ] ) ) {
+		$buckets[ $key ] = array(
+			'destination_blog_id' => (int) $event['blog_id'],
+			'route_family'        => $route,
+			'session_stage'       => $stage,
+			'people'              => 0,
+		);
+	}
+	++$buckets[ $key ]['people'];
+}
+
+/**
+ * Sort transition rows deterministically.
+ *
+ * @param array $buckets Transition buckets.
+ * @return array Ranked rows.
+ */
+function extrachill_analytics_geo_bridge_transition_rows( $buckets ) {
+	$rows = array_values( $buckets );
+	usort(
+		$rows,
+		static function ( $a, $b ) {
+			if ( $a['people'] !== $b['people'] ) {
+				return $b['people'] <=> $a['people'];
+			}
+			return strcmp( wp_json_encode( $a ), wp_json_encode( $b ) );
+		}
+	);
+	return $rows;
+}
+
+/**
+ * Return whether a canonical signal has ever existed in storage.
+ *
+ * @param string $event_type   Canonical event name.
+ * @param array  $instrumented Distinct stored event names.
+ * @return bool Whether instrumentation is observable.
+ */
+function extrachill_analytics_geo_bridge_is_instrumented( $event_type, $instrumented ) {
+	return in_array( $event_type, $instrumented, true );
+}
+
+/**
+ * Project a variant bucket without turning absent signals into measured zero.
+ *
+ * @param string $variant      Variant name.
+ * @param array  $bucket       Raw accumulator.
+ * @param array  $coverage     Coverage state.
+ * @param array  $instrumented Distinct stored event names.
+ * @param bool   $has_cohort   Whether any matching assignment exists.
+ * @return array Machine-readable variant row.
+ */
+function extrachill_analytics_geo_bridge_variant_row( $variant, $bucket, $coverage, $instrumented, $has_cohort ) {
+	$assignment_ready = $has_cohort && extrachill_analytics_geo_bridge_is_instrumented( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, $instrumented );
+	$exposure_ready   = $assignment_ready && extrachill_analytics_geo_bridge_is_instrumented( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented );
+	$click_ready      = $assignment_ready && extrachill_analytics_geo_bridge_is_instrumented( EC_ANALYTICS_EVENT_BRIDGE_CLICK, $instrumented );
+	$route_ready      = $assignment_ready && extrachill_analytics_geo_bridge_is_instrumented( EC_ANALYTICS_EVENT_PAGEVIEW, $instrumented );
+	$assigned         = (int) $bucket['assigned_people'];
+	$exposed          = (int) $bucket['exposed_people'];
+
+	$outcomes = array();
+	foreach ( extrachill_analytics_conversion_outcome_types() as $type ) {
+		$ready             = $assignment_ready && extrachill_analytics_geo_bridge_is_instrumented( $type, $instrumented );
+		$outcomes[ $type ] = array(
+			'coverage_status'  => $ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
+			'after_assignment' => $ready ? $bucket['outcomes_assignment'][ $type ] : null,
+			'after_exposure'   => $ready && $exposure_ready ? $bucket['outcomes_exposure'][ $type ] : null,
+		);
+	}
+
+	return array(
+		'variant'           => $variant,
+		'assignment'        => array(
+			'people'          => $assignment_ready ? $assigned : null,
+			'stored_events'   => $assignment_ready ? (int) $bucket['assignment_events'] : null,
+			'coverage_status' => $assignment_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
+		),
+		'exposure'          => array(
+			'people'          => $exposure_ready ? $exposed : null,
+			'stored_events'   => $exposure_ready ? (int) $bucket['exposure_events'] : null,
+			'rate'            => $exposure_ready && $assigned > 0 ? round( $exposed / $assigned, 4 ) : ( $exposure_ready ? 0.0 : null ),
+			'coverage_status' => $exposure_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
+		),
+		'bridge_clicks'     => array(
+			'after_assignment_events' => $click_ready ? (int) $bucket['bridge_click_events_assignment'] : null,
+			'after_assignment_people' => $click_ready ? count( $bucket['bridge_clickers_assignment'] ) : null,
+			'after_exposure_events'   => $click_ready && $exposure_ready ? (int) $bucket['bridge_click_events_exposure'] : null,
+			'after_exposure_people'   => $click_ready && $exposure_ready ? count( $bucket['bridge_clickers_exposure'] ) : null,
+			'events_per_assignment'   => $click_ready && $assigned > 0 ? round( $bucket['bridge_click_events_assignment'] / $assigned, 4 ) : ( $click_ready ? 0.0 : null ),
+			'events_per_exposure'     => $click_ready && $exposure_ready && $exposed > 0 ? round( $bucket['bridge_click_events_exposure'] / $exposed, 4 ) : ( $click_ready && $exposure_ready ? 0.0 : null ),
+			'coverage_status'         => $click_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
+		),
+		'route_transitions' => array(
+			'after_assignment' => $route_ready ? extrachill_analytics_geo_bridge_transition_rows( $bucket['transitions_assignment'] ) : null,
+			'after_exposure'   => $route_ready && $exposure_ready ? extrachill_analytics_geo_bridge_transition_rows( $bucket['transitions_exposure'] ) : null,
+			'coverage_status'  => $route_ready ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'not_instrumented',
+		),
+		'outcomes'          => $outcomes,
+	);
+}
+
+/**
+ * Aggregate normalized rows into the one approved experiment report.
+ *
+ * @param array $rows    Stored rows.
+ * @param array $options Window, bounds, and instrumentation state.
+ * @return array Machine-readable report.
+ */
+function extrachill_analytics_build_geo_bridge_experiment_report( $rows, $options ) {
+	$outcome_types = extrachill_analytics_conversion_outcome_types();
+	$events        = array_map( 'extrachill_analytics_geo_bridge_normalize_event', $rows );
+	usort(
+		$events,
+		static function ( $a, $b ) {
+			return $a['ts'] === $b['ts'] ? $a['id'] <=> $b['id'] : $a['ts'] <=> $b['ts'];
+		}
+	);
+
+	$visitor_users = array();
+	foreach ( $events as $event ) {
+		$user_id = extrachill_analytics_geo_bridge_event_user_id( $event );
+		if ( $user_id > 0 && '' !== $event['visitor_id'] ) {
+			$visitor_users[ $event['visitor_id'] ][ $user_id ] = true;
+		}
+	}
+	$visitor_to_user = array();
+	$ambiguous       = array();
+	foreach ( $visitor_users as $visitor_id => $users ) {
+		if ( 1 === count( $users ) ) {
+			$visitor_to_user[ $visitor_id ] = (int) array_key_first( $users );
+		} else {
+			$ambiguous[ $visitor_id ] = true;
+		}
+	}
+	$cohort_people = array();
+	foreach ( $events as $event ) {
+		if (
+			EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT !== $event['event_type']
+			|| ! empty( $event['event_data']['is_bot'] )
+			|| ! extrachill_analytics_geo_bridge_contract_matches( $event )
+		) {
+			continue;
+		}
+		$person = extrachill_analytics_geo_bridge_person_key( $event, $visitor_to_user );
+		if ( '' !== $person ) {
+			$cohort_people[ $person ] = true;
+		}
+	}
+
+	$buckets = array();
+	foreach ( EC_ANALYTICS_EXPERIMENT_VARIANTS as $variant ) {
+		$buckets[ $variant ] = extrachill_analytics_geo_bridge_variant_bucket( $outcome_types );
+	}
+	$assignments  = array();
+	$exposures    = array();
+	$route_state  = array(
+		'assignment' => array(),
+		'exposure'   => array(),
+	);
+	$outcome_seen = array(
+		'assignment' => array(),
+		'exposure'   => array(),
+	);
+	$coverage     = array(
+		'loaded_rows'                   => count( $events ),
+		'truncated'                     => ! empty( $options['truncated'] ),
+		'bot_rows_excluded'             => 0,
+		'unidentified_rows'             => array(),
+		'contract_rows_rejected'        => 0,
+		'duplicate_assignment_events'   => 0,
+		'conflicting_assignment_events' => 0,
+		'duplicate_exposure_events'     => 0,
+		'unattributed_exposure_events'  => 0,
+		'pre_assignment_outcome_events' => 0,
+		'unattributed_outcome_events'   => 0,
+		'ambiguous_visitor_ids'         => count( $ambiguous ),
+	);
+
+	foreach ( $events as $event ) {
+		$type = $event['event_type'];
+		if ( ! empty( $event['event_data']['is_bot'] ) ) {
+			++$coverage['bot_rows_excluded'];
+			continue;
+		}
+		$person = extrachill_analytics_geo_bridge_person_key( $event, $visitor_to_user );
+		if ( '' === $person ) {
+			$coverage['unidentified_rows'][ $type ] = (int) ( $coverage['unidentified_rows'][ $type ] ?? 0 ) + 1;
+			continue;
+		}
+
+		if ( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT === $type ) {
+			if ( ! extrachill_analytics_geo_bridge_contract_matches( $event ) ) {
+				++$coverage['contract_rows_rejected'];
+				continue;
+			}
+			$variant = (string) $event['event_data']['variant'];
+			++$buckets[ $variant ]['assignment_events'];
+			if ( isset( $assignments[ $person ] ) ) {
+				++$coverage['duplicate_assignment_events'];
+				if ( $variant !== $assignments[ $person ]['variant'] ) {
+					++$coverage['conflicting_assignment_events'];
+				}
+				continue;
+			}
+			$assignments[ $person ]               = array(
+				'variant'         => $variant,
+				'ts'              => $event['ts'],
+				'id'              => $event['id'],
+				'blog_id'         => $event['blog_id'],
+				'session_last_ts' => $event['ts'],
+				'session_stage'   => 'same_session',
+			);
+			$route_state['assignment'][ $person ] = false;
+			++$buckets[ $variant ]['assigned_people'];
+			continue;
+		}
+
+		if ( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE === $type ) {
+			if ( ! extrachill_analytics_geo_bridge_contract_matches( $event ) ) {
+				++$coverage['contract_rows_rejected'];
+				continue;
+			}
+			$variant = (string) $event['event_data']['variant'];
+			if ( ! isset( $assignments[ $person ] ) || $variant !== $assignments[ $person ]['variant'] || ! extrachill_analytics_geo_bridge_is_after( $event, $assignments[ $person ] ) ) {
+				++$coverage['unattributed_exposure_events'];
+				continue;
+			}
+			++$buckets[ $variant ]['exposure_events'];
+			if ( isset( $exposures[ $person ] ) ) {
+				++$coverage['duplicate_exposure_events'];
+				continue;
+			}
+			$exposures[ $person ]               = array(
+				'variant'         => $variant,
+				'ts'              => $event['ts'],
+				'id'              => $event['id'],
+				'blog_id'         => $event['blog_id'],
+				'session_last_ts' => $event['ts'],
+				'session_stage'   => 'same_session',
+			);
+			$route_state['exposure'][ $person ] = false;
+			++$buckets[ $variant ]['exposed_people'];
+			continue;
+		}
+
+		if ( EC_ANALYTICS_EVENT_PAGEVIEW === $type ) {
+			foreach ( array( 'assignment', 'exposure' ) as $lens ) {
+				$anchors = 'assignment' === $lens ? $assignments : $exposures;
+				if ( ! isset( $anchors[ $person ] ) || ! extrachill_analytics_geo_bridge_is_after( $event, $anchors[ $person ] ) ) {
+					continue;
+				}
+				$anchor = &$anchors[ $person ];
+				if ( $event['ts'] - $anchor['session_last_ts'] > (int) $options['session_gap_mins'] * MINUTE_IN_SECONDS ) {
+					$anchor['session_stage'] = 'later_session';
+				}
+				$anchor['session_last_ts'] = $event['ts'];
+				if ( false === $route_state[ $lens ][ $person ] && $event['blog_id'] !== $anchor['blog_id'] ) {
+					$variant = $anchor['variant'];
+					$key     = 'assignment' === $lens ? 'transitions_assignment' : 'transitions_exposure';
+					extrachill_analytics_geo_bridge_add_transition( $buckets[ $variant ][ $key ], $event, $anchor['session_stage'] );
+					$route_state[ $lens ][ $person ] = true;
+				}
+				if ( 'assignment' === $lens ) {
+					$assignments[ $person ] = $anchor;
+				} else {
+					$exposures[ $person ] = $anchor;
+				}
+				unset( $anchor );
+			}
+			continue;
+		}
+
+		if ( EC_ANALYTICS_EVENT_BRIDGE_CLICK === $type ) {
+			if ( isset( $assignments[ $person ] ) && extrachill_analytics_geo_bridge_is_after( $event, $assignments[ $person ] ) ) {
+				$variant = $assignments[ $person ]['variant'];
+				++$buckets[ $variant ]['bridge_click_events_assignment'];
+				$buckets[ $variant ]['bridge_clickers_assignment'][ $person ] = true;
+			}
+			if ( isset( $exposures[ $person ] ) && extrachill_analytics_geo_bridge_is_after( $event, $exposures[ $person ] ) ) {
+				$variant = $exposures[ $person ]['variant'];
+				++$buckets[ $variant ]['bridge_click_events_exposure'];
+				$buckets[ $variant ]['bridge_clickers_exposure'][ $person ] = true;
+			}
+			continue;
+		}
+
+		if ( in_array( $type, $outcome_types, true ) ) {
+			if ( EC_ANALYTICS_EVENT_NEWSLETTER_SIGNUP === $type && 'registration' === (string) ( $event['event_data']['context'] ?? '' ) ) {
+				continue;
+			}
+			if ( ! isset( $assignments[ $person ] ) || ! extrachill_analytics_geo_bridge_is_after( $event, $assignments[ $person ] ) ) {
+				if ( isset( $cohort_people[ $person ] ) ) {
+					++$coverage['pre_assignment_outcome_events'];
+				} else {
+					++$coverage['unattributed_outcome_events'];
+				}
+				continue;
+			}
+			foreach ( array( 'assignment', 'exposure' ) as $lens ) {
+				$anchor = 'assignment' === $lens ? ( $assignments[ $person ] ?? null ) : ( $exposures[ $person ] ?? null );
+				if ( null === $anchor || ! extrachill_analytics_geo_bridge_is_after( $event, $anchor ) || isset( $outcome_seen[ $lens ][ $type ][ $person ] ) ) {
+					continue;
+				}
+				$stage   = $event['ts'] - $anchor['session_last_ts'] > (int) $options['session_gap_mins'] * MINUTE_IN_SECONDS ? 'later_session' : $anchor['session_stage'];
+				$variant = $anchor['variant'];
+				$key     = 'assignment' === $lens ? 'outcomes_assignment' : 'outcomes_exposure';
+				++$buckets[ $variant ][ $key ][ $type ][ $stage ];
+				$outcome_seen[ $lens ][ $type ][ $person ] = true;
+			}
+		}
+	}
+
+	ksort( $coverage['unidentified_rows'] );
+	$has_cohort   = ! empty( $assignments );
+	$instrumented = array_values( array_unique( array_map( 'strval', $options['instrumented_types'] ?? array() ) ) );
+	$state        = $has_cohort
+		? ( $coverage['truncated'] ? 'truncated' : 'measured' )
+		: ( extrachill_analytics_geo_bridge_is_instrumented( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, $instrumented ) ? 'no_production_data' : 'not_instrumented' );
+	$variants     = array();
+	foreach ( EC_ANALYTICS_EXPERIMENT_VARIANTS as $variant ) {
+		$variants[] = extrachill_analytics_geo_bridge_variant_row( $variant, $buckets[ $variant ], $coverage, $instrumented, $has_cohort );
+	}
+
+	return array(
+		'experiment_key' => EC_ANALYTICS_EXPERIMENT_GEO_BRIDGE_HOLDOUT,
+		'surface'        => EC_ANALYTICS_EXPERIMENT_SURFACE_SINGLE_POST_BRIDGE,
+		'state'          => $state,
+		'variants'       => $variants,
+		'coverage'       => array_merge(
+			$coverage,
+			array(
+				'identified_assignment_people' => count( $assignments ),
+				'identified_exposure_people'   => count( $exposures ),
+				'unambiguous_identity_bridges' => count( $visitor_to_user ),
+				'gpc_dnt'                      => 'Privacy-excluded requests emit no assignment or exposure and may omit visitor identity from other rows; their number is intentionally not observable from stored analytics.',
+				'unidentified'                 => 'Rows without a usable visitor_id or user_id are retained only in coverage and never attributed to a variant.',
+				'no_data_semantics'            => 'Counts are null, not zero, when their event type has never been observed or no matching assignment cohort exists.',
+			)
+		),
+		'contract'       => array(
+			'assignment'       => 'One person enters the denominator at their first valid experiment_assignment ordered by created_at then ID. Duplicate rows do not add people; a conflicting later variant is disclosed and does not reassign the person.',
+			'exposure'         => 'One person is exposed only after a matching-variant experiment_exposure strictly after assignment. Exposure is never inferred from assignment, bridge clicks, impressions, or pageviews.',
+			'bridge_clicks'    => 'Stored non-bot bridge_click rows are counted independently after assignment and exposure. Event counts are not deduplicated, synthesized, or clamped; people counts are separate.',
+			'route_transition' => 'The first identified cross-blog pageview strictly after each anchor is a transition. Its destination is blog_id plus route_family; same/later session follows the configured pageview inactivity gap.',
+			'outcomes'         => 'Only newsletter_signup, user_registration, onboarding_completed, and artist_profile_first_publish are eligible. Automatic registration newsletter rows are excluded. Each person/outcome counts once per anchor; pre-assignment rows never attribute.',
+			'identity'         => 'Payload user_id, then stored user_id, then visitor_id. A visitor stitches to a user only when the bounded window observes exactly one user for that visitor; ambiguous visitors remain unmerged.',
+		),
+		'window'         => array(
+			'since'            => (string) $options['since'],
+			'as_of'            => (string) $options['as_of'],
+			'days'             => (int) $options['days'],
+			'session_gap_mins' => (int) $options['session_gap_mins'],
+		),
+		'query'          => array(
+			'event_types'   => extrachill_analytics_geo_bridge_event_types(),
+			'order'         => 'created_at ASC, id ASC',
+			'cursor'        => '(created_at, id) > (cursor_created_at, cursor_id)',
+			'page_size'     => 500,
+			'max_events'    => (int) $options['max_events'],
+			'bounded_state' => 'At most max_events normalized rows plus one truncation sentinel are retained; all person and outcome maps derive only from that bounded set.',
+		),
+	);
+}

--- a/tests/GeoBridgeExperimentTest.php
+++ b/tests/GeoBridgeExperimentTest.php
@@ -59,11 +59,13 @@ final class GeoBridgeExperimentTest extends TestCase {
 		$this->assertSame( 0.0, $control['exposure']['rate'] );
 		$this->assertSame( 2, $control['network_engagement']['any_bridge_click_after_assignment']['events'] );
 		$this->assertSame( 1, $control['network_engagement']['any_bridge_click_after_assignment']['people'] );
+		$this->assertSame( 'intent_to_treat', $control['network_engagement']['any_bridge_click_after_assignment']['analysis_lens'] );
 		$this->assertSame( 2, $treatment['assignment']['people'] );
 		$this->assertSame( 2, $treatment['exposure']['people'] );
 		$this->assertSame( 1.0, $treatment['exposure']['rate'] );
 		$this->assertSame( 2, $treatment['network_engagement']['any_bridge_click_after_exposure']['events'] );
 		$this->assertSame( 1.0, $treatment['network_engagement']['any_bridge_click_after_exposure']['events_per_exposure'] );
+		$this->assertSame( 'descriptive_exposure_conditioned', $treatment['network_engagement']['any_bridge_click_after_exposure']['analysis_lens'] );
 		$this->assertFalse( $treatment['network_engagement']['card_specific_click_instrumented'] );
 		$this->assertSame( 'homepage', $control['route_transitions']['after_assignment'][0]['route_family'] );
 		$this->assertSame( 'same_session', $control['route_transitions']['after_assignment'][0]['session_stage'] );
@@ -78,6 +80,21 @@ final class GeoBridgeExperimentTest extends TestCase {
 		$this->assertSame( 1, $report['coverage']['bot_rows_excluded'] );
 		$this->assertSame( 1, $report['coverage']['ambiguous_visitor_ids'] );
 		$this->assertGreaterThanOrEqual( 1, $report['coverage']['pre_assignment_outcome_events'] );
+	}
+
+	/**
+	 * Instrumented rates remain undefined when their denominator is absent.
+	 */
+	public function test_zero_denominators_return_null_rates(): void {
+		$report    = extrachill_analytics_build_geo_bridge_experiment_report(
+			array( $this->row( 1, 'experiment_assignment', 100, 'visitor-control', 0, 1, $this->experiment( 'control' ) ) ),
+			$this->options()
+		);
+		$treatment = $report['variants'][1];
+
+		$this->assertNull( $treatment['exposure']['rate'] );
+		$this->assertNull( $treatment['network_engagement']['any_bridge_click_after_assignment']['events_per_assignment'] );
+		$this->assertNull( $treatment['network_engagement']['any_bridge_click_after_exposure']['events_per_exposure'] );
 	}
 
 	/**

--- a/tests/GeoBridgeExperimentTest.php
+++ b/tests/GeoBridgeExperimentTest.php
@@ -1,0 +1,319 @@
+<?php
+/**
+ * Tests for the bounded geographic bridge experiment report.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/event-types.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-conversion-map.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-geo-bridge-experiment.php';
+
+/**
+ * Protect attribution, identity, coverage, and query bounds.
+ */
+final class GeoBridgeExperimentTest extends TestCase {
+	/**
+	 * The full fixture keeps denominators, lossy events, identity, and time distinct.
+	 */
+	public function test_control_and_treatment_fixture_matrix(): void {
+		$rows      = array(
+			$this->row( 1, 'newsletter_signup', 90, 'visitor-control' ),
+			$this->row( 2, 'experiment_assignment', 100, 'visitor-control', 0, 1, $this->experiment( 'control' ) ),
+			$this->row( 3, 'experiment_assignment', 100, 'visitor-control', 0, 1, $this->experiment( 'control' ) ),
+			$this->row( 4, 'pageview', 200, 'visitor-control', 0, 7, array( 'route_family' => 'homepage' ) ),
+			$this->row( 5, 'bridge_click', 300, 'visitor-control' ),
+			$this->row( 6, 'bridge_click', 301, 'visitor-control' ),
+			$this->row( 7, 'newsletter_signup', 400, 'visitor-control', 10 ),
+			$this->row( 8, 'newsletter_signup', 401, 'visitor-control', 10 ),
+			$this->row( 9, 'experiment_assignment', 500, 'visitor-mixed', 0, 1, $this->experiment( 'control' ) ),
+			$this->row( 10, 'user_registration', 600, 'visitor-mixed', 20, 1, array( 'user_id' => 20 ) ),
+			$this->row( 11, 'experiment_assignment', 1000, 'visitor-treatment', 0, 1, $this->experiment( 'treatment' ) ),
+			$this->row( 12, 'experiment_exposure', 1100, 'visitor-treatment', 0, 1, $this->experiment( 'treatment' ) ),
+			$this->row( 13, 'experiment_exposure', 1101, 'visitor-treatment', 0, 1, $this->experiment( 'treatment' ) ),
+			$this->row( 14, 'bridge_click', 1200, 'visitor-treatment', 0, 1, array( 'is_bot' => true ) ),
+			$this->row( 15, 'bridge_click', 1201, 'visitor-treatment' ),
+			$this->row( 16, 'bridge_click', 1202, 'visitor-treatment' ),
+			$this->row( 17, 'pageview', 1250, 'visitor-treatment', 0, 1, array( 'route_family' => 'singular' ) ),
+			$this->row( 18, 'pageview', 1300, 'visitor-treatment', 0, 7, array( 'route_family' => 'archive' ) ),
+			$this->row( 19, 'pageview', 4000, 'visitor-treatment', 0, 7, array( 'route_family' => 'archive' ) ),
+			$this->row( 20, 'onboarding_completed', 5000, 'visitor-treatment', 30, 1, array( 'user_id' => 30 ) ),
+			$this->row( 21, 'experiment_assignment', 100, 'visitor-later', 0, 1, $this->experiment( 'treatment' ) ),
+			$this->row( 22, 'experiment_exposure', 110, 'visitor-later', 0, 1, $this->experiment( 'treatment' ) ),
+			$this->row( 23, 'pageview', 2000, 'visitor-later', 0, 7, array( 'route_family' => 'homepage' ) ),
+			$this->row( 24, 'artist_profile_first_publish', 2100, 'visitor-later' ),
+			$this->row( 25, 'experiment_assignment', 700, 'visitor-ambiguous', 0, 1, $this->experiment( 'control' ) ),
+			$this->row( 26, 'user_registration', 800, 'visitor-ambiguous', 40, 1, array( 'user_id' => 40 ) ),
+			$this->row( 27, 'user_registration', 801, 'visitor-ambiguous', 41, 1, array( 'user_id' => 41 ) ),
+		);
+		$report    = extrachill_analytics_build_geo_bridge_experiment_report( $rows, $this->options() );
+		$control   = $report['variants'][0];
+		$treatment = $report['variants'][1];
+
+		$this->assertSame( 'measured', $report['state'] );
+		$this->assertSame( 3, $control['assignment']['people'] );
+		$this->assertSame( 4, $control['assignment']['stored_events'] );
+		$this->assertSame( 0, $control['exposure']['people'] );
+		$this->assertSame( 0.0, $control['exposure']['rate'] );
+		$this->assertSame( 2, $control['bridge_clicks']['after_assignment_events'] );
+		$this->assertSame( 1, $control['bridge_clicks']['after_assignment_people'] );
+		$this->assertSame( 2, $treatment['assignment']['people'] );
+		$this->assertSame( 2, $treatment['exposure']['people'] );
+		$this->assertSame( 1.0, $treatment['exposure']['rate'] );
+		$this->assertSame( 2, $treatment['bridge_clicks']['after_exposure_events'] );
+		$this->assertSame( 1.0, $treatment['bridge_clicks']['events_per_exposure'] );
+		$this->assertSame( 'homepage', $control['route_transitions']['after_assignment'][0]['route_family'] );
+		$this->assertSame( 'same_session', $control['route_transitions']['after_assignment'][0]['session_stage'] );
+		$this->assertSame( 1, $this->transition_people( $treatment, 'after_assignment', 'archive', 'same_session' ) );
+		$this->assertSame( 1, $this->transition_people( $treatment, 'after_assignment', 'homepage', 'later_session' ) );
+		$this->assertSame( 1, $control['outcomes']['newsletter_signup']['after_assignment']['same_session'] );
+		$this->assertSame( 1, $control['outcomes']['user_registration']['after_assignment']['same_session'] );
+		$this->assertSame( 1, $treatment['outcomes']['onboarding_completed']['after_assignment']['later_session'] );
+		$this->assertSame( 1, $treatment['outcomes']['artist_profile_first_publish']['after_exposure']['later_session'] );
+		$this->assertSame( 1, $report['coverage']['duplicate_assignment_events'] );
+		$this->assertSame( 1, $report['coverage']['duplicate_exposure_events'] );
+		$this->assertSame( 1, $report['coverage']['bot_rows_excluded'] );
+		$this->assertSame( 1, $report['coverage']['ambiguous_visitor_ids'] );
+		$this->assertGreaterThanOrEqual( 1, $report['coverage']['pre_assignment_outcome_events'] );
+	}
+
+	/**
+	 * Equal timestamps use IDs and exposure never appears without assignment.
+	 */
+	public function test_ordering_and_unattributed_exposure_are_explicit(): void {
+		$rows   = array(
+			$this->row( 8, 'experiment_exposure', 100, 'visitor-a', 0, 1, $this->experiment( 'control' ) ),
+			$this->row( 9, 'experiment_assignment', 100, 'visitor-a', 0, 1, $this->experiment( 'control' ) ),
+			$this->row( 10, 'newsletter_signup', 100, 'visitor-a' ),
+			$this->row( 11, 'bridge_click', 101, 'visitor-a' ),
+			$this->row( 12, 'bridge_click', 102, 'visitor-a' ),
+		);
+		$report = extrachill_analytics_build_geo_bridge_experiment_report( $rows, $this->options() );
+
+		$this->assertSame( 1, $report['coverage']['unattributed_exposure_events'] );
+		$this->assertSame( 0, $report['variants'][0]['exposure']['people'] );
+		$this->assertSame( 1, $report['variants'][0]['outcomes']['newsletter_signup']['after_assignment']['same_session'] );
+		$this->assertSame( 2.0, $report['variants'][0]['bridge_clicks']['events_per_assignment'] );
+	}
+
+	/**
+	 * Missing production events return null metrics and an explicit state.
+	 */
+	public function test_absent_instrumentation_is_not_measured_zero(): void {
+		$options                       = $this->options();
+		$options['instrumented_types'] = array( 'pageview', 'bridge_click' );
+		$report                        = extrachill_analytics_build_geo_bridge_experiment_report( array(), $options );
+
+		$this->assertSame( 'not_instrumented', $report['state'] );
+		$this->assertNull( $report['variants'][0]['assignment']['people'] );
+		$this->assertNull( $report['variants'][0]['exposure']['rate'] );
+		$this->assertNull( $report['variants'][0]['outcomes']['onboarding_completed']['after_assignment'] );
+		$this->assertStringContainsString( 'not observable', $report['coverage']['gpc_dnt'] );
+	}
+
+	/**
+	 * A bounded result retains observed values while disclosing truncation.
+	 */
+	public function test_truncation_is_propagated_to_machine_output(): void {
+		$options              = $this->options();
+		$options['truncated'] = true;
+		$report               = extrachill_analytics_build_geo_bridge_experiment_report(
+			array( $this->row( 1, 'experiment_assignment', 100, 'visitor-a', 0, 1, $this->experiment( 'control' ) ) ),
+			$options
+		);
+
+		$this->assertSame( 'truncated', $report['state'] );
+		$this->assertTrue( $report['coverage']['truncated'] );
+		$this->assertSame( 'truncated', $report['variants'][0]['assignment']['coverage_status'] );
+	}
+
+	/**
+	 * The SQL reader advances an equal-time keyset by ID and keeps one sentinel.
+	 */
+	public function test_reader_uses_stable_keyset_and_hard_bound(): void {
+		$first = array();
+		for ( $id = 1; $id <= 500; ++$id ) {
+			$row             = $this->row( $id, 'pageview', 100, 'visitor-' . $id );
+			$row->created_at = '2026-07-01 00:00:00';
+			$first[]         = $row;
+		}
+		$sentinel             = $this->row( 501, 'pageview', 100, 'visitor-501' );
+		$sentinel->created_at = '2026-07-01 00:00:00';
+		$db                   = $this->install_database( array( $first, array( $sentinel ) ) );
+
+		$result = extrachill_analytics_geo_bridge_read_events(
+			extrachill_analytics_geo_bridge_event_types(),
+			'2026-07-01 00:00:00',
+			'2026-07-02 00:00:00',
+			500
+		);
+
+		$this->assertTrue( $result['truncated'] );
+		$this->assertCount( 500, $result['rows'] );
+		$this->assertCount( 2, $db->prepared_queries );
+		$this->assertStringContainsString( 'ORDER BY created_at ASC, id ASC', $db->prepared_queries[0]['query'] );
+		$this->assertStringContainsString( 'id > %d', $db->prepared_queries[1]['query'] );
+		$this->assertSame( 500, $db->prepared_queries[1]['args'][ count( $db->prepared_queries[1]['args'] ) - 2 ] );
+	}
+
+	/**
+	 * Ability registration remains private, read-only, and fixed to one report.
+	 */
+	public function test_ability_contract_is_private_and_bounded(): void {
+		extrachill_analytics_register_geo_bridge_experiment_ability();
+		$ability = $GLOBALS['extrachill_analytics_registered_abilities']['extrachill/get-geo-bridge-experiment'];
+
+		$this->assertFalse( $ability['meta']['show_in_rest'] );
+		$this->assertTrue( $ability['meta']['annotations']['readonly'] );
+		$this->assertArrayHasKey( 'max_events', $ability['input_schema']['properties'] );
+		$this->assertArrayNotHasKey( 'experiment_key', $ability['input_schema']['properties'] );
+	}
+
+	/**
+	 * Build canonical experiment metadata.
+	 *
+	 * @param string $variant Variant.
+	 * @return array Metadata.
+	 */
+	private function experiment( string $variant ): array {
+		return array(
+			'experiment_key' => 'geo-bridge-holdout',
+			'variant'        => $variant,
+			'surface'        => 'single-post-bridge',
+		);
+	}
+
+	/**
+	 * Build a stored event fixture.
+	 *
+	 * @param int    $id         ID.
+	 * @param string $event_type Event name.
+	 * @param int    $timestamp  UTC timestamp.
+	 * @param string $visitor_id Visitor identity.
+	 * @param int    $user_id    User identity.
+	 * @param int    $blog_id    Blog ID.
+	 * @param array  $event_data Payload.
+	 * @return object Stored row.
+	 */
+	private function row( int $id, string $event_type, int $timestamp, string $visitor_id = '', int $user_id = 0, int $blog_id = 1, array $event_data = array() ): object {
+		return (object) array(
+			'id'         => $id,
+			'event_type' => $event_type,
+			'event_data' => wp_json_encode( $event_data ),
+			'source_url' => '',
+			'blog_id'    => $blog_id,
+			'user_id'    => $user_id,
+			'visitor_id' => $visitor_id,
+			'created_at' => gmdate( 'Y-m-d H:i:s', $timestamp ),
+			'ts'         => $timestamp,
+		);
+	}
+
+	/**
+	 * Return report fixture options.
+	 *
+	 * @return array Options.
+	 */
+	private function options(): array {
+		return array(
+			'since'              => '1970-01-01 00:00:00',
+			'as_of'              => '1970-01-02 00:00:00',
+			'days'               => 1,
+			'session_gap_mins'   => 30,
+			'max_events'         => 50000,
+			'truncated'          => false,
+			'instrumented_types' => extrachill_analytics_geo_bridge_event_types(),
+		);
+	}
+
+	/**
+	 * Find one transition fixture count.
+	 *
+	 * @param array  $variant Variant output.
+	 * @param string $lens    Transition lens.
+	 * @param string $route   Route family.
+	 * @param string $stage   Session stage.
+	 * @return int People count.
+	 */
+	private function transition_people( array $variant, string $lens, string $route, string $stage ): int {
+		foreach ( $variant['route_transitions'][ $lens ] as $row ) {
+			if ( $route === $row['route_family'] && $stage === $row['session_stage'] ) {
+				return (int) $row['people'];
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * Install ordered database pages.
+	 *
+	 * @param array $pages Result pages.
+	 * @return object Database fixture.
+	 */
+	private function install_database( array $pages ): object {
+		$db              = new class( $pages ) {
+			/**
+			 * Captured prepared queries.
+			 *
+			 * @var array
+			 */
+			public $prepared_queries = array();
+
+			/**
+			 * Result pages.
+			 *
+			 * @var array
+			 */
+			private $pages;
+
+			/**
+			 * Current page.
+			 *
+			 * @var int
+			 */
+			private $index = 0;
+
+			/**
+			 * Set pages.
+			 *
+			 * @param array $pages Result pages.
+			 */
+			public function __construct( $pages ) {
+				$this->pages = $pages;
+			}
+
+			/**
+			 * Capture prepared SQL.
+			 *
+			 * @param string $query SQL.
+			 * @param mixed  ...$args Values.
+			 * @return string SQL.
+			 */
+			public function prepare( $query, ...$args ) {
+				if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+					$args = $args[0];
+				}
+				$this->prepared_queries[] = array(
+					'query' => $query,
+					'args'  => $args,
+				);
+				return $query;
+			}
+
+			/**
+			 * Return next page.
+			 *
+			 * @param string $query SQL.
+			 * @return array Rows.
+			 */
+			public function get_results( $query ) {
+				unset( $query );
+				return $this->pages[ $this->index++ ] ?? array();
+			}
+		};
+		$GLOBALS['wpdb'] = $db;
+		return $db;
+	}
+}

--- a/tests/GeoBridgeExperimentTest.php
+++ b/tests/GeoBridgeExperimentTest.php
@@ -57,13 +57,14 @@ final class GeoBridgeExperimentTest extends TestCase {
 		$this->assertSame( 4, $control['assignment']['stored_events'] );
 		$this->assertSame( 0, $control['exposure']['people'] );
 		$this->assertSame( 0.0, $control['exposure']['rate'] );
-		$this->assertSame( 2, $control['bridge_clicks']['after_assignment_events'] );
-		$this->assertSame( 1, $control['bridge_clicks']['after_assignment_people'] );
+		$this->assertSame( 2, $control['network_engagement']['any_bridge_click_after_assignment']['events'] );
+		$this->assertSame( 1, $control['network_engagement']['any_bridge_click_after_assignment']['people'] );
 		$this->assertSame( 2, $treatment['assignment']['people'] );
 		$this->assertSame( 2, $treatment['exposure']['people'] );
 		$this->assertSame( 1.0, $treatment['exposure']['rate'] );
-		$this->assertSame( 2, $treatment['bridge_clicks']['after_exposure_events'] );
-		$this->assertSame( 1.0, $treatment['bridge_clicks']['events_per_exposure'] );
+		$this->assertSame( 2, $treatment['network_engagement']['any_bridge_click_after_exposure']['events'] );
+		$this->assertSame( 1.0, $treatment['network_engagement']['any_bridge_click_after_exposure']['events_per_exposure'] );
+		$this->assertFalse( $treatment['network_engagement']['card_specific_click_instrumented'] );
 		$this->assertSame( 'homepage', $control['route_transitions']['after_assignment'][0]['route_family'] );
 		$this->assertSame( 'same_session', $control['route_transitions']['after_assignment'][0]['session_stage'] );
 		$this->assertSame( 1, $this->transition_people( $treatment, 'after_assignment', 'archive', 'same_session' ) );
@@ -95,7 +96,66 @@ final class GeoBridgeExperimentTest extends TestCase {
 		$this->assertSame( 1, $report['coverage']['unattributed_exposure_events'] );
 		$this->assertSame( 0, $report['variants'][0]['exposure']['people'] );
 		$this->assertSame( 1, $report['variants'][0]['outcomes']['newsletter_signup']['after_assignment']['same_session'] );
-		$this->assertSame( 2.0, $report['variants'][0]['bridge_clicks']['events_per_assignment'] );
+		$this->assertSame( 2.0, $report['variants'][0]['network_engagement']['any_bridge_click_after_assignment']['events_per_assignment'] );
+	}
+
+	/**
+	 * Bot-stamped identity links cannot create visitor/user ambiguity.
+	 */
+	public function test_bot_identity_rows_are_excluded_before_stitching(): void {
+		$rows   = array(
+			$this->row( 1, 'experiment_assignment', 100, 'visitor-bot-link', 0, 1, $this->experiment( 'control' ) ),
+			$this->row(
+				2,
+				'user_registration',
+				110,
+				'visitor-bot-link',
+				91,
+				1,
+				array(
+					'user_id' => 91,
+					'is_bot'  => true,
+				)
+			),
+			$this->row( 3, 'user_registration', 120, 'visitor-bot-link', 92, 1, array( 'user_id' => 92 ) ),
+		);
+		$report = extrachill_analytics_build_geo_bridge_experiment_report( $rows, $this->options() );
+
+		$this->assertSame( 0, $report['coverage']['ambiguous_visitor_ids'] );
+		$this->assertSame( 1, $report['coverage']['unambiguous_identity_bridges'] );
+		$this->assertSame( 1, $report['coverage']['bot_rows_excluded'] );
+		$this->assertSame( 1, $report['variants'][0]['outcomes']['user_registration']['after_assignment']['same_session'] );
+	}
+
+	/**
+	 * Generic artist-card clicks remain broad intent-to-treat outcomes.
+	 */
+	public function test_unrelated_artist_click_is_never_labeled_geographic_card_attribution(): void {
+		$rows       = array(
+			$this->row( 1, 'experiment_assignment', 100, 'visitor-artist', 0, 1, $this->experiment( 'treatment' ) ),
+			$this->row( 2, 'experiment_exposure', 110, 'visitor-artist', 0, 1, $this->experiment( 'treatment' ) ),
+			$this->row(
+				3,
+				'bridge_click',
+				120,
+				'visitor-artist',
+				0,
+				1,
+				array(
+					'dest_site' => 'artist',
+					'term'      => 'Unrelated Artist',
+				)
+			),
+		);
+		$report     = extrachill_analytics_build_geo_bridge_experiment_report( $rows, $this->options() );
+		$treatment  = $report['variants'][1];
+		$engagement = $treatment['network_engagement'];
+
+		$this->assertSame( 1, $engagement['any_bridge_click_after_assignment']['events'] );
+		$this->assertSame( 1, $engagement['any_bridge_click_after_exposure']['events'] );
+		$this->assertFalse( $engagement['card_specific_click_instrumented'] );
+		$this->assertStringContainsString( 'unrelated artist or festival cards', $engagement['caveat'] );
+		$this->assertArrayNotHasKey( 'bridge_clicks', $treatment );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- add the private `extrachill/get-geo-bridge-experiment` ability for only `geo-bridge-holdout` on `single-post-bridge`
- separate first valid assignment people/events from matching server-validated 50%-viewport exposure people/events by control and treatment
- report first identified cross-blog pageview transitions, authoritative lifecycle outcomes, and broad any-bridge intent-to-treat engagement with explicit privacy/instrumentation/query coverage

## Event contract and denominators
The reader admits `experiment_assignment`, `experiment_exposure`, `bridge_click`, `pageview`, `newsletter_signup`, `user_registration`, `onboarding_completed`, and `artist_profile_first_publish`. Experiment rows must match the canonical key, surface, and declared control/treatment variants.

The assignment denominator is one identified person at their first valid assignment. Stored assignment events remain separately visible, including duplicate diagnostics. Exposure is one person only after a matching-variant exposure strictly after assignment; it is never inferred from assignment, clicks, impressions, or pageviews. Exposure rate is exposed people divided by assigned people.

## Honest bridge-click scope
The current `bridge_click` contract identifies no rendered card or taxonomy, so it cannot isolate the geographic treatment card. The report therefore exposes clicks only under `network_engagement.any_bridge_click_after_assignment` and `network_engagement.any_bridge_click_after_exposure` as broad intent-to-treat outcomes. An unrelated artist or festival card click remains included and is never labeled geographic-card attribution.

Every variant returns `card_specific_click_instrumented: false` beside a machine-readable caveat. Raw post-anchor event counts remain independently lossy and unclamped, with unique clicker counts reported separately.

## Attribution, ordering, and dedupe
All rows use deterministic `created_at ASC, id ASC` ordering. Bot-stamped rows are excluded before visitor/user identity observation, so bot links cannot create ambiguity or alter stitching. For remaining rows identity resolves from payload `user_id`, stored `user_id`, then `visitor_id`; a visitor stitches to a user only when the bounded window observes exactly one user.

The first assignment fixes the person's variant; later duplicate/conflicting assignments are diagnostics and cannot reassign the person. The first identified cross-blog pageview after assignment/exposure supplies destination `blog_id` and `route_family`, split into same/later session by the configured pageview inactivity gap.

Lifecycle attribution accepts only the four outcomes already supported by conversion reporting and excludes automatic registration newsletter subscriptions. Each person/outcome counts once per assignment and exposure lens. Outcomes must be strictly later than their anchor, so pre-assignment rows never attribute.

## Windows, coverage, and query bounds
The ability exposes an explicit UTC `since`/`as_of` window, 1-90 day lookback, 1-120 minute session gap, and 100-100000 row ceiling. It uses stable `(created_at, id)` keyset pages of 500 and retains at most `max_events` rows plus one truncation sentinel.

Machine output discloses truncation, unidentified rows, ambiguous visitor bridges, bot exclusions, rejected contract rows, duplicate/conflicting assignment and exposure rows, unattributed exposure/outcome rows, and GPC/DNT's intentionally unobservable excluded population. A signal whose canonical event type has never appeared, or a window with no matching assignment cohort, returns `null` plus coverage state rather than measured zero.

## Verification
- `vendor/bin/phpunit tests/GeoBridgeExperimentTest.php` (8 tests, 58 assertions)
- `vendor/bin/phpunit` (364 tests, 1398 assertions)
- changed-file `php -l`
- changed-file `vendor/bin/phpcs --standard=WordPress`
- `git diff --check`

Closes #192