### PR TITLE
feat: generalize experiment analytics reporting

### DIFF
--- a/docs/experiment-summary.md
+++ b/docs/experiment-summary.md
@@ -44,9 +44,11 @@ exposure, and outcome maps derive from the bounded retained rows.
 
 ## Attribution And Output
 
-Bot rows are removed before identity mapping. Payload `user_id`, stored
-`user_id`, and then `visitor_id` resolve a person. A visitor stitches to a user
-only when exactly one user is observed in the bounded window; ambiguous visitors
+Bot rows are removed first. Experiment rows then pass key, version, policy,
+variant, and surface contract admission before identity mapping, so rejected
+rows cannot create visitor/user edges. Payload `user_id`, stored `user_id`, and
+then `visitor_id` resolve a person. A visitor stitches to a user only when
+exactly one admitted user is observed in the bounded window; ambiguous visitors
 remain unmerged.
 
 The first valid assignment fixes a person's variant and definition version.

--- a/docs/experiment-summary.md
+++ b/docs/experiment-summary.md
@@ -62,10 +62,11 @@ people use identified pageviews and the configured inactivity gap.
 
 Intent-to-treat outcome rates use assigned people. Rate confidence intervals
 are 95% Wilson score intervals. Absolute lift against control uses the
-conservative difference of Wilson bounds. Relative lift uses a log risk-ratio
-interval only when both arms have observed successes. Zero denominators,
-zero-control rates, and insufficient samples return `null` confidence or lift
-values with explicit status. The Ability never declares a winner.
+Newcombe-Wilson hybrid-score difference-of-proportions interval. Relative lift
+uses a Katz log risk-ratio interval only when both arms have nonzero successes
+and nonzero failures. Boundary and otherwise unsupported relative intervals are
+`null` with `insufficient_data`; zero denominators remain explicit. The Ability
+never declares a winner.
 
 Coverage discloses missing instrumentation/no data, truncation, bot and
 unidentified rows, ambiguous visitor IDs, invalid/other experiment rows,

--- a/docs/experiment-summary.md
+++ b/docs/experiment-summary.md
@@ -1,0 +1,74 @@
+# Generic Experiment Summary
+
+`extrachill/get-experiment-summary` is a private, read-only Ability for one
+code-registered experiment. It is not a browser ingestion endpoint, assignment
+system, lifecycle store, or winner selector. The existing
+`extrachill/get-geo-bridge-experiment` report remains the domain-specific source
+for geographic broad-click, route, and lifecycle interpretation.
+
+## Trusted Persistence
+
+Only Network's trusted `extrachill_experiment_assignment` and
+`extrachill_experiment_exposure` server hooks persist experiment rows. Their
+payload must contain exactly these bounded fields, in order:
+
+- `experiment_key`: lowercase identifier, 1-64 characters.
+- `definition_version`: positive integer, at most 1,000,000.
+- `assignment_policy`: lowercase identifier, 1-64 characters.
+- `variant`: lowercase identifier, 1-64 characters.
+- `surface`: lowercase identifier, 1-64 characters.
+
+Assignment and exposure remain distinct. GPC/DNT requests emit neither. The
+generic `extrachill/track-analytics-event` Ability explicitly rejects both
+experiment event types, even though that Ability remains available for trusted
+non-experiment server emitters.
+
+## Inputs And Bounds
+
+The summary requires exactly one `experiment_key`, `control_variant`, and a
+declared unique `variants` list. `definition_version` is optional: when omitted,
+the report discloses and aggregates observed versions while preserving each
+person's first versioned assignment. `outcome_event_types` is optional and may
+contain only code-declared canonical Analytics outcomes.
+
+- `variants`: 2-8.
+- `outcome_event_types`: 0-10.
+- `days`: 1-90, default 28.
+- `attribution_window_days`: 1-90, default 28.
+- `session_gap_mins`: 1-120, default 30.
+- `max_events`: 100-100,000, default 50,000.
+
+Rows use ascending `(created_at, id)` keyset pagination in pages of 500. One
+extra row is read only as a truncation sentinel. All identity, assignment,
+exposure, and outcome maps derive from the bounded retained rows.
+
+## Attribution And Output
+
+Bot rows are removed before identity mapping. Payload `user_id`, stored
+`user_id`, and then `visitor_id` resolve a person. A visitor stitches to a user
+only when exactly one user is observed in the bounded window; ambiguous visitors
+remain unmerged.
+
+The first valid assignment fixes a person's variant and definition version.
+Exposure requires a matching event strictly after assignment and is never
+manufactured. Outcomes must be strictly after their anchor and within the
+attribution window. Each person/outcome/lens counts once, so duplicates do not
+inflate rates and pre-assignment outcomes never attribute.
+
+Each variant reports assignment people/events, descriptive exposure
+people/events/rate, canonical outcome people/rates after assignment, and
+optional descriptive exposure-conditioned outcomes. Same/later-session outcome
+people use identified pageviews and the configured inactivity gap.
+
+Intent-to-treat outcome rates use assigned people. Rate confidence intervals
+are 95% Wilson score intervals. Absolute lift against control uses the
+conservative difference of Wilson bounds. Relative lift uses a log risk-ratio
+interval only when both arms have observed successes. Zero denominators,
+zero-control rates, and insufficient samples return `null` confidence or lift
+values with explicit status. The Ability never declares a winner.
+
+Coverage discloses missing instrumentation/no data, truncation, bot and
+unidentified rows, ambiguous visitor IDs, invalid/other experiment rows,
+duplicate/conflicting assignment and exposure rows, pre-assignment outcomes,
+surfaces, assignment policies, and definition-version mixing. GPC/DNT exclusions
+are intentionally not inferable from stored analytics.

--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -43,6 +43,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/link-page-analytics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/experiment-integration.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/experiment-reporting.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/write-integrity.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/gtm.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities.php';
@@ -69,6 +70,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-demand-dr
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-conversion-map.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-route-transitions.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-geo-bridge-experiment.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-experiment-summary.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-crosslink-targets.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/revenue-ad-policy.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/abilities/get-surface-stickiness.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -31,6 +31,7 @@ add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_demand_drill
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_conversion_map_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_route_transitions_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_geo_bridge_experiment_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_experiment_summary_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_crosslink_targets_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_surface_stickiness_ability' );
 add_action( 'wp_abilities_api_init', 'extrachill_analytics_register_activation_funnel_ability' );
@@ -133,6 +134,13 @@ function extrachill_analytics_ability_track_event( $input ) {
 			'invalid_event_type',
 			__( 'Event type must use its canonical lowercase identifier.', 'extrachill-analytics' ),
 			array( 'status' => 400 )
+		);
+	}
+	if ( in_array( $event_type, array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE ), true ) ) {
+		return new WP_Error(
+			'protected_event_type',
+			__( 'Experiment events are accepted only from trusted server hooks.', 'extrachill-analytics' ),
+			array( 'status' => 403 )
 		);
 	}
 	$event_data = isset( $input['event_data'] ) ? $input['event_data'] : array();

--- a/inc/core/abilities/get-experiment-summary.php
+++ b/inc/core/abilities/get-experiment-summary.php
@@ -179,14 +179,14 @@ function extrachill_analytics_ability_get_experiment_summary( $input ) {
 }
 
 /**
- * Return a 95% Wilson score interval for one binomial proportion.
+ * Return raw 95% Wilson score bounds for one binomial proportion.
  *
  * @param int $successes Success count.
  * @param int $total     Denominator.
  * @return array|null Lower and upper bounds, or null without a denominator.
  */
-function extrachill_analytics_experiment_wilson_interval( $successes, $total ) {
-	if ( $total <= 0 ) {
+function extrachill_analytics_experiment_wilson_bounds( $successes, $total ) {
+	if ( $total <= 0 || $successes < 0 || $successes > $total ) {
 		return null;
 	}
 	$z      = 1.959963984540054;
@@ -196,8 +196,27 @@ function extrachill_analytics_experiment_wilson_interval( $successes, $total ) {
 	$margin = $z * sqrt( ( $p * ( 1 - $p ) + $z2 / ( 4 * $total ) ) / $total ) / ( 1 + $z2 / $total );
 
 	return array(
-		'lower' => round( max( 0, $center - $margin ), 4 ),
-		'upper' => round( min( 1, $center + $margin ), 4 ),
+		'lower' => max( 0, $center - $margin ),
+		'upper' => min( 1, $center + $margin ),
+	);
+}
+
+/**
+ * Return a rounded 95% Wilson score interval for one binomial proportion.
+ *
+ * @param int $successes Success count.
+ * @param int $total     Denominator.
+ * @return array|null Lower and upper bounds, or null without a denominator.
+ */
+function extrachill_analytics_experiment_wilson_interval( $successes, $total ) {
+	$bounds = extrachill_analytics_experiment_wilson_bounds( $successes, $total );
+	if ( null === $bounds ) {
+		return null;
+	}
+
+	return array(
+		'lower' => round( $bounds['lower'], 4 ),
+		'upper' => round( $bounds['upper'], 4 ),
 	);
 }
 
@@ -221,6 +240,15 @@ function extrachill_analytics_experiment_lift( $successes, $total, $control_succ
 			'status'         => 'zero_denominator',
 		);
 	}
+	if ( $successes < 0 || $successes > $total || $control_successes < 0 || $control_successes > $control_total ) {
+		return array(
+			'absolute'       => null,
+			'relative'       => null,
+			'absolute_ci_95' => null,
+			'relative_ci_95' => null,
+			'status'         => 'insufficient_data',
+		);
+	}
 	if ( $is_control ) {
 		return array(
 			'absolute'       => 0.0,
@@ -233,28 +261,28 @@ function extrachill_analytics_experiment_lift( $successes, $total, $control_succ
 
 	$rate         = $successes / $total;
 	$control_rate = $control_successes / $control_total;
-	$variant_ci   = extrachill_analytics_experiment_wilson_interval( $successes, $total );
-	$control_ci   = extrachill_analytics_experiment_wilson_interval( $control_successes, $control_total );
+	$variant_ci   = extrachill_analytics_experiment_wilson_bounds( $successes, $total );
+	$control_ci   = extrachill_analytics_experiment_wilson_bounds( $control_successes, $control_total );
+	$difference   = $rate - $control_rate;
 	$absolute_ci  = array(
-		'lower' => round( max( -1, $variant_ci['lower'] - $control_ci['upper'] ), 4 ),
-		'upper' => round( min( 1, $variant_ci['upper'] - $control_ci['lower'] ), 4 ),
+		'lower' => round( max( -1, $difference - sqrt( ( $rate - $variant_ci['lower'] ) ** 2 + ( $control_ci['upper'] - $control_rate ) ** 2 ) ), 4 ),
+		'upper' => round( min( 1, $difference + sqrt( ( $variant_ci['upper'] - $rate ) ** 2 + ( $control_rate - $control_ci['lower'] ) ** 2 ) ), 4 ),
 	);
 	$relative     = $control_rate > 0 ? ( $rate - $control_rate ) / $control_rate : null;
 	$relative_ci  = null;
-	$status       = $control_rate > 0 ? 'measured' : 'control_zero_rate';
-	if ( $successes > 0 && $control_successes > 0 ) {
+	$status       = 'insufficient_data';
+	if ( $successes > 0 && $successes < $total && $control_successes > 0 && $control_successes < $control_total ) {
 		$log_rr      = log( $rate / $control_rate );
 		$standard    = sqrt( ( 1 / $successes ) - ( 1 / $total ) + ( 1 / $control_successes ) - ( 1 / $control_total ) );
 		$relative_ci = array(
 			'lower' => round( exp( $log_rr - 1.959963984540054 * $standard ) - 1, 4 ),
 			'upper' => round( exp( $log_rr + 1.959963984540054 * $standard ) - 1, 4 ),
 		);
-	} elseif ( 'measured' === $status ) {
-		$status = 'insufficient_samples';
+		$status      = 'measured';
 	}
 
 	return array(
-		'absolute'       => round( $rate - $control_rate, 4 ),
+		'absolute'       => round( $difference, 4 ),
 		'relative'       => null === $relative ? null : round( $relative, 4 ),
 		'absolute_ci_95' => $absolute_ci,
 		'relative_ci_95' => $relative_ci,
@@ -544,7 +572,7 @@ function extrachill_analytics_build_experiment_summary( $rows, $options ) {
 				'people'          => $assignment_ready && $has_cohort && in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? $exposed : null,
 				'stored_events'   => $assignment_ready && $has_cohort && in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? (int) $bucket['exposure_events'] : null,
 				'rate'            => $assigned > 0 && in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? round( $exposed / $assigned, 4 ) : null,
-				'rate_status'     => $assigned > 0 && in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? 'measured' : 'zero_denominator',
+				'rate_status'     => ! in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? 'not_instrumented' : ( $assigned > 0 ? 'measured' : 'zero_denominator' ),
 				'rate_ci_95'      => in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? extrachill_analytics_experiment_wilson_interval( $exposed, $assigned ) : null,
 				'coverage_status' => ! in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? 'not_instrumented' : ( $has_cohort ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'no_data' ),
 				'analysis_lens'   => 'descriptive',
@@ -582,7 +610,7 @@ function extrachill_analytics_build_experiment_summary( $rows, $options ) {
 			'exposure'   => 'Exposure requires a matching variant/version event strictly after assignment and is never inferred. Exposure-conditioned outcomes are descriptive and may be selection-biased.',
 			'outcomes'   => 'Each requested canonical outcome counts once per person and lens, strictly after its anchor and within the attribution window. Pre-assignment outcomes never attribute.',
 			'identity'   => 'Bot rows are excluded before identity observation. Payload user_id, stored user_id, then visitor_id are used; visitors stitch only when exactly one user is observed.',
-			'statistics' => 'Rates use assignment or observed-exposure people as denominators. Rate intervals are 95% Wilson score intervals; absolute lift uses the conservative difference of Wilson bounds; relative lift uses a log risk-ratio interval when both arms have successes. Nulls carry explicit status. No winner is selected.',
+			'statistics' => 'Rates use assignment or observed-exposure people as denominators. Rate intervals are 95% Wilson score intervals; absolute lift uses the Newcombe-Wilson hybrid-score difference interval; relative lift uses a Katz log risk-ratio interval only when both arms have nonzero successes and failures. Nulls carry explicit status. No winner is selected.',
 		),
 		'window'              => array(
 			'since'                   => (string) $options['since'],

--- a/inc/core/abilities/get-experiment-summary.php
+++ b/inc/core/abilities/get-experiment-summary.php
@@ -1,0 +1,603 @@
+<?php
+/**
+ * Bounded generic experiment summary report.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once dirname( __DIR__ ) . '/experiment-reporting.php';
+
+/** Register the private generic experiment summary Ability. */
+function extrachill_analytics_register_experiment_summary_ability() {
+	$identifier = array(
+		'type'      => 'string',
+		'pattern'   => '^[a-z0-9][a-z0-9_-]{0,63}$',
+		'maxLength' => 64,
+	);
+	wp_register_ability(
+		'extrachill/get-experiment-summary',
+		array(
+			'label'               => __( 'Get Experiment Summary', 'extrachill-analytics' ),
+			'description'         => __( 'Report bounded assignment, exposure, outcome, lift, confidence, identity, privacy, and version coverage for one code-registered experiment.', 'extrachill-analytics' ),
+			'category'            => 'extrachill-analytics',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'experiment_key', 'control_variant', 'variants' ),
+				'additionalProperties' => false,
+				'properties'           => array(
+					'experiment_key'          => $identifier,
+					'definition_version'      => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'maximum' => 1000000,
+					),
+					'control_variant'         => $identifier,
+					'variants'                => array(
+						'type'        => 'array',
+						'minItems'    => 2,
+						'maxItems'    => EC_ANALYTICS_EXPERIMENT_MAX_VARIANTS,
+						'uniqueItems' => true,
+						'items'       => $identifier,
+					),
+					'outcome_event_types'     => array(
+						'type'        => 'array',
+						'maxItems'    => EC_ANALYTICS_EXPERIMENT_MAX_OUTCOMES,
+						'uniqueItems' => true,
+						'items'       => $identifier,
+					),
+					'days'                    => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'maximum' => 90,
+						'default' => 28,
+					),
+					'attribution_window_days' => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'maximum' => 90,
+						'default' => 28,
+					),
+					'session_gap_mins'        => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'maximum' => 120,
+						'default' => 30,
+					),
+					'max_events'              => array(
+						'type'    => 'integer',
+						'minimum' => 100,
+						'maximum' => 100000,
+						'default' => 50000,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'Descriptive intent-to-treat and exposure-conditioned results. No winner is selected.', 'extrachill-analytics' ),
+			),
+			'execute_callback'    => 'extrachill_analytics_ability_get_experiment_summary',
+			'permission_callback' => 'extrachill_analytics_can_read_reports',
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Validate and normalize generic report input.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error Normalized options or an admission error.
+ */
+function extrachill_analytics_experiment_summary_options( $input ) {
+	$allowed_keys = array( 'experiment_key', 'definition_version', 'control_variant', 'variants', 'outcome_event_types', 'days', 'attribution_window_days', 'session_gap_mins', 'max_events' );
+	if ( ! is_array( $input ) || array_diff( array_keys( $input ), $allowed_keys ) ) {
+		return new WP_Error( 'invalid_experiment_summary_input', __( 'Experiment summary input contains unsupported fields.', 'extrachill-analytics' ), array( 'status' => 400 ) );
+	}
+
+	$key      = $input['experiment_key'] ?? null;
+	$control  = $input['control_variant'] ?? null;
+	$variants = $input['variants'] ?? null;
+	$outcomes = $input['outcome_event_types'] ?? array();
+	$version  = $input['definition_version'] ?? null;
+	if (
+		! extrachill_analytics_experiment_identifier_is_valid( $key )
+		|| ! extrachill_analytics_experiment_identifier_is_valid( $control )
+		|| ! is_array( $variants )
+		|| count( $variants ) < 2
+		|| count( $variants ) > EC_ANALYTICS_EXPERIMENT_MAX_VARIANTS
+		|| array_values( $variants ) !== $variants
+		|| count( array_unique( $variants ) ) !== count( $variants )
+		|| ! in_array( $control, $variants, true )
+		|| ! is_array( $outcomes )
+		|| count( $outcomes ) > EC_ANALYTICS_EXPERIMENT_MAX_OUTCOMES
+		|| array_values( $outcomes ) !== $outcomes
+		|| count( array_unique( $outcomes ) ) !== count( $outcomes )
+		|| ( null !== $version && ( ! is_int( $version ) || $version <= 0 || $version > 1000000 ) )
+	) {
+		return new WP_Error( 'invalid_experiment_summary_input', __( 'Experiment key, version, control, variants, or outcomes are invalid.', 'extrachill-analytics' ), array( 'status' => 400 ) );
+	}
+	foreach ( $variants as $variant ) {
+		if ( ! extrachill_analytics_experiment_identifier_is_valid( $variant ) ) {
+			return new WP_Error( 'invalid_experiment_summary_input', __( 'Every variant must be a bounded canonical identifier.', 'extrachill-analytics' ), array( 'status' => 400 ) );
+		}
+	}
+	$canonical_outcomes = extrachill_analytics_experiment_outcome_types();
+	foreach ( $outcomes as $outcome ) {
+		if ( ! is_string( $outcome ) || ! in_array( $outcome, $canonical_outcomes, true ) ) {
+			return new WP_Error( 'invalid_experiment_summary_outcome', __( 'Every outcome must be a code-declared canonical analytics event.', 'extrachill-analytics' ), array( 'status' => 400 ) );
+		}
+	}
+
+	return array(
+		'experiment_key'          => $key,
+		'definition_version'      => $version,
+		'control_variant'         => $control,
+		'variants'                => $variants,
+		'outcome_event_types'     => $outcomes,
+		'days'                    => min( 90, max( 1, (int) ( $input['days'] ?? 28 ) ) ),
+		'attribution_window_days' => min( 90, max( 1, (int) ( $input['attribution_window_days'] ?? 28 ) ) ),
+		'session_gap_mins'        => min( 120, max( 1, (int) ( $input['session_gap_mins'] ?? 30 ) ) ),
+		'max_events'              => min( 100000, max( 100, (int) ( $input['max_events'] ?? 50000 ) ) ),
+	);
+}
+
+/**
+ * Execute one bounded generic experiment report.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error Report or input error.
+ */
+function extrachill_analytics_ability_get_experiment_summary( $input ) {
+	$options = extrachill_analytics_experiment_summary_options( $input );
+	if ( is_wp_error( $options ) ) {
+		return $options;
+	}
+	$options['as_of']              = gmdate( 'Y-m-d H:i:s' );
+	$options['since']              = gmdate( 'Y-m-d H:i:s', strtotime( '-' . $options['days'] . ' days' ) );
+	$event_types                   = array_values(
+		array_unique(
+			array_merge(
+				array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, EC_ANALYTICS_EVENT_PAGEVIEW ),
+				$options['outcome_event_types']
+			)
+		)
+	);
+	$query                         = extrachill_analytics_experiment_read_events( $event_types, $options['since'], $options['as_of'], $options['max_events'] );
+	$options['truncated']          = $query['truncated'];
+	$options['instrumented_types'] = extrachill_analytics_experiment_instrumented_types( $event_types );
+
+	return extrachill_analytics_build_experiment_summary( $query['rows'], $options );
+}
+
+/**
+ * Return a 95% Wilson score interval for one binomial proportion.
+ *
+ * @param int $successes Success count.
+ * @param int $total     Denominator.
+ * @return array|null Lower and upper bounds, or null without a denominator.
+ */
+function extrachill_analytics_experiment_wilson_interval( $successes, $total ) {
+	if ( $total <= 0 ) {
+		return null;
+	}
+	$z      = 1.959963984540054;
+	$p      = $successes / $total;
+	$z2     = $z * $z;
+	$center = ( $p + $z2 / ( 2 * $total ) ) / ( 1 + $z2 / $total );
+	$margin = $z * sqrt( ( $p * ( 1 - $p ) + $z2 / ( 4 * $total ) ) / $total ) / ( 1 + $z2 / $total );
+
+	return array(
+		'lower' => round( max( 0, $center - $margin ), 4 ),
+		'upper' => round( min( 1, $center + $margin ), 4 ),
+	);
+}
+
+/**
+ * Compare one variant proportion with control without winner declarations.
+ *
+ * @param int  $successes         Variant successes.
+ * @param int  $total             Variant denominator.
+ * @param int  $control_successes Control successes.
+ * @param int  $control_total     Control denominator.
+ * @param bool $is_control       Whether this is the reference row.
+ * @return array Lift estimates, confidence intervals, and status.
+ */
+function extrachill_analytics_experiment_lift( $successes, $total, $control_successes, $control_total, $is_control = false ) {
+	if ( $total <= 0 || $control_total <= 0 ) {
+		return array(
+			'absolute'       => null,
+			'relative'       => null,
+			'absolute_ci_95' => null,
+			'relative_ci_95' => null,
+			'status'         => 'zero_denominator',
+		);
+	}
+	if ( $is_control ) {
+		return array(
+			'absolute'       => 0.0,
+			'relative'       => 0.0,
+			'absolute_ci_95' => null,
+			'relative_ci_95' => null,
+			'status'         => 'control_reference',
+		);
+	}
+
+	$rate         = $successes / $total;
+	$control_rate = $control_successes / $control_total;
+	$variant_ci   = extrachill_analytics_experiment_wilson_interval( $successes, $total );
+	$control_ci   = extrachill_analytics_experiment_wilson_interval( $control_successes, $control_total );
+	$absolute_ci  = array(
+		'lower' => round( max( -1, $variant_ci['lower'] - $control_ci['upper'] ), 4 ),
+		'upper' => round( min( 1, $variant_ci['upper'] - $control_ci['lower'] ), 4 ),
+	);
+	$relative     = $control_rate > 0 ? ( $rate - $control_rate ) / $control_rate : null;
+	$relative_ci  = null;
+	$status       = $control_rate > 0 ? 'measured' : 'control_zero_rate';
+	if ( $successes > 0 && $control_successes > 0 ) {
+		$log_rr      = log( $rate / $control_rate );
+		$standard    = sqrt( ( 1 / $successes ) - ( 1 / $total ) + ( 1 / $control_successes ) - ( 1 / $control_total ) );
+		$relative_ci = array(
+			'lower' => round( exp( $log_rr - 1.959963984540054 * $standard ) - 1, 4 ),
+			'upper' => round( exp( $log_rr + 1.959963984540054 * $standard ) - 1, 4 ),
+		);
+	} elseif ( 'measured' === $status ) {
+		$status = 'insufficient_samples';
+	}
+
+	return array(
+		'absolute'       => round( $rate - $control_rate, 4 ),
+		'relative'       => null === $relative ? null : round( $relative, 4 ),
+		'absolute_ci_95' => $absolute_ci,
+		'relative_ci_95' => $relative_ci,
+		'status'         => $status,
+	);
+}
+
+/**
+ * Create one empty generic variant bucket.
+ *
+ * @param string[] $outcome_types Requested outcomes.
+ * @return array Bucket.
+ */
+function extrachill_analytics_experiment_summary_bucket( $outcome_types ) {
+	$outcomes = array();
+	foreach ( $outcome_types as $type ) {
+		$outcomes[ $type ] = array(
+			'assignment' => array(),
+			'exposure'   => array(),
+		);
+	}
+	return array(
+		'assignment_events' => 0,
+		'assigned_people'   => 0,
+		'exposure_events'   => 0,
+		'exposed_people'    => 0,
+		'outcomes'          => $outcomes,
+	);
+}
+
+/**
+ * Validate stored experiment metadata for the requested summary.
+ *
+ * @param array $event   Normalized event.
+ * @param array $options Report options.
+ * @return bool Whether the row matches the requested contract.
+ */
+function extrachill_analytics_experiment_summary_contract_matches( $event, $options ) {
+	$data    = $event['event_data'];
+	$version = $data['definition_version'] ?? null;
+	return (string) ( $data['experiment_key'] ?? '' ) === (string) $options['experiment_key']
+		&& is_int( $version )
+		&& $version > 0
+		&& ( null === $options['definition_version'] || $version === $options['definition_version'] )
+		&& extrachill_analytics_experiment_identifier_is_valid( $data['assignment_policy'] ?? null )
+		&& in_array( (string) ( $data['variant'] ?? '' ), $options['variants'], true )
+		&& extrachill_analytics_experiment_identifier_is_valid( $data['surface'] ?? null );
+}
+
+/**
+ * Aggregate stored rows into a bounded generic experiment summary.
+ *
+ * @param array $rows    Stored rows.
+ * @param array $options Normalized report options.
+ * @return array Machine-readable summary.
+ */
+function extrachill_analytics_build_experiment_summary( $rows, $options ) {
+	$events = array_map( 'extrachill_analytics_experiment_normalize_event', $rows );
+	usort(
+		$events,
+		static function ( $a, $b ) {
+			return $a['ts'] === $b['ts'] ? $a['id'] <=> $b['id'] : $a['ts'] <=> $b['ts'];
+		}
+	);
+	$identity        = extrachill_analytics_experiment_identity_map( $events );
+	$visitor_to_user = $identity['map'];
+	$buckets         = array();
+	foreach ( $options['variants'] as $variant ) {
+		$buckets[ $variant ] = extrachill_analytics_experiment_summary_bucket( $options['outcome_event_types'] );
+	}
+	$assignments = array();
+	$exposures   = array();
+	$versions    = array();
+	$surfaces    = array();
+	$policies    = array();
+	$cohort      = array();
+	$coverage    = array(
+		'loaded_rows'                   => count( $events ),
+		'truncated'                     => ! empty( $options['truncated'] ),
+		'bot_rows_excluded'             => 0,
+		'unidentified_rows'             => array(),
+		'other_experiment_rows'         => 0,
+		'invalid_contract_rows'         => 0,
+		'other_definition_version_rows' => 0,
+		'duplicate_assignment_events'   => 0,
+		'conflicting_assignment_events' => 0,
+		'duplicate_exposure_events'     => 0,
+		'unattributed_exposure_events'  => 0,
+		'pre_assignment_outcome_events' => 0,
+		'unattributed_outcome_events'   => 0,
+		'ambiguous_visitor_ids'         => count( $identity['ambiguous'] ),
+	);
+	foreach ( $events as $event ) {
+		if ( ! empty( $event['event_data']['is_bot'] ) || EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT !== $event['event_type'] || ! extrachill_analytics_experiment_summary_contract_matches( $event, $options ) ) {
+			continue;
+		}
+		$person = extrachill_analytics_experiment_person_key( $event, $visitor_to_user );
+		if ( '' !== $person ) {
+			$cohort[ $person ] = true;
+		}
+	}
+
+	foreach ( $events as $event ) {
+		$type = $event['event_type'];
+		if ( ! empty( $event['event_data']['is_bot'] ) ) {
+			++$coverage['bot_rows_excluded'];
+			continue;
+		}
+		$person = extrachill_analytics_experiment_person_key( $event, $visitor_to_user );
+		if ( '' === $person ) {
+			$coverage['unidentified_rows'][ $type ] = (int) ( $coverage['unidentified_rows'][ $type ] ?? 0 ) + 1;
+			continue;
+		}
+
+		if ( in_array( $type, array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE ), true ) ) {
+			$data = $event['event_data'];
+			if ( (string) ( $data['experiment_key'] ?? '' ) !== $options['experiment_key'] ) {
+				++$coverage['other_experiment_rows'];
+				continue;
+			}
+			$stored_version = $data['definition_version'] ?? null;
+			if ( is_int( $stored_version ) && $stored_version > 0 ) {
+				$versions[ $stored_version ] = (int) ( $versions[ $stored_version ] ?? 0 ) + 1;
+			}
+			if ( null !== $options['definition_version'] && $stored_version !== $options['definition_version'] ) {
+				++$coverage['other_definition_version_rows'];
+				continue;
+			}
+			if ( ! extrachill_analytics_experiment_summary_contract_matches( $event, $options ) ) {
+				++$coverage['invalid_contract_rows'];
+				continue;
+			}
+			$variant                               = (string) $data['variant'];
+			$surfaces[ (string) $data['surface'] ] = true;
+			$policies[ (string) $data['assignment_policy'] ] = true;
+			if ( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT === $type ) {
+				++$buckets[ $variant ]['assignment_events'];
+				if ( isset( $assignments[ $person ] ) ) {
+					++$coverage['duplicate_assignment_events'];
+					if (
+						$variant !== $assignments[ $person ]['variant']
+						|| $stored_version !== $assignments[ $person ]['definition_version']
+						|| (string) $data['assignment_policy'] !== $assignments[ $person ]['assignment_policy']
+						|| (string) $data['surface'] !== $assignments[ $person ]['surface']
+					) {
+						++$coverage['conflicting_assignment_events'];
+					}
+					continue;
+				}
+				$assignments[ $person ] = array(
+					'variant'            => $variant,
+					'definition_version' => $stored_version,
+					'assignment_policy'  => (string) $data['assignment_policy'],
+					'surface'            => (string) $data['surface'],
+					'ts'                 => $event['ts'],
+					'id'                 => $event['id'],
+					'session_last_ts'    => $event['ts'],
+					'session_stage'      => 'same_session',
+				);
+				++$buckets[ $variant ]['assigned_people'];
+				continue;
+			}
+			if (
+				! isset( $assignments[ $person ] )
+				|| $variant !== $assignments[ $person ]['variant']
+				|| $stored_version !== $assignments[ $person ]['definition_version']
+				|| (string) $data['assignment_policy'] !== $assignments[ $person ]['assignment_policy']
+				|| (string) $data['surface'] !== $assignments[ $person ]['surface']
+				|| ! extrachill_analytics_experiment_is_after( $event, $assignments[ $person ] )
+			) {
+				++$coverage['unattributed_exposure_events'];
+				continue;
+			}
+			++$buckets[ $variant ]['exposure_events'];
+			if ( isset( $exposures[ $person ] ) ) {
+				++$coverage['duplicate_exposure_events'];
+				continue;
+			}
+			$exposures[ $person ] = array(
+				'variant'         => $variant,
+				'ts'              => $event['ts'],
+				'id'              => $event['id'],
+				'session_last_ts' => $event['ts'],
+				'session_stage'   => 'same_session',
+			);
+			++$buckets[ $variant ]['exposed_people'];
+			continue;
+		}
+
+		if ( EC_ANALYTICS_EVENT_PAGEVIEW === $type ) {
+			foreach ( array( 'assignment', 'exposure' ) as $lens ) {
+				$anchor = 'assignment' === $lens ? ( $assignments[ $person ] ?? null ) : ( $exposures[ $person ] ?? null );
+				if ( null === $anchor || ! extrachill_analytics_experiment_is_after( $event, $anchor ) ) {
+					continue;
+				}
+				if ( $event['ts'] - $anchor['session_last_ts'] > $options['session_gap_mins'] * MINUTE_IN_SECONDS ) {
+					$anchor['session_stage'] = 'later_session';
+				}
+				$anchor['session_last_ts'] = $event['ts'];
+				if ( 'assignment' === $lens ) {
+					$assignments[ $person ] = $anchor;
+				} else {
+					$exposures[ $person ] = $anchor;
+				}
+			}
+			continue;
+		}
+
+		if ( ! in_array( $type, $options['outcome_event_types'], true ) ) {
+			continue;
+		}
+		if ( ! isset( $assignments[ $person ] ) || ! extrachill_analytics_experiment_is_after( $event, $assignments[ $person ] ) ) {
+			if ( isset( $cohort[ $person ] ) ) {
+				++$coverage['pre_assignment_outcome_events'];
+			} else {
+				++$coverage['unattributed_outcome_events'];
+			}
+			continue;
+		}
+		foreach ( array( 'assignment', 'exposure' ) as $lens ) {
+			$anchor = 'assignment' === $lens ? ( $assignments[ $person ] ?? null ) : ( $exposures[ $person ] ?? null );
+			if (
+				null === $anchor
+				|| ! extrachill_analytics_experiment_is_after( $event, $anchor )
+				|| $event['ts'] - $anchor['ts'] > $options['attribution_window_days'] * DAY_IN_SECONDS
+				|| isset( $buckets[ $anchor['variant'] ]['outcomes'][ $type ][ $lens ][ $person ] )
+			) {
+				continue;
+			}
+			$stage = $event['ts'] - $anchor['session_last_ts'] > $options['session_gap_mins'] * MINUTE_IN_SECONDS ? 'later_session' : $anchor['session_stage'];
+			$buckets[ $anchor['variant'] ]['outcomes'][ $type ][ $lens ][ $person ] = $stage;
+		}
+	}
+
+	ksort( $coverage['unidentified_rows'] );
+	ksort( $versions );
+	$instrumented     = array_values( array_unique( array_map( 'strval', $options['instrumented_types'] ?? array() ) ) );
+	$assignment_ready = in_array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, $instrumented, true );
+	$has_cohort       = ! empty( $assignments );
+	$state            = $has_cohort ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : ( $assignment_ready ? 'no_data' : 'not_instrumented' );
+	$control_bucket   = $buckets[ $options['control_variant'] ];
+	$variant_rows     = array();
+	foreach ( $options['variants'] as $variant ) {
+		$bucket   = $buckets[ $variant ];
+		$assigned = (int) $bucket['assigned_people'];
+		$exposed  = (int) $bucket['exposed_people'];
+		$outcomes = array();
+		foreach ( $options['outcome_event_types'] as $type ) {
+			$outcome_instrumented = in_array( $type, $instrumented, true );
+			$ready                = $has_cohort && $outcome_instrumented;
+			$outcome_coverage     = ! $outcome_instrumented ? 'not_instrumented' : ( $has_cohort ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'no_data' );
+			$assignment_map       = $bucket['outcomes'][ $type ]['assignment'];
+			$exposure_map         = $bucket['outcomes'][ $type ]['exposure'];
+			$successes            = count( $assignment_map );
+			$exposed_hits         = count( $exposure_map );
+			$control_hits         = count( $control_bucket['outcomes'][ $type ]['assignment'] );
+			$outcomes[ $type ]    = array(
+				'coverage_status'  => $outcome_coverage,
+				'after_assignment' => $ready ? array(
+					'people'               => $successes,
+					'rate'                 => $assigned > 0 ? round( $successes / $assigned, 4 ) : null,
+					'rate_status'          => $assigned > 0 ? 'measured' : 'zero_denominator',
+					'rate_ci_95'           => extrachill_analytics_experiment_wilson_interval( $successes, $assigned ),
+					'same_session_people'  => count( array_filter( $assignment_map, static fn( $stage ) => 'same_session' === $stage ) ),
+					'later_session_people' => count( array_filter( $assignment_map, static fn( $stage ) => 'later_session' === $stage ) ),
+					'lift_vs_control'      => extrachill_analytics_experiment_lift( $successes, $assigned, $control_hits, $control_bucket['assigned_people'], $variant === $options['control_variant'] ),
+				) : null,
+				'after_exposure'   => $ready && in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? array(
+					'people'               => $exposed_hits,
+					'rate'                 => $exposed > 0 ? round( $exposed_hits / $exposed, 4 ) : null,
+					'rate_status'          => $exposed > 0 ? 'measured' : 'zero_denominator',
+					'rate_ci_95'           => extrachill_analytics_experiment_wilson_interval( $exposed_hits, $exposed ),
+					'same_session_people'  => count( array_filter( $exposure_map, static fn( $stage ) => 'same_session' === $stage ) ),
+					'later_session_people' => count( array_filter( $exposure_map, static fn( $stage ) => 'later_session' === $stage ) ),
+					'analysis_lens'        => 'descriptive_exposure_conditioned',
+				) : null,
+			);
+		}
+		$variant_rows[] = array(
+			'variant'    => $variant,
+			'assignment' => array(
+				'people'          => $assignment_ready && $has_cohort ? $assigned : null,
+				'stored_events'   => $assignment_ready && $has_cohort ? (int) $bucket['assignment_events'] : null,
+				'coverage_status' => $assignment_ready && $has_cohort ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : ( $assignment_ready ? 'no_data' : 'not_instrumented' ),
+			),
+			'exposure'   => array(
+				'people'          => $assignment_ready && $has_cohort && in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? $exposed : null,
+				'stored_events'   => $assignment_ready && $has_cohort && in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? (int) $bucket['exposure_events'] : null,
+				'rate'            => $assigned > 0 && in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? round( $exposed / $assigned, 4 ) : null,
+				'rate_status'     => $assigned > 0 && in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? 'measured' : 'zero_denominator',
+				'rate_ci_95'      => in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? extrachill_analytics_experiment_wilson_interval( $exposed, $assigned ) : null,
+				'coverage_status' => ! in_array( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $instrumented, true ) ? 'not_instrumented' : ( $has_cohort ? ( $coverage['truncated'] ? 'truncated' : 'measured' ) : 'no_data' ),
+				'analysis_lens'   => 'descriptive',
+			),
+			'outcomes'   => $outcomes,
+		);
+	}
+
+	return array(
+		'experiment_key'      => $options['experiment_key'],
+		'definition_version'  => $options['definition_version'],
+		'control_variant'     => $options['control_variant'],
+		'state'               => $state,
+		'variants'            => $variant_rows,
+		'version_diagnostics' => array(
+			'observed_event_rows_by_version' => $versions,
+			'mixed_versions_observed'        => count( $versions ) > 1,
+			'requested_version'              => $options['definition_version'],
+			'surfaces'                       => array_values( array_keys( $surfaces ) ),
+			'assignment_policies'            => array_values( array_keys( $policies ) ),
+		),
+		'coverage'            => array_merge(
+			$coverage,
+			array(
+				'identified_assignment_people' => count( $assignments ),
+				'identified_exposure_people'   => count( $exposures ),
+				'unambiguous_identity_bridges' => count( $visitor_to_user ),
+				'gpc_dnt'                      => 'Privacy-excluded requests emit no assignment or exposure and may omit visitor identity from other rows; their number is intentionally not observable from stored analytics.',
+				'unidentified'                 => 'Rows without a usable visitor_id or user_id are diagnostics only and are never attributed.',
+				'no_data_semantics'            => 'Counts and rates are null when assignment or requested outcome instrumentation is absent; zero denominators never become zero rates.',
+			)
+		),
+		'contract'            => array(
+			'assignment' => 'The first valid assignment ordered by created_at then ID fixes a person variant and version. Duplicate/conflicting rows are diagnostics and never reassign.',
+			'exposure'   => 'Exposure requires a matching variant/version event strictly after assignment and is never inferred. Exposure-conditioned outcomes are descriptive and may be selection-biased.',
+			'outcomes'   => 'Each requested canonical outcome counts once per person and lens, strictly after its anchor and within the attribution window. Pre-assignment outcomes never attribute.',
+			'identity'   => 'Bot rows are excluded before identity observation. Payload user_id, stored user_id, then visitor_id are used; visitors stitch only when exactly one user is observed.',
+			'statistics' => 'Rates use assignment or observed-exposure people as denominators. Rate intervals are 95% Wilson score intervals; absolute lift uses the conservative difference of Wilson bounds; relative lift uses a log risk-ratio interval when both arms have successes. Nulls carry explicit status. No winner is selected.',
+		),
+		'window'              => array(
+			'since'                   => (string) $options['since'],
+			'as_of'                   => (string) $options['as_of'],
+			'days'                    => (int) $options['days'],
+			'attribution_window_days' => (int) $options['attribution_window_days'],
+			'session_gap_mins'        => (int) $options['session_gap_mins'],
+		),
+		'query'               => array(
+			'event_types'   => array_values( array_unique( array_merge( array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, EC_ANALYTICS_EVENT_PAGEVIEW ), $options['outcome_event_types'] ) ) ),
+			'order'         => 'created_at ASC, id ASC',
+			'cursor'        => '(created_at, id) > (cursor_created_at, cursor_id)',
+			'page_size'     => 500,
+			'max_events'    => (int) $options['max_events'],
+			'bounded_state' => 'Variants are capped at 8, outcomes at 10, and retained rows at max_events plus one truncation sentinel; all identity and outcome maps derive from that bounded set.',
+		),
+	);
+}

--- a/inc/core/abilities/get-experiment-summary.php
+++ b/inc/core/abilities/get-experiment-summary.php
@@ -326,6 +326,7 @@ function extrachill_analytics_experiment_summary_contract_matches( $event, $opti
 	return (string) ( $data['experiment_key'] ?? '' ) === (string) $options['experiment_key']
 		&& is_int( $version )
 		&& $version > 0
+		&& $version <= 1000000
 		&& ( null === $options['definition_version'] || $version === $options['definition_version'] )
 		&& extrachill_analytics_experiment_identifier_is_valid( $data['assignment_policy'] ?? null )
 		&& in_array( (string) ( $data['variant'] ?? '' ), $options['variants'], true )
@@ -404,9 +405,11 @@ function extrachill_analytics_build_experiment_summary( $rows, $options ) {
 				continue;
 			}
 			$stored_version = $data['definition_version'] ?? null;
-			if ( is_int( $stored_version ) && $stored_version > 0 ) {
-				$versions[ $stored_version ] = (int) ( $versions[ $stored_version ] ?? 0 ) + 1;
+			if ( ! is_int( $stored_version ) || $stored_version <= 0 || $stored_version > 1000000 ) {
+				++$coverage['invalid_contract_rows'];
+				continue;
 			}
+			$versions[ $stored_version ] = (int) ( $versions[ $stored_version ] ?? 0 ) + 1;
 			if ( null !== $options['definition_version'] && $stored_version !== $options['definition_version'] ) {
 				++$coverage['other_definition_version_rows'];
 				continue;

--- a/inc/core/abilities/get-experiment-summary.php
+++ b/inc/core/abilities/get-experiment-summary.php
@@ -334,6 +334,31 @@ function extrachill_analytics_experiment_summary_contract_matches( $event, $opti
 }
 
 /**
+ * Classify one stored experiment row before identity observation.
+ *
+ * @param array $event   Normalized event.
+ * @param array $options Report options.
+ * @return string Contract status.
+ */
+function extrachill_analytics_experiment_summary_contract_status( $event, $options ) {
+	if ( ! in_array( $event['event_type'], array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE ), true ) ) {
+		return 'not_experiment';
+	}
+	$data = $event['event_data'];
+	if ( (string) ( $data['experiment_key'] ?? '' ) !== $options['experiment_key'] ) {
+		return 'other_experiment';
+	}
+	$version = $data['definition_version'] ?? null;
+	if ( ! is_int( $version ) || $version <= 0 || $version > 1000000 ) {
+		return 'invalid_contract';
+	}
+	if ( null !== $options['definition_version'] && $version !== $options['definition_version'] ) {
+		return 'other_definition_version';
+	}
+	return extrachill_analytics_experiment_summary_contract_matches( $event, $options ) ? 'matched' : 'invalid_contract';
+}
+
+/**
  * Aggregate stored rows into a bounded generic experiment summary.
  *
  * @param array $rows    Stored rows.
@@ -348,7 +373,17 @@ function extrachill_analytics_build_experiment_summary( $rows, $options ) {
 			return $a['ts'] === $b['ts'] ? $a['id'] <=> $b['id'] : $a['ts'] <=> $b['ts'];
 		}
 	);
-	$identity        = extrachill_analytics_experiment_identity_map( $events );
+	$identity_events = array();
+	foreach ( $events as $event ) {
+		if ( ! empty( $event['event_data']['is_bot'] ) ) {
+			continue;
+		}
+		$status = extrachill_analytics_experiment_summary_contract_status( $event, $options );
+		if ( in_array( $status, array( 'not_experiment', 'matched' ), true ) ) {
+			$identity_events[] = $event;
+		}
+	}
+	$identity        = extrachill_analytics_experiment_identity_map( $identity_events );
 	$visitor_to_user = $identity['map'];
 	$buckets         = array();
 	foreach ( $options['variants'] as $variant ) {
@@ -392,30 +427,27 @@ function extrachill_analytics_build_experiment_summary( $rows, $options ) {
 			++$coverage['bot_rows_excluded'];
 			continue;
 		}
-		$person = extrachill_analytics_experiment_person_key( $event, $visitor_to_user );
-		if ( '' === $person ) {
-			$coverage['unidentified_rows'][ $type ] = (int) ( $coverage['unidentified_rows'][ $type ] ?? 0 ) + 1;
-			continue;
-		}
 
 		if ( in_array( $type, array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE ), true ) ) {
-			$data = $event['event_data'];
-			if ( (string) ( $data['experiment_key'] ?? '' ) !== $options['experiment_key'] ) {
+			$status = extrachill_analytics_experiment_summary_contract_status( $event, $options );
+			if ( 'other_experiment' === $status ) {
 				++$coverage['other_experiment_rows'];
 				continue;
 			}
-			$stored_version = $data['definition_version'] ?? null;
-			if ( ! is_int( $stored_version ) || $stored_version <= 0 || $stored_version > 1000000 ) {
+			if ( 'invalid_contract' === $status ) {
 				++$coverage['invalid_contract_rows'];
 				continue;
 			}
+			$data                        = $event['event_data'];
+			$stored_version              = $data['definition_version'] ?? null;
 			$versions[ $stored_version ] = (int) ( $versions[ $stored_version ] ?? 0 ) + 1;
-			if ( null !== $options['definition_version'] && $stored_version !== $options['definition_version'] ) {
+			if ( 'other_definition_version' === $status ) {
 				++$coverage['other_definition_version_rows'];
 				continue;
 			}
-			if ( ! extrachill_analytics_experiment_summary_contract_matches( $event, $options ) ) {
-				++$coverage['invalid_contract_rows'];
+			$person = extrachill_analytics_experiment_person_key( $event, $visitor_to_user );
+			if ( '' === $person ) {
+				$coverage['unidentified_rows'][ $type ] = (int) ( $coverage['unidentified_rows'][ $type ] ?? 0 ) + 1;
 				continue;
 			}
 			$variant                               = (string) $data['variant'];
@@ -472,6 +504,11 @@ function extrachill_analytics_build_experiment_summary( $rows, $options ) {
 				'session_stage'   => 'same_session',
 			);
 			++$buckets[ $variant ]['exposed_people'];
+			continue;
+		}
+		$person = extrachill_analytics_experiment_person_key( $event, $visitor_to_user );
+		if ( '' === $person ) {
+			$coverage['unidentified_rows'][ $type ] = (int) ( $coverage['unidentified_rows'][ $type ] ?? 0 ) + 1;
 			continue;
 		}
 

--- a/inc/core/abilities/get-geo-bridge-experiment.php
+++ b/inc/core/abilities/get-geo-bridge-experiment.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+require_once dirname( __DIR__ ) . '/experiment-reporting.php';
+
 /**
  * Register the one approved contextual-bridge experiment report.
  */
@@ -118,65 +120,7 @@ function extrachill_analytics_geo_bridge_event_types() {
  * @return array{rows:array,truncated:bool}
  */
 function extrachill_analytics_geo_bridge_read_events( $event_types, $since, $as_of, $max_events ) {
-	global $wpdb;
-
-	$table        = extrachill_analytics_events_table();
-	$page_size    = 500;
-	$rows         = array();
-	$cursor_time  = null;
-	$cursor_id    = 0;
-	$placeholders = implode( ', ', array_fill( 0, count( $event_types ), '%s' ) );
-
-	do {
-		$remaining = $max_events + 1 - count( $rows );
-		if ( $remaining <= 0 ) {
-			break;
-		}
-		$limit  = min( $page_size, $remaining );
-		$where  = array(
-			"event_type IN ({$placeholders})",
-			'created_at >= %s',
-			'created_at <= %s',
-		);
-		$values = array_merge( array_map( 'sanitize_key', $event_types ), array( $since, $as_of ) );
-		if ( null !== $cursor_time ) {
-			$where[]  = '(created_at > %s OR (created_at = %s AND id > %d))';
-			$values[] = $cursor_time;
-			$values[] = $cursor_time;
-			$values[] = $cursor_id;
-		}
-		$values[]     = $limit;
-		$where_clause = implode( ' AND ', $where );
-
-		// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery -- Bounded report; identifiers are code-defined and values are prepared.
-		$sql  = "SELECT id, event_type, event_data, source_url, blog_id, user_id, visitor_id, created_at, UNIX_TIMESTAMP(created_at) AS ts
-			FROM {$table}
-			WHERE {$where_clause}
-			ORDER BY created_at ASC, id ASC
-			LIMIT %d";
-		$page = (array) $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
-		// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery
-
-		if ( empty( $page ) ) {
-			break;
-		}
-		$rows        = array_merge( $rows, $page );
-		$page_count  = count( $page );
-		$last        = end( $page );
-		$cursor_time = (string) $last->created_at;
-		$cursor_id   = (int) $last->id;
-		$row_count   = count( $rows );
-	} while ( $page_count === $limit && $row_count <= $max_events );
-
-	$truncated = count( $rows ) > $max_events;
-	if ( $truncated ) {
-		array_pop( $rows );
-	}
-
-	return array(
-		'rows'      => $rows,
-		'truncated' => $truncated,
-	);
+	return extrachill_analytics_experiment_read_events( $event_types, $since, $as_of, $max_events );
 }
 
 /**
@@ -186,23 +130,7 @@ function extrachill_analytics_geo_bridge_read_events( $event_types, $since, $as_
  * @return array Normalized event.
  */
 function extrachill_analytics_geo_bridge_normalize_event( $row ) {
-	$row  = (array) $row;
-	$data = $row['event_data'] ?? array();
-	if ( is_string( $data ) ) {
-		$data = json_decode( $data, true );
-	}
-	$data = is_array( $data ) ? $data : array();
-	$ts   = isset( $row['ts'] ) ? (int) $row['ts'] : strtotime( (string) ( $row['created_at'] ?? '' ) . ' UTC' );
-
-	return array(
-		'id'         => (int) ( $row['id'] ?? 0 ),
-		'event_type' => (string) ( $row['event_type'] ?? '' ),
-		'event_data' => $data,
-		'blog_id'    => (int) ( $row['blog_id'] ?? 0 ),
-		'user_id'    => (int) ( $row['user_id'] ?? 0 ),
-		'visitor_id' => trim( (string) ( $row['visitor_id'] ?? '' ) ),
-		'ts'         => max( 0, (int) $ts ),
-	);
+	return extrachill_analytics_experiment_normalize_event( $row );
 }
 
 /**
@@ -212,7 +140,7 @@ function extrachill_analytics_geo_bridge_normalize_event( $row ) {
  * @return int Positive user ID or zero.
  */
 function extrachill_analytics_geo_bridge_event_user_id( $event ) {
-	return (int) ( $event['event_data']['user_id'] ?? $event['user_id'] ?? 0 );
+	return extrachill_analytics_experiment_event_user_id( $event );
 }
 
 /**
@@ -223,18 +151,7 @@ function extrachill_analytics_geo_bridge_event_user_id( $event ) {
  * @return string Person key, or empty when unidentified.
  */
 function extrachill_analytics_geo_bridge_person_key( $event, $visitor_to_user ) {
-	$user_id = extrachill_analytics_geo_bridge_event_user_id( $event );
-	if ( $user_id > 0 ) {
-		return 'user:' . $user_id;
-	}
-	$visitor_id = (string) $event['visitor_id'];
-	if ( '' === $visitor_id ) {
-		return '';
-	}
-	if ( isset( $visitor_to_user[ $visitor_id ] ) ) {
-		return 'user:' . (int) $visitor_to_user[ $visitor_id ];
-	}
-	return 'visitor:' . $visitor_id;
+	return extrachill_analytics_experiment_person_key( $event, $visitor_to_user );
 }
 
 /**
@@ -245,8 +162,7 @@ function extrachill_analytics_geo_bridge_person_key( $event, $visitor_to_user ) 
  * @return bool Whether event is strictly later.
  */
 function extrachill_analytics_geo_bridge_is_after( $event, $anchor ) {
-	return (int) $event['ts'] > (int) $anchor['ts']
-		|| ( (int) $event['ts'] === (int) $anchor['ts'] && (int) $event['id'] > (int) $anchor['id'] );
+	return extrachill_analytics_experiment_is_after( $event, $anchor );
 }
 
 /**

--- a/inc/core/experiment-integration.php
+++ b/inc/core/experiment-integration.php
@@ -58,28 +58,33 @@ add_filter( 'extrachill_experiment_measurement_eligible', 'extrachill_analytics_
  * Network fires the assignment hook only after a measured assignment resolves,
  * and the exposure hook only after re-validating the browser's 50%-viewport
  * signal against that assignment. This callback accepts no browser request and
- * persists only the three bounded scalar dimensions supplied by those hooks.
+ * persists only the five bounded scalar dimensions supplied by those hooks.
  *
  * @param string $event_type Canonical assignment or exposure event name.
  * @param array  $metadata   Network-validated experiment metadata.
  * @return int|false Event ID, or false when the contract/privacy check fails.
  */
 function extrachill_analytics_record_experiment_event( $event_type, $metadata ) {
-	if ( ! is_array( $metadata ) || array( 'experiment_key', 'variant', 'surface' ) !== array_keys( $metadata ) ) {
+	$fields = array( 'experiment_key', 'definition_version', 'assignment_policy', 'variant', 'surface' );
+	if ( ! is_array( $metadata ) || array_keys( $metadata ) !== $fields ) {
 		return false;
 	}
 
-	$experiment_key = $metadata['experiment_key'];
-	$variant        = $metadata['variant'];
-	$surface        = $metadata['surface'];
+	$experiment_key     = $metadata['experiment_key'];
+	$definition_version = $metadata['definition_version'];
+	$assignment_policy  = $metadata['assignment_policy'];
+	$variant            = $metadata['variant'];
+	$surface            = $metadata['surface'];
 	if (
 		! in_array( $event_type, array( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE ), true )
-		|| ! is_string( $experiment_key )
-		|| ! is_string( $variant )
-		|| ! is_string( $surface )
-		|| EC_ANALYTICS_EXPERIMENT_GEO_BRIDGE_HOLDOUT !== $experiment_key
-		|| EC_ANALYTICS_EXPERIMENT_SURFACE_SINGLE_POST_BRIDGE !== $surface
-		|| ! in_array( $variant, EC_ANALYTICS_EXPERIMENT_VARIANTS, true )
+		|| ! function_exists( 'extrachill_analytics_experiment_identifier_is_valid' )
+		|| ! extrachill_analytics_experiment_identifier_is_valid( $experiment_key )
+		|| ! is_int( $definition_version )
+		|| $definition_version <= 0
+		|| $definition_version > 1000000
+		|| ! extrachill_analytics_experiment_identifier_is_valid( $assignment_policy )
+		|| ! extrachill_analytics_experiment_identifier_is_valid( $variant )
+		|| ! extrachill_analytics_experiment_identifier_is_valid( $surface )
 		|| ( function_exists( 'extrachill_analytics_visitor_opted_out' ) && extrachill_analytics_visitor_opted_out() )
 	) {
 		return false;

--- a/inc/core/experiment-reporting.php
+++ b/inc/core/experiment-reporting.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * Shared bounded experiment-reporting primitives.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/** Maximum dimensions accepted by the generic experiment reader. */
+const EC_ANALYTICS_EXPERIMENT_MAX_VARIANTS = 8;
+const EC_ANALYTICS_EXPERIMENT_MAX_OUTCOMES = 10;
+
+/**
+ * Validate a bounded experiment identifier.
+ *
+ * @param mixed $value Candidate value.
+ * @return bool Whether the value is canonical and bounded.
+ */
+function extrachill_analytics_experiment_identifier_is_valid( $value ) {
+	return is_string( $value ) && 1 === preg_match( '/^[a-z0-9][a-z0-9_-]{0,63}$/', $value );
+}
+
+/**
+ * Return canonical event types eligible as generic experiment outcomes.
+ *
+ * Assignment, exposure, pageviews, security events, and delivery-only signals
+ * are intentionally excluded. Adding an outcome requires a code review here.
+ *
+ * @return string[] Canonical outcome event names.
+ */
+function extrachill_analytics_experiment_outcome_types() {
+	return array_values(
+		array_unique(
+			array_merge(
+				array(
+					EC_ANALYTICS_EVENT_USER_REGISTRATION,
+					EC_ANALYTICS_EVENT_NEWSLETTER_SIGNUP,
+					EC_ANALYTICS_EVENT_SHARE_CLICK,
+					EC_ANALYTICS_EVENT_BRIDGE_CLICK,
+					EC_ANALYTICS_EVENT_BRIDGE_IMPRESSION,
+					EC_ANALYTICS_EVENT_OUTBOUND_CLICK,
+					EC_ANALYTICS_EVENT_REDIRECT_FIRE,
+				),
+				EC_ANALYTICS_TEAM_EXPERIENCE_EVENTS,
+				EC_ANALYTICS_ONBOARDING_FUNNEL_EVENTS,
+				EC_ANALYTICS_LOCAL_SCENE_PROMPT_EVENTS,
+				EC_ANALYTICS_ARTIST_FUNNEL_EVENTS,
+				EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS,
+				EC_ANALYTICS_ARTIST_DISPATCH_EVENTS
+			)
+		)
+	);
+}
+
+/**
+ * Read relevant rows with stable ascending time/ID keyset pagination.
+ *
+ * @param string[] $event_types Canonical event names.
+ * @param string   $since       Inclusive UTC lower bound.
+ * @param string   $as_of       Inclusive UTC upper bound.
+ * @param int      $max_events  Hard row ceiling.
+ * @return array{rows:array,truncated:bool}
+ */
+function extrachill_analytics_experiment_read_events( $event_types, $since, $as_of, $max_events ) {
+	global $wpdb;
+
+	$event_types = array_values( array_unique( array_map( 'sanitize_key', $event_types ) ) );
+	if ( empty( $event_types ) ) {
+		return array(
+			'rows'      => array(),
+			'truncated' => false,
+		);
+	}
+
+	$table        = extrachill_analytics_events_table();
+	$page_size    = 500;
+	$rows         = array();
+	$cursor_time  = null;
+	$cursor_id    = 0;
+	$placeholders = implode( ', ', array_fill( 0, count( $event_types ), '%s' ) );
+
+	do {
+		$remaining = $max_events + 1 - count( $rows );
+		if ( $remaining <= 0 ) {
+			break;
+		}
+		$limit  = min( $page_size, $remaining );
+		$where  = array(
+			"event_type IN ({$placeholders})",
+			'created_at >= %s',
+			'created_at <= %s',
+		);
+		$values = array_merge( $event_types, array( $since, $as_of ) );
+		if ( null !== $cursor_time ) {
+			$where[]  = '(created_at > %s OR (created_at = %s AND id > %d))';
+			$values[] = $cursor_time;
+			$values[] = $cursor_time;
+			$values[] = $cursor_id;
+		}
+		$values[]     = $limit;
+		$where_clause = implode( ' AND ', $where );
+
+		// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery -- Bounded report; identifiers are code-defined and values are prepared.
+		$sql  = "SELECT id, event_type, event_data, source_url, blog_id, user_id, visitor_id, created_at, UNIX_TIMESTAMP(created_at) AS ts
+			FROM {$table}
+			WHERE {$where_clause}
+			ORDER BY created_at ASC, id ASC
+			LIMIT %d";
+		$page = (array) $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+		// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery
+
+		if ( empty( $page ) ) {
+			break;
+		}
+		$rows         = array_merge( $rows, $page );
+		$page_count   = count( $page );
+		$last         = end( $page );
+		$cursor_time  = (string) $last->created_at;
+		$cursor_id    = (int) $last->id;
+		$current_rows = count( $rows );
+	} while ( $page_count === $limit && $current_rows <= $max_events );
+
+	$truncated = count( $rows ) > $max_events;
+	if ( $truncated ) {
+		array_pop( $rows );
+	}
+
+	return array(
+		'rows'      => $rows,
+		'truncated' => $truncated,
+	);
+}
+
+/**
+ * Return only requested event types that have ever existed in storage.
+ *
+ * @param string[] $event_types Bounded requested event names.
+ * @return string[] Instrumented event names.
+ */
+function extrachill_analytics_experiment_instrumented_types( $event_types ) {
+	global $wpdb;
+
+	$event_types = array_values( array_unique( array_map( 'sanitize_key', $event_types ) ) );
+	if ( empty( $event_types ) ) {
+		return array();
+	}
+	$table        = extrachill_analytics_events_table();
+	$placeholders = implode( ', ', array_fill( 0, count( $event_types ), '%s' ) );
+
+	// phpcs:disable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery -- Bounded code-defined projection with prepared values.
+	$sql = "SELECT DISTINCT event_type FROM {$table} WHERE event_type IN ({$placeholders}) ORDER BY event_type ASC";
+	return array_map( 'strval', (array) $wpdb->get_col( $wpdb->prepare( $sql, $event_types ) ) );
+	// phpcs:enable WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery
+}
+
+/**
+ * Normalize a stored event row.
+ *
+ * @param object|array $row Stored row.
+ * @return array Normalized event.
+ */
+function extrachill_analytics_experiment_normalize_event( $row ) {
+	$row  = (array) $row;
+	$data = $row['event_data'] ?? array();
+	if ( is_string( $data ) ) {
+		$data = json_decode( $data, true );
+	}
+	$data = is_array( $data ) ? $data : array();
+	$ts   = isset( $row['ts'] ) ? (int) $row['ts'] : strtotime( (string) ( $row['created_at'] ?? '' ) . ' UTC' );
+
+	return array(
+		'id'         => (int) ( $row['id'] ?? 0 ),
+		'event_type' => (string) ( $row['event_type'] ?? '' ),
+		'event_data' => $data,
+		'blog_id'    => (int) ( $row['blog_id'] ?? 0 ),
+		'user_id'    => (int) ( $row['user_id'] ?? 0 ),
+		'visitor_id' => trim( (string) ( $row['visitor_id'] ?? '' ) ),
+		'ts'         => max( 0, (int) $ts ),
+	);
+}
+
+/**
+ * Resolve an event's strongest explicit user identity.
+ *
+ * @param array $event Normalized event.
+ * @return int Positive user ID or zero.
+ */
+function extrachill_analytics_experiment_event_user_id( $event ) {
+	return (int) ( $event['event_data']['user_id'] ?? $event['user_id'] ?? 0 );
+}
+
+/**
+ * Build ambiguity-safe visitor-to-user bridges after bot filtering.
+ *
+ * @param array $events Normalized events.
+ * @return array{map:array,ambiguous:array}
+ */
+function extrachill_analytics_experiment_identity_map( $events ) {
+	$visitor_users = array();
+	foreach ( $events as $event ) {
+		if ( ! empty( $event['event_data']['is_bot'] ) ) {
+			continue;
+		}
+		$user_id = extrachill_analytics_experiment_event_user_id( $event );
+		if ( $user_id > 0 && '' !== $event['visitor_id'] ) {
+			$visitor_users[ $event['visitor_id'] ][ $user_id ] = true;
+		}
+	}
+
+	$map       = array();
+	$ambiguous = array();
+	foreach ( $visitor_users as $visitor_id => $users ) {
+		if ( 1 === count( $users ) ) {
+			$map[ $visitor_id ] = (int) array_key_first( $users );
+		} else {
+			$ambiguous[ $visitor_id ] = true;
+		}
+	}
+
+	return array(
+		'map'       => $map,
+		'ambiguous' => $ambiguous,
+	);
+}
+
+/**
+ * Resolve an ambiguity-safe person key.
+ *
+ * @param array $event           Normalized event.
+ * @param array $visitor_to_user One-to-one visitor/user bridges.
+ * @return string Person key, or empty when unidentified.
+ */
+function extrachill_analytics_experiment_person_key( $event, $visitor_to_user ) {
+	$user_id = extrachill_analytics_experiment_event_user_id( $event );
+	if ( $user_id > 0 ) {
+		return 'user:' . $user_id;
+	}
+	$visitor_id = (string) $event['visitor_id'];
+	if ( '' === $visitor_id ) {
+		return '';
+	}
+	if ( isset( $visitor_to_user[ $visitor_id ] ) ) {
+		return 'user:' . (int) $visitor_to_user[ $visitor_id ];
+	}
+	return 'visitor:' . $visitor_id;
+}
+
+/**
+ * Check strict event ordering using created_at then ID.
+ *
+ * @param array $event  Candidate event.
+ * @param array $anchor Earlier anchor.
+ * @return bool Whether event is strictly later.
+ */
+function extrachill_analytics_experiment_is_after( $event, $anchor ) {
+	return (int) $event['ts'] > (int) $anchor['ts']
+		|| ( (int) $event['ts'] === (int) $anchor['ts'] && (int) $event['id'] > (int) $anchor['id'] );
+}

--- a/tests/EventContractsTest.php
+++ b/tests/EventContractsTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once dirname( __DIR__ ) . '/inc/core/event-types.php';
 require_once dirname( __DIR__ ) . '/inc/core/assets.php';
+require_once dirname( __DIR__ ) . '/inc/core/experiment-reporting.php';
 require_once dirname( __DIR__ ) . '/inc/core/experiment-integration.php';
 require_once dirname( __DIR__ ) . '/inc/core/write-integrity.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities.php';
@@ -62,6 +63,20 @@ final class EventContractsTest extends TestCase {
 	public function test_experiment_events_are_not_public_browser_events(): void {
 		$this->assertNotContains( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, extrachill_analytics_public_browser_event_types() );
 		$this->assertNotContains( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, extrachill_analytics_public_browser_event_types() );
+		$result = extrachill_analytics_ability_track_event(
+			array(
+				'event_type' => EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT,
+				'event_data' => array(
+					'experiment_key'     => 'copy-test',
+					'definition_version' => 1,
+					'assignment_policy'  => 'weighted_random',
+					'variant'            => 'control',
+					'surface'            => 'hero',
+				),
+			)
+		);
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'protected_event_type', $result->code );
 	}
 
 	/**
@@ -119,16 +134,20 @@ final class EventContractsTest extends TestCase {
 	public function test_network_hooks_persist_exact_assignment_and_exposure_payloads(): void {
 		extrachill_analytics_record_experiment_assignment(
 			array(
-				'experiment_key' => 'geo-bridge-holdout',
-				'variant'        => 'control',
-				'surface'        => 'single-post-bridge',
+				'experiment_key'     => 'geo-bridge-holdout',
+				'definition_version' => 1,
+				'assignment_policy'  => 'weighted_random',
+				'variant'            => 'control',
+				'surface'            => 'single-post-bridge',
 			)
 		);
 		extrachill_analytics_record_experiment_exposure(
 			array(
-				'experiment_key' => 'geo-bridge-holdout',
-				'variant'        => 'treatment',
-				'surface'        => 'single-post-bridge',
+				'experiment_key'     => 'artist-cta-copy',
+				'definition_version' => 3,
+				'assignment_policy'  => 'weighted_random',
+				'variant'            => 'challenger-b',
+				'surface'            => 'artist-link-page',
 			)
 		);
 
@@ -137,13 +156,15 @@ final class EventContractsTest extends TestCase {
 		$this->assertSame( EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE, $GLOBALS['extrachill_analytics_test_events'][1][0] );
 		$this->assertSame(
 			array(
-				'experiment_key' => 'geo-bridge-holdout',
-				'variant'        => 'control',
-				'surface'        => 'single-post-bridge',
+				'experiment_key'     => 'geo-bridge-holdout',
+				'definition_version' => 1,
+				'assignment_policy'  => 'weighted_random',
+				'variant'            => 'control',
+				'surface'            => 'single-post-bridge',
 			),
 			$GLOBALS['extrachill_analytics_test_events'][0][1]
 		);
-		$this->assertSame( array( 'experiment_key', 'variant', 'surface' ), array_keys( $GLOBALS['extrachill_analytics_test_events'][1][1] ) );
+		$this->assertSame( array( 'experiment_key', 'definition_version', 'assignment_policy', 'variant', 'surface' ), array_keys( $GLOBALS['extrachill_analytics_test_events'][1][1] ) );
 	}
 
 	/**
@@ -174,10 +195,12 @@ final class EventContractsTest extends TestCase {
 			extrachill_analytics_record_experiment_event(
 				EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT,
 				array(
-					'experiment_key' => 'geo-bridge-holdout',
-					'variant'        => 'control',
-					'surface'        => 'single-post-bridge',
-					'extra'          => 'rejected',
+					'experiment_key'     => 'geo-bridge-holdout',
+					'definition_version' => 1,
+					'assignment_policy'  => 'weighted_random',
+					'variant'            => 'control',
+					'surface'            => 'single-post-bridge',
+					'extra'              => 'rejected',
 				)
 			)
 		);
@@ -186,14 +209,16 @@ final class EventContractsTest extends TestCase {
 	/**
 	 * The persistence listener rejects drift and privacy exclusion.
 	 */
-	public function test_experiment_listener_rejects_unregistered_contract_values(): void {
+	public function test_experiment_listener_rejects_unbounded_contract_values(): void {
 		$this->assertFalse(
 			extrachill_analytics_record_experiment_event(
 				EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT,
 				array(
-					'experiment_key' => 'other',
-					'variant'        => 'control',
-					'surface'        => 'single-post-bridge',
+					'experiment_key'     => 'invalid key',
+					'definition_version' => 1,
+					'assignment_policy'  => 'weighted_random',
+					'variant'            => 'control',
+					'surface'            => 'single-post-bridge',
 				)
 			)
 		);
@@ -201,9 +226,11 @@ final class EventContractsTest extends TestCase {
 			extrachill_analytics_record_experiment_event(
 				EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT,
 				array(
-					'experiment_key' => 'geo-bridge-holdout',
-					'variant'        => 'challenger',
-					'surface'        => 'single-post-bridge',
+					'experiment_key'     => 'geo-bridge-holdout',
+					'definition_version' => 0,
+					'assignment_policy'  => 'weighted_random',
+					'variant'            => 'challenger',
+					'surface'            => 'single-post-bridge',
 				)
 			)
 		);
@@ -211,9 +238,11 @@ final class EventContractsTest extends TestCase {
 			extrachill_analytics_record_experiment_event(
 				EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE,
 				array(
-					'experiment_key' => 'geo-bridge-holdout',
-					'variant'        => 'treatment',
-					'surface'        => 'other',
+					'experiment_key'     => 'geo-bridge-holdout',
+					'definition_version' => 1,
+					'assignment_policy'  => str_repeat( 'x', 65 ),
+					'variant'            => 'treatment',
+					'surface'            => 'other',
 				)
 			)
 		);
@@ -223,9 +252,11 @@ final class EventContractsTest extends TestCase {
 			extrachill_analytics_record_experiment_event(
 				EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE,
 				array(
-					'experiment_key' => 'geo-bridge-holdout',
-					'variant'        => 'treatment',
-					'surface'        => 'single-post-bridge',
+					'experiment_key'     => 'geo-bridge-holdout',
+					'definition_version' => 1,
+					'assignment_policy'  => 'weighted_random',
+					'variant'            => 'treatment',
+					'surface'            => 'single-post-bridge',
 				)
 			)
 		);

--- a/tests/ExperimentSummaryTest.php
+++ b/tests/ExperimentSummaryTest.php
@@ -70,6 +70,39 @@ final class ExperimentSummaryTest extends TestCase {
 		$this->assertStringContainsString( 'not observable', $report['coverage']['gpc_dnt'] );
 	}
 
+	/** Oversized stored versions cannot affect an unfiltered summary or its diagnostics. */
+	public function test_unfiltered_oversized_version_is_fully_rejected(): void {
+		$options                       = $this->options( null );
+		$options['instrumented_types'] = array( 'experiment_assignment', 'experiment_exposure', 'newsletter_signup' );
+		$rows                          = array(
+			$this->row( 1, 'experiment_assignment', 100, 'visitor-control', 0, $this->experiment( 'copy-test', 1, 'control', 'hero' ) ),
+			$this->row( 2, 'newsletter_signup', 110, 'visitor-control' ),
+			$this->row( 3, 'experiment_assignment', 120, 'visitor-oversized', 0, $this->experiment( 'copy-test', 1000001, 'treatment', 'hero' ) ),
+			$this->row( 4, 'experiment_exposure', 130, 'visitor-oversized', 0, $this->experiment( 'copy-test', 1000001, 'treatment', 'hero' ) ),
+			$this->row( 5, 'newsletter_signup', 140, 'visitor-oversized' ),
+		);
+		$report                        = extrachill_analytics_build_experiment_summary( $rows, $options );
+		$control                       = $report['variants'][0];
+		$treatment                     = $report['variants'][1];
+
+		$this->assertFalse( extrachill_analytics_experiment_summary_contract_matches( extrachill_analytics_experiment_normalize_event( $rows[2] ), $options ) );
+		$this->assertSame( 1, $control['assignment']['people'] );
+		$this->assertSame( 1, $control['outcomes']['newsletter_signup']['after_assignment']['people'] );
+		$this->assertSame( 0, $treatment['assignment']['people'] );
+		$this->assertSame( 0, $treatment['exposure']['people'] );
+		$this->assertSame( 0, $treatment['outcomes']['newsletter_signup']['after_assignment']['people'] );
+		$this->assertNull( $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['absolute'] );
+		$this->assertNull( $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['relative'] );
+		$this->assertSame( 'zero_denominator', $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['status'] );
+		$this->assertSame( 2, $report['coverage']['invalid_contract_rows'] );
+		$this->assertSame( 1, $report['coverage']['unattributed_outcome_events'] );
+		$this->assertSame( array( 1 => 1 ), $report['version_diagnostics']['observed_event_rows_by_version'] );
+		$this->assertFalse( $report['version_diagnostics']['mixed_versions_observed'] );
+		$this->assertArrayNotHasKey( 1000001, $report['version_diagnostics']['observed_event_rows_by_version'] );
+		$this->assertSame( 1, $report['coverage']['identified_assignment_people'] );
+		$this->assertSame( 0, $report['coverage']['identified_exposure_people'] );
+	}
+
 	/** Zero denominators and absent instrumentation return null with explicit status. */
 	public function test_zero_denominator_and_no_instrumentation_states(): void {
 		$report    = extrachill_analytics_build_experiment_summary(

--- a/tests/ExperimentSummaryTest.php
+++ b/tests/ExperimentSummaryTest.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Tests for generic bounded experiment summaries.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/event-types.php';
+require_once dirname( __DIR__ ) . '/inc/core/experiment-reporting.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-experiment-summary.php';
+
+/** Protect generic experiment attribution, statistics, and bounds. */
+final class ExperimentSummaryTest extends TestCase {
+	/**
+	 * Multiple keys, versions, surfaces, variants, identities, and lossy rows stay honest.
+	 */
+	public function test_generic_fixture_matrix(): void {
+		$rows      = array(
+			$this->row( 1, 'newsletter_signup', 90, 'visitor-control' ),
+			$this->row( 2, 'experiment_assignment', 100, 'visitor-control', 0, $this->experiment( 'copy-test', 1, 'control', 'hero' ) ),
+			$this->row( 3, 'experiment_assignment', 101, 'visitor-control', 0, $this->experiment( 'copy-test', 1, 'control', 'hero' ) ),
+			$this->row( 4, 'experiment_exposure', 110, 'visitor-control', 0, $this->experiment( 'copy-test', 1, 'control', 'hero' ) ),
+			$this->row( 5, 'newsletter_signup', 120, 'visitor-control', 10, array( 'user_id' => 10 ) ),
+			$this->row( 6, 'newsletter_signup', 121, 'visitor-control', 10, array( 'user_id' => 10 ) ),
+			$this->row( 7, 'experiment_assignment', 130, 'visitor-control-2', 0, $this->experiment( 'copy-test', 1, 'control', 'footer' ) ),
+			$this->row( 8, 'experiment_assignment', 200, 'visitor-treatment', 0, $this->experiment( 'copy-test', 1, 'treatment', 'hero' ) ),
+			$this->row( 9, 'experiment_exposure', 210, 'visitor-treatment', 0, $this->experiment( 'copy-test', 1, 'treatment', 'hero' ) ),
+			$this->row( 10, 'newsletter_signup', 220, 'visitor-treatment' ),
+			$this->row( 11, 'experiment_assignment', 230, 'visitor-treatment-2', 0, $this->experiment( 'copy-test', 1, 'treatment', 'footer' ) ),
+			$this->row( 12, 'pageview', 4000, 'visitor-treatment-2' ),
+			$this->row( 13, 'newsletter_signup', 4010, 'visitor-treatment-2' ),
+			$this->row( 14, 'experiment_assignment', 240, 'visitor-other', 0, $this->experiment( 'other-test', 1, 'control', 'hero' ) ),
+			$this->row( 15, 'experiment_assignment', 250, 'visitor-v2', 0, $this->experiment( 'copy-test', 2, 'control', 'hero' ) ),
+			$this->row( 16, 'experiment_assignment', 260, 'visitor-bot', 0, array_merge( $this->experiment( 'copy-test', 1, 'control', 'hero' ), array( 'is_bot' => true ) ) ),
+			$this->row( 17, 'experiment_assignment', 270, '', 0, $this->experiment( 'copy-test', 1, 'control', 'hero' ) ),
+			$this->row( 18, 'experiment_assignment', 280, 'visitor-ambiguous', 0, $this->experiment( 'copy-test', 1, 'control', 'hero' ) ),
+			$this->row( 19, 'newsletter_signup', 290, 'visitor-ambiguous', 70, array( 'user_id' => 70 ) ),
+			$this->row( 20, 'newsletter_signup', 291, 'visitor-ambiguous', 71, array( 'user_id' => 71 ) ),
+		);
+		$report    = extrachill_analytics_build_experiment_summary( $rows, $this->options( 1 ) );
+		$control   = $report['variants'][0];
+		$treatment = $report['variants'][1];
+
+		$this->assertSame( 'measured', $report['state'] );
+		$this->assertSame( 3, $control['assignment']['people'] );
+		$this->assertSame( 4, $control['assignment']['stored_events'] );
+		$this->assertSame( 1, $control['exposure']['people'] );
+		$this->assertSame( 0.3333, $control['exposure']['rate'] );
+		$this->assertSame( 2, $treatment['assignment']['people'] );
+		$this->assertSame( 1, $treatment['exposure']['people'] );
+		$this->assertSame( 1, $control['outcomes']['newsletter_signup']['after_assignment']['people'] );
+		$this->assertSame( 2, $treatment['outcomes']['newsletter_signup']['after_assignment']['people'] );
+		$this->assertSame( 1, $treatment['outcomes']['newsletter_signup']['after_assignment']['later_session_people'] );
+		$this->assertSame( 1.0, $treatment['outcomes']['newsletter_signup']['after_assignment']['rate'] );
+		$this->assertSame( 0.6667, $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['absolute'] );
+		$this->assertSame( 2.0, $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['relative'] );
+		$this->assertNotNull( $treatment['outcomes']['newsletter_signup']['after_assignment']['rate_ci_95'] );
+		$this->assertNotNull( $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['relative_ci_95'] );
+		$this->assertSame( 1, $report['coverage']['duplicate_assignment_events'] );
+		$this->assertSame( 1, $report['coverage']['pre_assignment_outcome_events'] );
+		$this->assertSame( 1, $report['coverage']['bot_rows_excluded'] );
+		$this->assertSame( 1, $report['coverage']['ambiguous_visitor_ids'] );
+		$this->assertSame( 1, $report['coverage']['other_experiment_rows'] );
+		$this->assertSame( 1, $report['coverage']['other_definition_version_rows'] );
+		$this->assertTrue( $report['version_diagnostics']['mixed_versions_observed'] );
+		$this->assertSame( array( 'hero', 'footer' ), $report['version_diagnostics']['surfaces'] );
+		$this->assertStringContainsString( 'not observable', $report['coverage']['gpc_dnt'] );
+	}
+
+	/** Zero denominators and absent instrumentation return null with explicit status. */
+	public function test_zero_denominator_and_no_instrumentation_states(): void {
+		$report    = extrachill_analytics_build_experiment_summary(
+			array( $this->row( 1, 'experiment_assignment', 100, 'visitor-control', 0, $this->experiment( 'copy-test', 1, 'control', 'hero' ) ) ),
+			$this->options( 1 )
+		);
+		$treatment = $report['variants'][1];
+
+		$this->assertNull( $treatment['exposure']['rate'] );
+		$this->assertNull( $treatment['outcomes']['newsletter_signup']['after_assignment']['rate'] );
+		$this->assertSame( 'zero_denominator', $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['status'] );
+
+		$options                       = $this->options( 1 );
+		$options['instrumented_types'] = array();
+		$empty                         = extrachill_analytics_build_experiment_summary( array(), $options );
+		$this->assertSame( 'not_instrumented', $empty['state'] );
+		$this->assertNull( $empty['variants'][0]['assignment']['people'] );
+		$this->assertNull( $empty['variants'][0]['outcomes']['newsletter_signup']['after_assignment'] );
+	}
+
+	/** Truncation is retained next to observed values. */
+	public function test_truncation_is_explicit(): void {
+		$options              = $this->options( 1 );
+		$options['truncated'] = true;
+		$report               = extrachill_analytics_build_experiment_summary(
+			array( $this->row( 1, 'experiment_assignment', 100, 'visitor-control', 0, $this->experiment( 'copy-test', 1, 'control', 'hero' ) ) ),
+			$options
+		);
+
+		$this->assertSame( 'truncated', $report['state'] );
+		$this->assertSame( 'truncated', $report['variants'][0]['assignment']['coverage_status'] );
+	}
+
+	/** Wilson intervals and lift math stay deterministic and never select a winner. */
+	public function test_confidence_and_lift_math(): void {
+		$this->assertSame(
+			array(
+				'lower' => 0.2366,
+				'upper' => 0.7634,
+			),
+			extrachill_analytics_experiment_wilson_interval( 5, 10 )
+		);
+		$lift = extrachill_analytics_experiment_lift( 8, 10, 5, 10 );
+
+		$this->assertSame( 0.3, $lift['absolute'] );
+		$this->assertSame( 0.6, $lift['relative'] );
+		$this->assertSame( 'measured', $lift['status'] );
+		$this->assertArrayNotHasKey( 'winner', $lift );
+	}
+
+	/** Ability input is private, exact, bounded, and canonical-outcome-only. */
+	public function test_ability_contract_and_input_validation(): void {
+		extrachill_analytics_register_experiment_summary_ability();
+		$ability = $GLOBALS['extrachill_analytics_registered_abilities']['extrachill/get-experiment-summary'];
+
+		$this->assertFalse( $ability['meta']['show_in_rest'] );
+		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
+		$this->assertSame( EC_ANALYTICS_EXPERIMENT_MAX_VARIANTS, $ability['input_schema']['properties']['variants']['maxItems'] );
+		$this->assertSame( EC_ANALYTICS_EXPERIMENT_MAX_OUTCOMES, $ability['input_schema']['properties']['outcome_event_types']['maxItems'] );
+
+		$invalid = extrachill_analytics_experiment_summary_options(
+			array(
+				'experiment_key'      => 'copy-test',
+				'control_variant'     => 'control',
+				'variants'            => array( 'control', 'treatment' ),
+				'outcome_event_types' => array( 'free_form_event' ),
+			)
+		);
+		$this->assertInstanceOf( WP_Error::class, $invalid );
+		$this->assertSame( 'invalid_experiment_summary_outcome', $invalid->code );
+	}
+
+	/**
+	 * Build canonical versioned metadata.
+	 *
+	 * @param string $key     Experiment key.
+	 * @param int    $version Definition version.
+	 * @param string $variant Variant.
+	 * @param string $surface Surface.
+	 * @return array Metadata.
+	 */
+	private function experiment( string $key, int $version, string $variant, string $surface ): array {
+		return array(
+			'experiment_key'     => $key,
+			'definition_version' => $version,
+			'assignment_policy'  => 'weighted_random',
+			'variant'            => $variant,
+			'surface'            => $surface,
+		);
+	}
+
+	/**
+	 * Build one stored fixture row.
+	 *
+	 * @param int    $id         Row ID.
+	 * @param string $event_type Event type.
+	 * @param int    $timestamp  UTC timestamp.
+	 * @param string $visitor_id Visitor ID.
+	 * @param int    $user_id    User ID.
+	 * @param array  $event_data Event payload.
+	 * @return object Stored row.
+	 */
+	private function row( int $id, string $event_type, int $timestamp, string $visitor_id = '', int $user_id = 0, array $event_data = array() ): object {
+		return (object) array(
+			'id'         => $id,
+			'event_type' => $event_type,
+			'event_data' => wp_json_encode( $event_data ),
+			'source_url' => '',
+			'blog_id'    => 1,
+			'user_id'    => $user_id,
+			'visitor_id' => $visitor_id,
+			'created_at' => gmdate( 'Y-m-d H:i:s', $timestamp ),
+			'ts'         => $timestamp,
+		);
+	}
+
+	/**
+	 * Return deterministic report options.
+	 *
+	 * @param int|null $version Requested definition version.
+	 * @return array Report options.
+	 */
+	private function options( ?int $version ): array {
+		return array(
+			'experiment_key'          => 'copy-test',
+			'definition_version'      => $version,
+			'control_variant'         => 'control',
+			'variants'                => array( 'control', 'treatment' ),
+			'outcome_event_types'     => array( 'newsletter_signup' ),
+			'since'                   => '1970-01-01 00:00:00',
+			'as_of'                   => '1970-01-02 00:00:00',
+			'days'                    => 1,
+			'attribution_window_days' => 1,
+			'session_gap_mins'        => 30,
+			'max_events'              => 50000,
+			'truncated'               => false,
+			'instrumented_types'      => array( 'experiment_assignment', 'experiment_exposure', 'pageview', 'newsletter_signup' ),
+		);
+	}
+}

--- a/tests/ExperimentSummaryTest.php
+++ b/tests/ExperimentSummaryTest.php
@@ -103,6 +103,35 @@ final class ExperimentSummaryTest extends TestCase {
 		$this->assertSame( 0, $report['coverage']['identified_exposure_people'] );
 	}
 
+	/** Invalid experiment rows cannot contaminate otherwise valid identity bridges. */
+	public function test_oversized_assignment_cannot_create_cross_variant_identity_edge(): void {
+		$options   = $this->options( null );
+		$rows      = array(
+			$this->row( 1, 'experiment_assignment', 100, 'visitor-control', 0, $this->experiment( 'copy-test', 1, 'control', 'hero' ) ),
+			$this->row( 2, 'newsletter_signup', 110, 'visitor-control', 10, array( 'user_id' => 10 ) ),
+			$this->row( 3, 'experiment_assignment', 120, 'visitor-treatment', 20, $this->experiment( 'copy-test', 1, 'treatment', 'hero' ) ),
+			$this->row( 4, 'newsletter_signup', 130, 'visitor-treatment', 20, array( 'user_id' => 20 ) ),
+			$this->row( 5, 'experiment_assignment', 140, 'visitor-control', 20, $this->experiment( 'copy-test', 1000001, 'treatment', 'hero' ) ),
+		);
+		$report    = extrachill_analytics_build_experiment_summary( $rows, $options );
+		$control   = $report['variants'][0];
+		$treatment = $report['variants'][1];
+
+		$this->assertSame( 1, $control['assignment']['people'] );
+		$this->assertSame( 1, $treatment['assignment']['people'] );
+		$this->assertSame( 1, $control['outcomes']['newsletter_signup']['after_assignment']['people'] );
+		$this->assertSame( 1, $treatment['outcomes']['newsletter_signup']['after_assignment']['people'] );
+		$this->assertSame( 0.0, $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['absolute'] );
+		$this->assertSame( 0.0, $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['relative'] );
+		$this->assertSame( 0, $report['coverage']['ambiguous_visitor_ids'] );
+		$this->assertSame( 2, $report['coverage']['unambiguous_identity_bridges'] );
+		$this->assertSame( 1, $report['coverage']['invalid_contract_rows'] );
+		$this->assertSame( 0, $report['coverage']['duplicate_assignment_events'] );
+		$this->assertSame( 0, $report['coverage']['conflicting_assignment_events'] );
+		$this->assertSame( array( 1 => 2 ), $report['version_diagnostics']['observed_event_rows_by_version'] );
+		$this->assertFalse( $report['version_diagnostics']['mixed_versions_observed'] );
+	}
+
 	/** Zero denominators and absent instrumentation return null with explicit status. */
 	public function test_zero_denominator_and_no_instrumentation_states(): void {
 		$report    = extrachill_analytics_build_experiment_summary(

--- a/tests/ExperimentSummaryTest.php
+++ b/tests/ExperimentSummaryTest.php
@@ -57,7 +57,8 @@ final class ExperimentSummaryTest extends TestCase {
 		$this->assertSame( 0.6667, $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['absolute'] );
 		$this->assertSame( 2.0, $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['relative'] );
 		$this->assertNotNull( $treatment['outcomes']['newsletter_signup']['after_assignment']['rate_ci_95'] );
-		$this->assertNotNull( $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['relative_ci_95'] );
+		$this->assertNull( $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['relative_ci_95'] );
+		$this->assertSame( 'insufficient_data', $treatment['outcomes']['newsletter_signup']['after_assignment']['lift_vs_control']['status'] );
 		$this->assertSame( 1, $report['coverage']['duplicate_assignment_events'] );
 		$this->assertSame( 1, $report['coverage']['pre_assignment_outcome_events'] );
 		$this->assertSame( 1, $report['coverage']['bot_rows_excluded'] );
@@ -102,7 +103,7 @@ final class ExperimentSummaryTest extends TestCase {
 		$this->assertSame( 'truncated', $report['variants'][0]['assignment']['coverage_status'] );
 	}
 
-	/** Wilson intervals and lift math stay deterministic and never select a winner. */
+	/** Wilson intervals and normal lift math stay deterministic and never select a winner. */
 	public function test_confidence_and_lift_math(): void {
 		$this->assertSame(
 			array(
@@ -111,12 +112,164 @@ final class ExperimentSummaryTest extends TestCase {
 			),
 			extrachill_analytics_experiment_wilson_interval( 5, 10 )
 		);
-		$lift = extrachill_analytics_experiment_lift( 8, 10, 5, 10 );
+		$lift = extrachill_analytics_experiment_lift( 80, 100, 50, 100 );
 
 		$this->assertSame( 0.3, $lift['absolute'] );
 		$this->assertSame( 0.6, $lift['relative'] );
+		$this->assertSame(
+			array(
+				'lower' => 0.1691,
+				'upper' => 0.417,
+			),
+			$lift['absolute_ci_95']
+		);
+		$this->assertSame(
+			array(
+				'lower' => 0.2851,
+				'upper' => 0.992,
+			),
+			$lift['relative_ci_95']
+		);
 		$this->assertSame( 'measured', $lift['status'] );
 		$this->assertArrayNotHasKey( 'winner', $lift );
+	}
+
+	/**
+	 * Newcombe absolute intervals remain valid while Katz fails closed at boundaries.
+	 *
+	 * @dataProvider lift_boundary_provider
+	 *
+	 * @param int   $successes         Variant successes.
+	 * @param int   $total             Variant denominator.
+	 * @param int   $control_successes Control successes.
+	 * @param int   $control_total     Control denominator.
+	 * @param array $expected          Exact expected lift output.
+	 */
+	public function test_lift_boundary_intervals( $successes, $total, $control_successes, $control_total, $expected ): void {
+		$this->assertSame(
+			$expected,
+			extrachill_analytics_experiment_lift( $successes, $total, $control_successes, $control_total )
+		);
+	}
+
+	/** Return saturated, zero-boundary, and small-sample lift fixtures. */
+	public function lift_boundary_provider(): array {
+		return array(
+			'saturated 1/1 versus 1/1' => array(
+				1,
+				1,
+				1,
+				1,
+				array(
+					'absolute'       => 0.0,
+					'relative'       => 0.0,
+					'absolute_ci_95' => array(
+						'lower' => -0.7935,
+						'upper' => 0.7935,
+					),
+					'relative_ci_95' => null,
+					'status'         => 'insufficient_data',
+				),
+			),
+			'zero variant successes'   => array(
+				0,
+				10,
+				2,
+				10,
+				array(
+					'absolute'       => -0.2,
+					'relative'       => -1.0,
+					'absolute_ci_95' => array(
+						'lower' => -0.5098,
+						'upper' => 0.1124,
+					),
+					'relative_ci_95' => null,
+					'status'         => 'insufficient_data',
+				),
+			),
+			'zero control successes'   => array(
+				2,
+				10,
+				0,
+				10,
+				array(
+					'absolute'       => 0.2,
+					'relative'       => null,
+					'absolute_ci_95' => array(
+						'lower' => -0.1124,
+						'upper' => 0.5098,
+					),
+					'relative_ci_95' => null,
+					'status'         => 'insufficient_data',
+				),
+			),
+			'zero variant failures'    => array(
+				10,
+				10,
+				8,
+				10,
+				array(
+					'absolute'       => 0.2,
+					'relative'       => 0.25,
+					'absolute_ci_95' => array(
+						'lower' => -0.1124,
+						'upper' => 0.5098,
+					),
+					'relative_ci_95' => null,
+					'status'         => 'insufficient_data',
+				),
+			),
+			'zero control failures'    => array(
+				8,
+				10,
+				10,
+				10,
+				array(
+					'absolute'       => -0.2,
+					'relative'       => -0.2,
+					'absolute_ci_95' => array(
+						'lower' => -0.5098,
+						'upper' => 0.1124,
+					),
+					'relative_ci_95' => null,
+					'status'         => 'insufficient_data',
+				),
+			),
+			'small interior sample'    => array(
+				2,
+				5,
+				1,
+				5,
+				array(
+					'absolute'       => 0.2,
+					'relative'       => 1.0,
+					'absolute_ci_95' => array(
+						'lower' => -0.3098,
+						'upper' => 0.604,
+					),
+					'relative_ci_95' => array(
+						'lower' => -0.744,
+						'upper' => 14.6235,
+					),
+					'status'         => 'measured',
+				),
+			),
+		);
+	}
+
+	/** Missing exposure instrumentation is distinct from a measured zero denominator. */
+	public function test_absent_exposure_instrumentation_status(): void {
+		$options                       = $this->options( 1 );
+		$options['instrumented_types'] = array( 'experiment_assignment', 'newsletter_signup' );
+		$report                        = extrachill_analytics_build_experiment_summary(
+			array( $this->row( 1, 'experiment_assignment', 100, 'visitor-control', 0, $this->experiment( 'copy-test', 1, 'control', 'hero' ) ) ),
+			$options
+		);
+
+		$this->assertNull( $report['variants'][0]['exposure']['rate'] );
+		$this->assertNull( $report['variants'][0]['exposure']['rate_ci_95'] );
+		$this->assertSame( 'not_instrumented', $report['variants'][0]['exposure']['rate_status'] );
+		$this->assertSame( 'not_instrumented', $report['variants'][0]['exposure']['coverage_status'] );
 	}
 
 	/** Ability input is private, exact, bounded, and canonical-outcome-only. */


### PR DESCRIPTION
## Summary
- generalize trusted Network assignment/exposure persistence to exact, bounded versioned metadata for any code-registered experiment while rejecting experiment events from the flexible tracking Ability
- add the private `extrachill/get-experiment-summary` Ability with stable keyset reads, bounded identity state, assignment/exposure separation, canonical outcome dedupe, version diagnostics, lift, and confidence intervals
- extract only the shared row, ordering, and identity primitives from the geographic report so its broad-click, route, lifecycle interpretation and output remain compatible

## Generic Ability
Required inputs:
- `experiment_key`: one bounded canonical key
- `control_variant`: declared control
- `variants`: 2-8 unique declared variants including control

Optional inputs:
- `definition_version`: positive integer up to 1,000,000; omission reports across observed valid versions with mixing diagnostics
- `outcome_event_types`: up to 10 code-declared canonical Analytics outcomes
- `days`: 1-90
- `attribution_window_days`: 1-90
- `session_gap_mins`: 1-120
- `max_events`: 100-100,000

Output reports assignment people/events, descriptive exposure people/events/rates, per-person deduplicated outcomes after assignment, optional descriptive exposure-conditioned outcomes, absolute/relative lift against control, rate intervals, identity/privacy coverage, truncation, and definition-version/surface/policy diagnostics. It never infers exposure or declares a winner.

## Statistical Method
- assignment outcome rates use assigned people as intent-to-treat denominators
- exposure-conditioned rates use observed exposed people and are labeled descriptive
- rate intervals are 95% Wilson score intervals
- absolute lift uses the Newcombe-Wilson hybrid-score difference-of-proportions 95% interval
- relative lift uses a Katz log risk-ratio interval only when both arms have nonzero successes and nonzero failures
- boundary or unsupported relative intervals are null with `insufficient_data`; zero denominators remain explicit
- saturated 1/1, both zero-success boundaries, both zero-failure boundaries, small interior samples, and normal measured samples have exact fixture assertions

## Persistence, Identity, And Privacy
Trusted Network hooks must supply exactly `experiment_key`, `definition_version`, `assignment_policy`, `variant`, and `surface`, with canonical 1-64 character identifiers and a positive version no greater than 1,000,000. Existing `ec_vid`, GPC, and DNT providers remain unchanged. The flexible `extrachill/track-analytics-event` Ability explicitly rejects assignment and exposure event types.

Bot rows are excluded first. Experiment rows then pass key, version, policy, variant, and surface contract classification before visitor/user identity edges are constructed. Rejected or filtered experiment rows remain diagnosed but cannot create identity bridges, ambiguity, cohort collisions, outcome attribution, or lift changes. Canonical non-experiment outcome/pageview rows remain eligible identity evidence.

## Coverage And Bounds
- ascending `(created_at, id)` keyset pagination, 500 rows per page
- one truncation sentinel beyond the configured hard row ceiling
- at most 8 variants and 10 outcomes
- first valid assignment fixes person, variant, and version
- exposure must match assignment variant, version, policy, and surface
- stored versions above 1,000,000 are invalid before version filtering or diagnostics and cannot enter cohorts, outcomes, lift, version mixing, or identity edges
- missing exposure instrumentation reports `not_instrumented`, never `zero_denominator`
- outcomes must follow their anchor, fit the attribution window, and count once per person/outcome/lens
- diagnostics cover mixed valid versions, duplicate/conflicting rows, invalid oversized versions, pre-assignment outcomes, bot/unidentified/ambiguous identities, GPC/DNT observability, missing instrumentation, no data, and truncation

## Compatibility
`extrachill/get-geo-bridge-experiment` retains its exact output contract and domain-specific broad-click, route-transition, and lifecycle caveats. Only its generic keyset reader, row normalization, strict ordering, and person-key helpers moved to shared primitives.

## Verification
- focused experiment summary suite -> 14 tests, 85 assertions
- `vendor/bin/phpunit` -> 383 tests, 1,532 assertions
- changed-file `vendor/bin/phpcs --standard=WordPress --extensions=php ...` -> clean
- `php -l` for changed implementation and fixtures -> clean
- `git diff --check` -> clean

Closes #211