### PR TITLE
fix: sanitize outbound analytics source URLs

### DIFF
--- a/assets/js/outbound-tracking.js
+++ b/assets/js/outbound-tracking.js
@@ -26,7 +26,7 @@
 	function send( destUrl, destHost ) {
 		var payload = {
 			click_type: 'outbound',
-			source_url: window.location.href,
+			source_url: window.location.origin + window.location.pathname,
 			destination_url: destUrl,
 			dest_host: destHost,
 		};
@@ -79,7 +79,7 @@
 				return;
 			}
 
-			send( url.href, host );
+			send( url.origin + url.pathname, host );
 		},
 		true
 	);

--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -39,6 +39,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/outbound-classifier.php
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/mediavine-csv-import.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/revenue-content-attribution.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/isbot-backfill.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/source-url-backfill.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/view-counts.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/link-page-analytics.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/assets.php';

--- a/inc/core/abilities.php
+++ b/inc/core/abilities.php
@@ -155,6 +155,15 @@ function extrachill_analytics_ability_track_event( $input ) {
 	$source_url = $admission['source_url'];
 	if ( in_array( $event_type, extrachill_analytics_public_browser_event_types(), true ) ) {
 		$visitor_id = function_exists( 'extrachill_analytics_read_visitor_id' ) ? extrachill_analytics_read_visitor_id() : '';
+		if ( function_exists( 'extrachill_analytics_classify_request' ) ) {
+			$verdict              = extrachill_analytics_classify_request(
+				array(
+					'has_visitor_cookie' => '' !== $visitor_id,
+					'request_origin'     => 'web',
+				)
+			);
+			$event_data['is_bot'] = (bool) $verdict['is_bot'];
+		}
 	}
 
 	// Defense-in-depth: if a 'search' event arrives with a payload-shaped term,

--- a/inc/core/abilities/get-outbound-clicks.php
+++ b/inc/core/abilities/get-outbound-clicks.php
@@ -11,10 +11,9 @@
  *
  * Why this is the first-party exit channel:
  *
- *   Each `outbound_click` row is fired client-side with sendBeacon and
- *   therefore only exists for a real, JS-executing browser. The generic
- *   request classifier currently stamps these REST beacons as bots, so this
- *   report deliberately counts outbound_click rows regardless of that stamp.
+ *   Each `outbound_click` row is fired client-side with sendBeacon. The public
+ *   write boundary classifies that validated browser beacon with the canonical
+ *   visitor classifier, and this report includes only human-stamped rows.
  *   Rows carry the anonymous first-party visitor_id (NULL under GPC/DNT
  *   opt-out, excluded from per-visitor cuts exactly like the rest of the
  *   system).
@@ -74,8 +73,8 @@ function extrachill_analytics_register_outbound_clicks_ability() {
 					),
 					'include_bots' => array(
 						'type'        => 'boolean',
-						'description' => __( 'Deprecated compatibility option. Outbound browser beacons are always included because the generic REST bot stamp does not distinguish them from bots.', 'extrachill-analytics' ),
-						'default'     => true,
+						'description' => __( 'Include bot-stamped outbound events for diagnostics. Human-only by default.', 'extrachill-analytics' ),
+						'default'     => false,
 					),
 				),
 			),
@@ -105,11 +104,10 @@ function extrachill_analytics_register_outbound_clicks_ability() {
  * Strategy: pull the in-window `outbound_click` rows (bounded by the
  * event_type + created_at index) and aggregate in PHP. event_data carries the
  * dest_host, dest_url, and category the capture route stamped — so the read
- * does not re-derive classification, it just rolls up. The generic REST is_bot
- * stamp is intentionally not used: browser beacons are consistently marked as
- * bots despite being the canonical outbound signal. Volume is low (a new
- * event), so a single bounded fetch + PHP aggregation is clearer and cheaper
- * than three GROUP-BY JSON queries.
+ * does not re-derive destination classification, it just rolls up. The
+ * server-owned is_bot stamp enforces the default human-only report contract.
+ * Volume is low, so a single bounded fetch + PHP aggregation is clearer and
+ * cheaper than three GROUP-BY JSON queries.
  *
  * @param array $input Input parameters.
  * @return array Outbound-click report.
@@ -117,11 +115,12 @@ function extrachill_analytics_register_outbound_clicks_ability() {
 function extrachill_analytics_ability_get_outbound_clicks( $input ) {
 	global $wpdb;
 
-	$days       = isset( $input['days'] ) ? (int) $input['days'] : 28;
-	$blog_id    = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
-	$category   = isset( $input['category'] ) ? sanitize_key( (string) $input['category'] ) : '';
-	$limit      = isset( $input['limit'] ) ? max( 1, (int) $input['limit'] ) : 25;
-	$event_type = EC_ANALYTICS_EVENT_OUTBOUND_CLICK;
+	$days         = isset( $input['days'] ) ? (int) $input['days'] : 28;
+	$blog_id      = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
+	$category     = isset( $input['category'] ) ? sanitize_key( (string) $input['category'] ) : '';
+	$limit        = isset( $input['limit'] ) ? max( 1, (int) $input['limit'] ) : 25;
+	$include_bots = ! empty( $input['include_bots'] );
+	$event_type   = EC_ANALYTICS_EVENT_OUTBOUND_CLICK;
 
 	// Read the in-window outbound_click rows through the canonical events query
 	// helper (it owns the safe, prepared WHERE building) rather than re-rolling
@@ -162,6 +161,9 @@ function extrachill_analytics_ability_get_outbound_clicks( $input ) {
 	foreach ( (array) $rows as $row ) {
 		// extrachill_get_analytics_events() returns event_data already decoded.
 		$data = is_array( $row->event_data ) ? $row->event_data : array();
+		if ( ! $include_bots && ( ! array_key_exists( 'is_bot', $data ) || false !== $data['is_bot'] ) ) {
+			continue;
+		}
 
 		$dest_host = isset( $data['dest_host'] ) ? strtolower( (string) $data['dest_host'] ) : '';
 
@@ -197,7 +199,9 @@ function extrachill_analytics_ability_get_outbound_clicks( $input ) {
 			++$missing_destination_dimensions;
 		}
 
-		$source = (string) $row->source_url;
+		$source = function_exists( 'extrachill_analytics_canonicalize_tracked_url' )
+			? extrachill_analytics_canonicalize_tracked_url( (string) $row->source_url )
+			: '';
 		if ( '' !== $source ) {
 			if ( ! isset( $by_source[ $source ] ) ) {
 				$by_source[ $source ] = 0;
@@ -279,6 +283,6 @@ function extrachill_analytics_ability_get_outbound_clicks( $input ) {
 		'period'         => $days > 0
 			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
 			: 'all time',
-		'note'           => 'Outbound clicks fire client-side (sendBeacon) and are counted regardless of the generic REST bot stamp, which does not distinguish these browser beacons from bots. The outbound_click event captures exits going forward only, so totals are low/zero until clicks accumulate. NULL-visitor rows (GPC/DNT opt-out) are still counted in aggregate volume but excluded from any per-visitor cut, same as the rest of the system.',
+		'note'           => $include_bots ? 'Outbound clicks include bot-stamped rows for diagnostics.' : 'Outbound clicks are limited to events classified as human at the server-owned write boundary. Source and destination URLs are reduced to origin plus path.',
 	);
 }

--- a/inc/core/events.php
+++ b/inc/core/events.php
@@ -94,6 +94,12 @@ function extrachill_track_analytics_event( $event_type, $event_data = array(), $
 
 	$current_user_id = get_current_user_id();
 
+	// The event table is the final trust boundary for every caller, including
+	// server-owned events that do not pass through the public ability adapter.
+	$source_url = function_exists( 'extrachill_analytics_canonicalize_tracked_url' )
+		? extrachill_analytics_canonicalize_tracked_url( $source_url )
+		: '';
+
 	$result = $wpdb->insert(
 		$table_name,
 		array(

--- a/inc/core/route-classifier.php
+++ b/inc/core/route-classifier.php
@@ -35,6 +35,47 @@ function extrachill_analytics_normalize_route_path( $route ) {
 }
 
 /**
+ * Reduce an HTTP(S) URL or root-relative route to origin plus path only.
+ *
+ * @param string $url Raw URL or path.
+ * @return string Canonical URL/path, or an empty string when invalid.
+ */
+function extrachill_analytics_canonicalize_tracked_url( $url ) {
+	$url = trim( (string) $url );
+	if ( '' === $url || false !== strpos( $url, "\0" ) ) {
+		return '';
+	}
+
+	if ( '/' === $url[0] && 0 !== strpos( $url, '//' ) ) {
+		return extrachill_analytics_normalize_route_path( $url );
+	}
+
+	$parts = wp_parse_url( $url );
+	if ( ! is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+		return '';
+	}
+
+	$scheme = strtolower( (string) $parts['scheme'] );
+	if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+		return '';
+	}
+
+	$host = strtolower( rtrim( (string) $parts['host'], '.' ) );
+	if ( '' === $host || preg_match( '/[\s\/?#@]/', $host ) ) {
+		return '';
+	}
+
+	$path = extrachill_analytics_normalize_route_path( isset( $parts['path'] ) ? (string) $parts['path'] : '/' );
+	if ( '' === $path ) {
+		return '';
+	}
+
+	$port = isset( $parts['port'] ) ? ':' . (int) $parts['port'] : '';
+
+	return $scheme . '://' . $host . $port . $path;
+}
+
+/**
  * Return the route families accepted by pageview events.
  *
  * @return string[] Route family slugs.

--- a/inc/core/source-url-backfill.php
+++ b/inc/core/source-url-backfill.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Historical analytics source URL redaction.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Redact stored event source URLs without exposing their values in output.
+ *
+ * @param array $args Backfill arguments.
+ * @return array{scanned:int,redacted:int,invalid:int,batches:int,live:bool}
+ */
+function extrachill_analytics_redact_source_urls( $args = array() ) {
+	global $wpdb;
+
+	$args = array_merge(
+		array(
+			'batch_size' => 1000,
+			'live'       => false,
+			'progress'   => null,
+		),
+		(array) $args
+	);
+
+	$batch_size = max( 1, (int) $args['batch_size'] );
+	$live       = (bool) $args['live'];
+	$progress   = is_callable( $args['progress'] ) ? $args['progress'] : null;
+	$table      = extrachill_analytics_events_table();
+	$last_id    = 0;
+	$totals     = array(
+		'scanned'  => 0,
+		'redacted' => 0,
+		'invalid'  => 0,
+		'batches'  => 0,
+		'live'     => $live,
+	);
+
+	do {
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$sql  = "SELECT id, source_url FROM {$table} WHERE source_url <> '' AND id > %d ORDER BY id ASC LIMIT %d";
+		$rows = $wpdb->get_results( $wpdb->prepare( $sql, $last_id, $batch_size ) );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		if ( empty( $rows ) ) {
+			break;
+		}
+
+		foreach ( $rows as $row ) {
+			$last_id   = (int) $row->id;
+			$canonical = extrachill_analytics_canonicalize_tracked_url( (string) $row->source_url );
+			++$totals['scanned'];
+
+			if ( $canonical === (string) $row->source_url ) {
+				continue;
+			}
+
+			++$totals['redacted'];
+			if ( '' === $canonical ) {
+				++$totals['invalid'];
+			}
+
+			if ( $live ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- One-time bounded privacy backfill.
+				$wpdb->update( $table, array( 'source_url' => $canonical ), array( 'id' => $last_id ), array( '%s' ), array( '%d' ) );
+			}
+		}
+
+		++$totals['batches'];
+		if ( $progress ) {
+			call_user_func( $progress, $totals );
+		}
+		$row_count = count( $rows );
+	} while ( $row_count === $batch_size );
+
+	return $totals;
+}
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	/**
+	 * Redact historical event source URLs. Dry-run unless --live is supplied.
+	 *
+	 * @param array $pos_args Positional arguments.
+	 * @param array $assoc_args Command flags.
+	 * @return void
+	 */
+	function extrachill_analytics_cli_redact_source_urls( $pos_args, $assoc_args ) {
+		unset( $pos_args );
+		$live       = isset( $assoc_args['live'] );
+		$batch_size = isset( $assoc_args['batch-size'] ) ? (int) $assoc_args['batch-size'] : 1000;
+		$result     = extrachill_analytics_redact_source_urls(
+			array(
+				'live'       => $live,
+				'batch_size' => $batch_size,
+			)
+		);
+
+		WP_CLI::log(
+			sprintf(
+				'%s: scanned %d rows; %d require redaction; %d invalid values become empty.',
+				$live ? 'Complete' : 'Dry run',
+				$result['scanned'],
+				$result['redacted'],
+				$result['invalid']
+			)
+		);
+		WP_CLI::success( $live ? 'Historical source URLs redacted.' : 'Re-run with --live to apply.' );
+	}
+
+	WP_CLI::add_command( 'extrachill-analytics redact-source-urls', 'extrachill_analytics_cli_redact_source_urls' );
+}

--- a/inc/core/write-integrity.php
+++ b/inc/core/write-integrity.php
@@ -384,13 +384,14 @@ function extrachill_analytics_validate_public_event_write( $event_type, $event_d
 		return new WP_Error( 'invalid_event_origin', __( 'Analytics events must originate on the current public site.', 'extrachill-analytics' ), array( 'status' => 403 ) );
 	}
 
-	$parts        = wp_parse_url( (string) $source_url );
-	$claimed_host = is_array( $parts ) && isset( $parts['host'] ) ? strtolower( rtrim( (string) $parts['host'], '.' ) ) : '';
+	$canonical_source = extrachill_analytics_canonicalize_tracked_url( (string) $source_url );
+	$parts            = wp_parse_url( $canonical_source );
+	$claimed_host     = is_array( $parts ) && isset( $parts['host'] ) ? strtolower( rtrim( (string) $parts['host'], '.' ) ) : '';
 	if ( '' !== $claimed_host && $source_host !== $claimed_host ) {
 		return new WP_Error( 'invalid_event_source', __( 'Event source host does not match the browser origin.', 'extrachill-analytics' ), array( 'status' => 403 ) );
 	}
 
-	$source_path = extrachill_analytics_normalize_route_path( (string) $source_url );
+	$source_path = extrachill_analytics_normalize_route_path( $canonical_source );
 	if ( '' === $source_path ) {
 		return new WP_Error( 'invalid_event_source', __( 'A valid event source path is required.', 'extrachill-analytics' ), array( 'status' => 400 ) );
 	}
@@ -402,6 +403,22 @@ function extrachill_analytics_validate_public_event_write( $event_type, $event_d
 	$valid_event_data = extrachill_analytics_validate_public_event_data( $event_type, $event_data );
 	if ( is_wp_error( $valid_event_data ) ) {
 		return $valid_event_data;
+	}
+
+	$url_field = EC_ANALYTICS_EVENT_OUTBOUND_CLICK === $event_type ? 'dest_url' : 'share_url';
+	if ( isset( $event_data[ $url_field ] ) && '' !== $event_data[ $url_field ] ) {
+		$canonical_url = extrachill_analytics_canonicalize_tracked_url( $event_data[ $url_field ] );
+		if ( '' === $canonical_url ) {
+			return new WP_Error(
+				'invalid_event_field',
+				__( 'Event data contains an invalid URL.', 'extrachill-analytics' ),
+				array(
+					'status' => 400,
+					'field'  => $url_field,
+				)
+			);
+		}
+		$event_data[ $url_field ] = $canonical_url;
 	}
 
 	$source_post = isset( $event_data['source_post'] ) ? (int) $event_data['source_post'] : 0;

--- a/tests/GetOutboundClicksTest.php
+++ b/tests/GetOutboundClicksTest.php
@@ -8,6 +8,7 @@
 use PHPUnit\Framework\TestCase;
 
 require_once dirname( __DIR__ ) . '/inc/core/outbound-classifier.php';
+require_once dirname( __DIR__ ) . '/inc/core/route-classifier.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-outbound-clicks.php';
 
 /**
@@ -23,8 +24,7 @@ final class GetOutboundClicksTest extends TestCase {
 	}
 
 	/**
-	 * Browser beacon rows are currently marked is_bot by the generic REST
-	 * classifier. They must still produce destination rows.
+	 * Human-stamped browser beacon rows produce destination rows.
 	 */
 	public function test_recorded_outbound_events_produce_destination_rows(): void {
 		$GLOBALS['extrachill_analytics_outbound_fixture_rows'] = array(
@@ -32,7 +32,7 @@ final class GetOutboundClicksTest extends TestCase {
 				'event_data' => array(
 					'dest_host' => 'open.spotify.com',
 					'category'  => 'spotify',
-					'is_bot'    => true,
+					'is_bot'    => false,
 				),
 				'source_url' => 'https://extrachill.com/artist-one/',
 			),
@@ -40,7 +40,7 @@ final class GetOutboundClicksTest extends TestCase {
 				'event_data' => array(
 					'dest_host' => 'open.spotify.com',
 					'category'  => 'spotify',
-					'is_bot'    => true,
+					'is_bot'    => false,
 				),
 				'source_url' => 'https://events.extrachill.com/events/show-one/',
 			),
@@ -76,6 +76,7 @@ final class GetOutboundClicksTest extends TestCase {
 			(object) array(
 				'event_data' => array(
 					'category' => 'other',
+					'is_bot'   => false,
 				),
 				'source_url' => 'https://extrachill.com/legacy-page/',
 			),
@@ -88,5 +89,46 @@ final class GetOutboundClicksTest extends TestCase {
 		$this->assertSame( 'missing_destination_dimensions', $report['diagnostic']['code'] );
 		$this->assertSame( 1, $report['diagnostic']['rows_missing_dest_host'] );
 		$this->assertStringContainsString( 'dest_host dimension', $report['diagnostic']['message'] );
+	}
+
+	/**
+	 * Bot-stamped rows stay out of the default human report.
+	 */
+	public function test_synthetic_rows_are_excluded_by_default(): void {
+		$GLOBALS['extrachill_analytics_outbound_fixture_rows'] = array(
+			(object) array(
+				'event_data' => array(
+					'dest_host' => 'tickets.example',
+					'category'  => 'ticketing',
+					'is_bot'    => true,
+				),
+				'source_url' => 'https://extrachill.com/testing/',
+			),
+		);
+
+		$report = extrachill_analytics_ability_get_outbound_clicks( array( 'days' => 0 ) );
+
+		$this->assertSame( 0, $report['total'] );
+		$this->assertSame( array(), $report['by_source'] );
+	}
+
+	/**
+	 * Historical source values are minimized before report aggregation.
+	 */
+	public function test_report_never_returns_source_query_or_fragment(): void {
+		$GLOBALS['extrachill_analytics_outbound_fixture_rows'] = array(
+			(object) array(
+				'event_data' => array(
+					'dest_host' => 'tickets.example',
+					'category'  => 'ticketing',
+					'is_bot'    => false,
+				),
+				'source_url' => 'https://extrachill.com/contact/?access_token=fixture#response',
+			),
+		);
+
+		$report = extrachill_analytics_ability_get_outbound_clicks( array( 'days' => 0 ) );
+
+		$this->assertSame( 'https://extrachill.com/contact/', $report['by_source'][0]['source_url'] );
 	}
 }

--- a/tests/PublicWriteIntegrityTest.php
+++ b/tests/PublicWriteIntegrityTest.php
@@ -152,11 +152,72 @@ final class PublicWriteIntegrityTest extends TestCase {
 				'source_site' => 'main',
 				'dest_site'   => 'events',
 			),
-			'https://extrachill.com/story/?email=reader@example.test'
+			'https://extrachill.com/story/?email=fixture%40example.test#form'
 		);
 
 		$this->assertIsArray( $result );
 		$this->assertSame( '/story/', $result['source_url'] );
+	}
+
+	/**
+	 * The public event boundary minimizes source and destination URLs.
+	 */
+	public function test_outbound_event_urls_are_minimized_server_side(): void {
+		$result = extrachill_analytics_ability_track_event(
+			array(
+				'event_type' => EC_ANALYTICS_EVENT_OUTBOUND_CLICK,
+				'event_data' => array(
+					'dest_host' => 'tickets.example',
+					'dest_url'  => 'https://tickets.example/show/?token=fixture#checkout',
+					'category'  => 'ticketing',
+				),
+				'source_url' => 'https://extrachill.com/login/?redirect_to=%2Faccount%2F#form',
+			)
+		);
+
+		$this->assertSame( 1, $result );
+		$this->assertSame( '/login/', $GLOBALS['extrachill_analytics_test_events'][0][2] );
+		$this->assertSame( 'https://tickets.example/show/', $GLOBALS['extrachill_analytics_test_events'][0][1]['dest_url'] );
+	}
+
+	/**
+	 * URL user information is never retained by canonicalization.
+	 */
+	public function test_tracked_url_canonicalization_removes_userinfo(): void {
+		$this->assertSame(
+			'https://extrachill.com/account/',
+			extrachill_analytics_canonicalize_tracked_url( 'https://fixture:fixture@extrachill.com/account/' )
+		);
+	}
+
+	/**
+	 * Malformed and non-HTTP event URLs fail closed.
+	 *
+	 * @dataProvider invalid_tracked_url_provider
+	 *
+	 * @param string $url Invalid URL fixture.
+	 */
+	public function test_public_event_rejects_invalid_tracked_urls( $url ): void {
+		$result = extrachill_analytics_validate_public_event_write(
+			EC_ANALYTICS_EVENT_OUTBOUND_CLICK,
+			array( 'dest_url' => $url ),
+			'/story/'
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_event_field', $result->code );
+	}
+
+	/**
+	 * Invalid tracked URLs.
+	 *
+	 * @return array<string,array{string}>
+	 */
+	public function invalid_tracked_url_provider() {
+		return array(
+			'non-http scheme' => array( 'javascript:alert(1)' ),
+			'malformed value' => array( 'not a URL' ),
+		);
 	}
 
 	/**

--- a/tests/SourceUrlBackfillTest.php
+++ b/tests/SourceUrlBackfillTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Tests for historical source URL redaction.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/route-classifier.php';
+require_once dirname( __DIR__ ) . '/inc/core/source-url-backfill.php';
+
+/**
+ * Verify the privacy backfill is bounded and dry-run by default.
+ */
+final class SourceUrlBackfillTest extends TestCase {
+	/**
+	 * Historical values are canonicalized without writes during a dry run.
+	 */
+	public function test_backfill_dry_run_counts_redactions_without_writing(): void {
+		global $wpdb;
+
+		$wpdb = new class() {
+			/**
+			 * Stored source fixtures.
+			 *
+			 * @var array<int,object>
+			 */
+			public $rows;
+
+			/**
+			 * Captured update calls.
+			 *
+			 * @var array<int,array>
+			 */
+			public $updates = array();
+
+			/**
+			 * Seed source URL fixtures.
+			 */
+			public function __construct() {
+				$this->rows = array(
+					(object) array(
+						'id'         => 1,
+						'source_url' => 'https://extrachill.com/login/?token=fixture#form',
+					),
+					(object) array(
+						'id'         => 2,
+						'source_url' => 'https://extrachill.com/story/',
+					),
+					(object) array(
+						'id'         => 3,
+						'source_url' => 'not a URL',
+					),
+				);
+			}
+
+			/**
+			 * Capture prepared query arguments.
+			 *
+			 * @param string $sql  Query template.
+			 * @param mixed  ...$args Query arguments.
+			 * @return array Prepared query fixture.
+			 */
+			public function prepare( $sql, ...$args ) {
+				return array( $sql, $args );
+			}
+
+			/**
+			 * Return a cursor-paginated fixture batch.
+			 *
+			 * @param array $query Prepared query fixture.
+			 * @return array<object> Matching rows.
+			 */
+			public function get_results( $query ) {
+				$last_id = (int) $query[1][0];
+				$limit   = (int) $query[1][1];
+				$rows    = array_filter(
+					$this->rows,
+					static function ( $row ) use ( $last_id ) {
+						return $row->id > $last_id;
+					}
+				);
+				return array_slice( array_values( $rows ), 0, $limit );
+			}
+
+			/**
+			 * Capture an update call.
+			 *
+			 * @param mixed ...$args Update arguments.
+			 * @return int Updated row count.
+			 */
+			public function update( ...$args ) {
+				$this->updates[] = $args;
+				return 1;
+			}
+		};
+
+		$result = extrachill_analytics_redact_source_urls( array( 'batch_size' => 2 ) );
+
+		$this->assertSame( 3, $result['scanned'] );
+		$this->assertSame( 2, $result['redacted'] );
+		$this->assertSame( 1, $result['invalid'] );
+		$this->assertSame( array(), $wpdb->updates );
+	}
+}


### PR DESCRIPTION
## Summary
- canonicalize tracked source and public destination URLs to origin/path data before persistence, with browser-side minimization as defense in depth
- restore the outbound report's human-only default by using the repository classifier at the validated beacon boundary and excluding bot or unclassified rows
- add read-time protection plus a dry-run-by-default command for irreversibly redacting historical source URLs without printing stored values

## Root cause and defense boundary
The outbound browser sent `window.location.href`, while historical event rows retained URLs that predated the newer public-write normalization. The report then emitted stored `source_url` values directly. Separately, it deliberately ignored every `is_bot` stamp because REST beacons had been classified from their transport context rather than their validated browser evidence, allowing synthetic rows into a human ranking.

The event table write helper is now the final server-side source URL trust boundary for every caller. Public event validation additionally canonicalizes outbound `dest_url` and adjacent share `share_url` fields, rejects malformed/non-HTTP(S) values, and removes userinfo, query strings, and fragments. The client submits minimized source and destination URLs too, but server enforcement remains authoritative. The report canonicalizes historical source values again before output so sensitive URL components cannot escape while cleanup is pending.

## Synthetic filtering
Validated public browser events are classified through the existing canonical visitor classifier with browser-origin semantics after the public origin, payload, and cookie checks. The report defaults to human-only rows and excludes bot-stamped or unclassified events. `include_bots` remains available only as an explicit diagnostic option, with source output still canonicalized.

## Historical data
No automatic production mutation is performed. The included command is bounded, cursor-paginated, idempotent, and dry-run by default; it reports counts only and never logs stored URL values:

```sh
wp extrachill-analytics redact-source-urls
wp extrachill-analytics redact-source-urls --live
```

Malformed historical source values become empty during the authorized live run. Operators should review the dry-run counts before separately authorizing `--live` after deployment.

## Adjacent-event audit
The existing Extra Chill API click adapter routes share, bridge, and outbound writes through `extrachill/track-analytics-event`; no adapter bypass was found. Because all event types share the same events-table helper, the final source URL canonicalization protects adjacent first-party events as well. The only adjacent public payload URL confirmed was share `share_url`, which now receives the same canonicalization as outbound `dest_url`. No new shared infrastructure or cross-repository change was needed.

## Tests
- `vendor/bin/phpunit` (`390` tests, `1547` assertions)
- focused URL privacy tests (`21` tests after final additions, included in the full suite)
- changed-file WordPress PHPCS: no errors; only existing direct-database warnings in `inc/core/events.php`
- `node --check assets/js/outbound-tracking.js`
- `git diff --check`

## Residual risk
A sufficiently capable synthetic client can forge browser headers and a visitor cookie; this change restores the repository-owned classifier contract rather than introducing payload-value heuristics. Privacy-preserving visitors without the first-party visitor cookie remain excluded from the human-only ranking under the canonical classifier's existing policy.

Closes #213