### PR TITLE
feat: define onboarding artist access grant event

### DIFF
--- a/inc/core/abilities/get-activation-funnel.php
+++ b/inc/core/abilities/get-activation-funnel.php
@@ -26,7 +26,10 @@
  *
  * Friction / anomaly signals
  * --------------------------
- * Alongside the happy-path steps it also surfaces an `anomalies` section that
+ * The `access_paths` section reports explicit request, explicit approval, and
+ * onboarding grant as separate upstream events so the auto-grant branch never
+ * changes the meaning of manual approval. Alongside the happy-path steps it
+ * also surfaces an `anomalies` section that
  * counts the activation FRICTION events (`EC_ANALYTICS_ARTIST_ACTIVATION_
  * FRICTION_EVENTS` — duplicate profile creation and re-registration attempts)
  * by DISTINCT person over the SAME window and dedup key. These make funnel
@@ -82,7 +85,7 @@ function extrachill_analytics_register_activation_funnel_ability() {
 			),
 			'output_schema'       => array(
 				'type'        => 'object',
-				'description' => __( 'Object with a chronologically ordered per-person steps array (event_type, people, conversion_from_prev, conversion_from_top), the biggest_abandon_step, an anomalies array of friction signals (duplicate profile creation, re-registration attempts) each with DISTINCT people and raw event counts, and the exact UTC window.', 'extrachill-analytics' ),
+				'description' => __( 'Object with separate upstream access_paths, a chronologically ordered per-person steps array (event_type, people, conversion_from_prev, conversion_from_top), the biggest_abandon_step, an anomalies array of friction signals (duplicate profile creation, re-registration attempts) each with DISTINCT people and raw event counts, and the exact UTC window.', 'extrachill-analytics' ),
 			),
 			'execute_callback'    => 'extrachill_analytics_ability_get_activation_funnel',
 			'permission_callback' => function () {
@@ -214,7 +217,10 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 	$friction_events = defined( 'EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS' )
 		? EC_ANALYTICS_ARTIST_ACTIVATION_FRICTION_EVENTS
 		: array( 'artist_profile_duplicate_created', 'user_reregistration_attempt' );
-	$event_types     = array_merge( $steps, $friction_events );
+	$access_events   = defined( 'EC_ANALYTICS_ARTIST_ACCESS_EVENTS' )
+		? EC_ANALYTICS_ARTIST_ACCESS_EVENTS
+		: array( 'artist_access_requested', 'artist_access_approved', 'artist_access_granted' );
+	$event_types     = array_merge( $steps, $friction_events, $access_events );
 
 	// First pass: observe real visitor-to-user bridges. A visitor shared by more
 	// than one user is deliberately left ambiguous rather than merging accounts.
@@ -244,10 +250,13 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 
 	$step_index     = array_flip( $steps );
 	$friction_index = array_flip( $friction_events );
+	$access_index   = array_flip( $access_events );
 	$ordered_counts = array_fill( 0, count( $steps ), 0 );
 	$progress       = array();
 	$anomaly_events = array_fill_keys( $friction_events, 0 );
 	$anomaly_people = array_fill_keys( $friction_events, array() );
+	$access_counts  = array_fill_keys( $access_events, 0 );
+	$access_people  = array_fill_keys( $access_events, array() );
 
 	// Second pass: resolve every row through the observed bridge and advance the
 	// per-person state machine in deterministic stored event order.
@@ -256,7 +265,7 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 		$event_types,
 		$window_where,
 		$window_values,
-		static function ( $page ) use ( &$ordered_counts, &$progress, &$anomaly_events, &$anomaly_people, $visitor_to_user, $step_index, $friction_index ) {
+		static function ( $page ) use ( &$ordered_counts, &$progress, &$anomaly_events, &$anomaly_people, &$access_counts, &$access_people, $visitor_to_user, $step_index, $friction_index, $access_index ) {
 			foreach ( $page as $row ) {
 				$user_id    = extrachill_analytics_activation_event_user_id( $row );
 				$visitor_id = trim( (string) $row->visitor_id );
@@ -281,6 +290,9 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 				} elseif ( isset( $friction_index[ $event_type ] ) ) {
 					++$anomaly_events[ $event_type ];
 					$anomaly_people[ $event_type ][ $person_id ] = true;
+				} elseif ( isset( $access_index[ $event_type ] ) ) {
+					++$access_counts[ $event_type ];
+					$access_people[ $event_type ][ $person_id ] = true;
 				}
 			}
 		}
@@ -354,7 +366,17 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 		);
 	}
 
+	$access_paths = array();
+	foreach ( $access_events as $event_type ) {
+		$access_paths[] = array(
+			'event_type' => $event_type,
+			'people'     => count( $access_people[ $event_type ] ),
+			'events'     => $access_counts[ $event_type ],
+		);
+	}
+
 	return array(
+		'access_paths'         => $access_paths,
 		'steps'                => $steps_out,
 		'overall_conversion'   => $overall_conversion,
 		'biggest_abandon_step' => $biggest_abandon,
@@ -368,6 +390,6 @@ function extrachill_analytics_ability_get_activation_funnel( $input ) {
 		// same created_at >= since bound used by get-analytics-summary.
 		'since'                => $since,
 		'as_of'                => $now_utc,
-		'note'                 => 'Ordered per-person funnel: event_data.user_id (registration-safe) then stored user_id is authoritative; visitor_id is the anonymous fallback and is stitched to a user only when this window observes that visitor with exactly one user. Ambiguous visitors are not merged. Events are read in bounded keyset pages and ordered by created_at then event row ID; equal timestamps follow insertion order. A person counts at a step only after completing every prior step, and repeated emits count once. Rows with neither identity are excluded because their progression is unknowable. Counts are intentionally NOT comparable to get-analytics-summary COUNT(*) raw volume. The anomalies array remains independent reach over the same bounded stream.',
+		'note'                 => 'Ordered per-person funnel: event_data.user_id (registration-safe) then stored user_id is authoritative; visitor_id is the anonymous fallback and is stitched to a user only when this window observes that visitor with exactly one user. Ambiguous visitors are not merged. Events are read in bounded keyset pages and ordered by created_at then event row ID; equal timestamps follow insertion order. A person counts at a step only after completing every prior step, and repeated emits count once. Rows with neither identity are excluded because their progression is unknowable. Counts are intentionally NOT comparable to get-analytics-summary COUNT(*) raw volume. Access paths preserve explicit request/approval and onboarding grant as separate independent reach; anomalies remain independent reach over the same bounded stream.',
 	);
 }

--- a/inc/core/event-types.php
+++ b/inc/core/event-types.php
@@ -173,14 +173,29 @@ const EC_ANALYTICS_EVENT_LOCAL_SCENE_PROMPT_COMPLETED = 'local_scene_prompt_comp
  * is the same visitor_id<->user_id stitching the registration referrer/UTM
  * work keys on (Extra-Chill/extrachill-users#145) — built once, shared.
  *
- * The access-gate events (`artist_access_requested` / `_approved`) sit
- * upstream of this funnel for users who must request access first.
+ * The access-gate events sit upstream of this funnel. Explicit access keeps
+ * its request -> approval semantics, while onboarding-origin access uses the
+ * distinct `artist_access_granted` transition event.
+ *
+ * `artist_access_granted` has one bounded, privacy-safe payload contract:
+ * `user_id` is a positive server-owned integer, `source` is exactly
+ * `onboarding`, and `method` is one of `artist`, `professional`, or
+ * `artist_and_professional`. Emitters MUST NOT add names, emails, usernames,
+ * profile text, Local Scene values, or other free-form/user-controlled data.
  */
 const EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED      = 'artist_access_requested';
 const EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED       = 'artist_access_approved';
+const EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED        = 'artist_access_granted';
 const EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED        = 'artist_signup_started';
 const EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED       = 'artist_profile_created';
 const EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH = 'artist_profile_first_publish';
+
+const EC_ANALYTICS_ARTIST_ACCESS_GRANTED_SOURCE_ONBOARDING = 'onboarding';
+const EC_ANALYTICS_ARTIST_ACCESS_GRANTED_METHODS           = array(
+	'artist',
+	'professional',
+	'artist_and_professional',
+);
 
 /**
  * Artist-funnel FRICTION events — the failure/thrash modes that sit alongside
@@ -297,9 +312,22 @@ const EC_ANALYTICS_LOCAL_SCENE_PROMPT_EVENTS = array(
 const EC_ANALYTICS_ARTIST_FUNNEL_EVENTS = array(
 	EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED,
 	EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED,
+	EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED,
 	EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED,
 	EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED,
 	EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH,
+);
+
+/**
+ * Distinct upstream access-path events surfaced by the activation reader.
+ * Order preserves the explicit request/approve branch before auto-grant.
+ *
+ * @var string[]
+ */
+const EC_ANALYTICS_ARTIST_ACCESS_EVENTS = array(
+	EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED,
+	EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED,
+	EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED,
 );
 
 /**

--- a/tests/ActivationFunnelTest.php
+++ b/tests/ActivationFunnelTest.php
@@ -82,6 +82,30 @@ final class ActivationFunnelTest extends TestCase {
 	}
 
 	/**
+	 * Manual approval and onboarding grant remain readable as distinct paths.
+	 */
+	public function test_ability_reports_distinct_access_paths_without_changing_activation_steps(): void {
+		$rows = array(
+			$this->row( 1, 'artist_access_requested', 100, 80 ),
+			$this->row( 2, 'artist_access_approved', 101, 80 ),
+			$this->row( 3, 'artist_access_granted', 102, 90 ),
+			$this->row( 4, 'artist_access_granted', 103, 90 ),
+			$this->row( 5, 'artist_signup_started', 104, 90 ),
+		);
+		$this->install_database( array( $rows, $rows ) );
+
+		$response = extrachill_analytics_ability_get_activation_funnel( array( 'days' => 28 ) );
+
+		$this->assertSame(
+			array( 'artist_access_requested', 'artist_access_approved', 'artist_access_granted' ),
+			array_column( $response['access_paths'], 'event_type' )
+		);
+		$this->assertSame( array( 1, 1, 1 ), array_column( $response['access_paths'], 'people' ) );
+		$this->assertSame( array( 1, 1, 2 ), array_column( $response['access_paths'], 'events' ) );
+		$this->assertSame( array( 1, 0, 0 ), array_column( $response['steps'], 'people' ) );
+	}
+
+	/**
 	 * Equal timestamps follow row-ID order in the ability's persisted stream.
 	 */
 	public function test_ability_uses_event_id_for_equal_timestamp_ordering(): void {

--- a/tests/EventContractsTest.php
+++ b/tests/EventContractsTest.php
@@ -55,6 +55,21 @@ final class EventContractsTest extends TestCase {
 		$this->assertNotSame( EC_ANALYTICS_EVENT_EXPERIMENT_ASSIGNMENT, EC_ANALYTICS_EVENT_EXPERIMENT_EXPOSURE );
 		$this->assertSame( 'geo-bridge-holdout', EC_ANALYTICS_EXPERIMENT_GEO_BRIDGE_HOLDOUT );
 		$this->assertSame( 'single-post-bridge', EC_ANALYTICS_EXPERIMENT_SURFACE_SINGLE_POST_BRIDGE );
+		$this->assertSame( 'artist_access_granted', EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED );
+		$this->assertSame( 'onboarding', EC_ANALYTICS_ARTIST_ACCESS_GRANTED_SOURCE_ONBOARDING );
+		$this->assertSame(
+			array( 'artist', 'professional', 'artist_and_professional' ),
+			EC_ANALYTICS_ARTIST_ACCESS_GRANTED_METHODS
+		);
+		$this->assertContains( EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED, EC_ANALYTICS_ARTIST_FUNNEL_EVENTS );
+		$this->assertSame(
+			array(
+				EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED,
+				EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED,
+				EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED,
+			),
+			EC_ANALYTICS_ARTIST_ACCESS_EVENTS
+		);
 	}
 
 	/**

--- a/tests/GetAnalyticsSummaryTest.php
+++ b/tests/GetAnalyticsSummaryTest.php
@@ -131,6 +131,50 @@ final class GetAnalyticsSummaryTest extends TestCase {
 	}
 
 	/**
+	 * Canonical onboarding grants require no parallel summary reader.
+	 */
+	public function test_onboarding_grant_is_readable_by_existing_summary(): void {
+		$GLOBALS['wpdb'] = new class() {
+			/**
+			 * Capture prepared values and return the fixture query.
+			 *
+			 * @param string $query Query string.
+			 * @param mixed  ...$args Prepared values.
+			 * @return string Query string.
+			 */
+			public function prepare( $query, ...$args ) {
+				$this->args = $args;
+				return $query;
+			}
+
+			/**
+			 * Return the canonical grant summary fixture.
+			 *
+			 * @return array<object> Summary rows.
+			 */
+			public function get_results() {
+				return array(
+					(object) array(
+						'event_type' => 'artist_access_granted',
+						'count'      => '2',
+					),
+				);
+			}
+		};
+
+		$summary = extrachill_analytics_ability_get_summary(
+			array(
+				'days'       => 28,
+				'event_type' => EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED,
+			)
+		);
+
+		$this->assertSame( 'artist_access_granted', $summary['event_types'][0]['event_type'] );
+		$this->assertSame( 2, $summary['event_types'][0]['count'] );
+		$this->assertContains( 'artist_access_granted', $GLOBALS['wpdb']->args[0] );
+	}
+
+	/**
 	 * Source and context rankings are deterministic and bounded in SQL.
 	 */
 	public function test_source_and_context_queries_are_stable_and_bounded(): void {


### PR DESCRIPTION
## Summary
- define the canonical `artist_access_granted` event and bounded onboarding payload contract
- expose manual request, manual approval, and onboarding grant as distinct access paths in the existing activation report
- prove the existing analytics summary reads the new event without another read surface

## Testing
- `composer test` (392 tests, 1,559 assertions)
- scoped PHPCS on all changed files
- full PHPCS attempted; existing repository-wide baseline violations remain outside this change

## Related
- Extra-Chill/extrachill-users#233
- Extra-Chill/extrachill-artist-platform#72
- Must merge before the linked Extra Chill Users PR because Users consumes these constants.