### PR TITLE
perf: cache expensive network analytics reports

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -29,6 +29,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/link-page-analytics
 // Core functionality (network-wide).
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/event-types.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/events.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/report-result-cache.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/security-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/visitor-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/search-source-classifier.php';

--- a/inc/core/abilities/get-conversion-map.php
+++ b/inc/core/abilities/get-conversion-map.php
@@ -170,6 +170,30 @@ function extrachill_analytics_conversion_surface_map() {
  * @return array Conversion map.
  */
 function extrachill_analytics_ability_get_conversion_map( $input ) {
+	$normalized = array(
+		'days'                    => isset( $input['days'] ) ? max( 1, (int) $input['days'] ) : 28,
+		'session_gap_mins'        => isset( $input['session_gap_mins'] ) ? max( 1, (int) $input['session_gap_mins'] ) : 30,
+		'top_articles'            => isset( $input['top_articles'] ) ? max( 1, (int) $input['top_articles'] ) : 25,
+		'min_entry_sessions'      => isset( $input['min_entry_sessions'] ) ? max( 1, (int) $input['min_entry_sessions'] ) : 1,
+		'return_observation_days' => isset( $input['return_observation_days'] ) ? max( 0, (int) $input['return_observation_days'] ) : 7,
+	);
+
+	return extrachill_analytics_report_cache_remember(
+		'conversion_map',
+		$normalized,
+		static function () use ( $normalized ) {
+			return extrachill_analytics_compute_conversion_map( $normalized );
+		}
+	);
+}
+
+/**
+ * Compute an uncached conversion-map report.
+ *
+ * @param array $input Normalized input parameters.
+ * @return array Conversion map.
+ */
+function extrachill_analytics_compute_conversion_map( $input ) {
 	global $wpdb;
 
 	$days                    = isset( $input['days'] ) ? max( 1, (int) $input['days'] ) : 28;

--- a/inc/core/abilities/get-retention-stats.php
+++ b/inc/core/abilities/get-retention-stats.php
@@ -89,6 +89,29 @@ function extrachill_analytics_register_retention_stats_ability() {
  * @return array Retention metrics.
  */
 function extrachill_analytics_ability_get_retention_stats( $input ) {
+	$normalized = array(
+		'days'         => isset( $input['days'] ) ? max( 1, (int) $input['days'] ) : 28,
+		'end_days_ago' => isset( $input['end_days_ago'] ) ? max( 0, (int) $input['end_days_ago'] ) : 0,
+		'blog_id'      => isset( $input['blog_id'] ) ? max( 0, (int) $input['blog_id'] ) : 0,
+		'cohort_weeks' => isset( $input['cohort_weeks'] ) ? max( 1, (int) $input['cohort_weeks'] ) : 8,
+	);
+
+	return extrachill_analytics_report_cache_remember(
+		'retention_stats',
+		$normalized,
+		static function () use ( $normalized ) {
+			return extrachill_analytics_compute_retention_stats( $normalized );
+		}
+	);
+}
+
+/**
+ * Compute an uncached retention report.
+ *
+ * @param array $input Normalized input parameters.
+ * @return array Retention metrics.
+ */
+function extrachill_analytics_compute_retention_stats( $input ) {
 	global $wpdb;
 
 	$days         = isset( $input['days'] ) ? max( 1, (int) $input['days'] ) : 28;

--- a/inc/core/abilities/get-surface-growth.php
+++ b/inc/core/abilities/get-surface-growth.php
@@ -161,6 +161,24 @@ function extrachill_analytics_surface_growth_map() {
  */
 function extrachill_analytics_ability_get_surface_growth( $input ) {
 	$weeks = isset( $input['weeks'] ) ? max( 1, (int) $input['weeks'] ) : 4;
+
+	return extrachill_analytics_report_cache_remember(
+		'surface_growth',
+		array( 'weeks' => $weeks ),
+		static function () use ( $weeks ) {
+			return extrachill_analytics_compute_surface_growth( array( 'weeks' => $weeks ) );
+		}
+	);
+}
+
+/**
+ * Compute an uncached surface-growth report.
+ *
+ * @param array $input Normalized input parameters.
+ * @return array Cross-surface growth read.
+ */
+function extrachill_analytics_compute_surface_growth( $input ) {
+	$weeks = isset( $input['weeks'] ) ? max( 1, (int) $input['weeks'] ) : 4;
 	$days  = $weeks * 7;
 
 	$now_utc      = gmdate( 'Y-m-d H:i:s' );
@@ -361,29 +379,26 @@ function extrachill_analytics_surface_demand_growth( $surface, $ga_ability, $ga_
 	// Sum organic sessions per window from traffic_sources so the slope is
 	// computed from true organic demand, not a single-window share applied to
 	// both periods (which algebraically cancels back to the total-sessions slope).
-	$cur_organic  = extrachill_analytics_ga_organic_sessions( $ga_ability, $host, $cur_start, $cur_end );
-	$prev_organic = extrachill_analytics_ga_organic_sessions( $ga_ability, $host, $prev_start, $prev_end );
+	$cur_traffic  = extrachill_analytics_ga_traffic_source_stats( $ga_ability, $host, $cur_start, $cur_end );
+	$prev_traffic = extrachill_analytics_ga_traffic_source_stats( $ga_ability, $host, $prev_start, $prev_end );
 
 	$organic_basis = 'organic';
 	// If organic data can't be derived for EITHER window, fall back to total
 	// sessions for BOTH windows. Mixing organic-basis for one window with
 	// total-basis for the other would manufacture a misleading slope.
-	if ( is_wp_error( $cur_organic ) || is_wp_error( $prev_organic ) ) {
+	if ( is_wp_error( $cur_traffic ) || is_wp_error( $prev_traffic ) ) {
 		$cur_organic   = $cur_total;
 		$prev_organic  = $prev_total;
 		$organic_basis = 'all_sessions';
+		$organic_share = null;
+	} else {
+		$cur_organic   = (int) $cur_traffic['organic_sessions'];
+		$prev_organic  = (int) $prev_traffic['organic_sessions'];
+		$organic_share = $cur_traffic['organic_share'];
 	}
 
 	$cur_organic  = (int) $cur_organic;
 	$prev_organic = (int) $prev_organic;
-
-	// Current-window organic share for reference; null when we fell back to totals.
-	$organic_share = ( 'organic' === $organic_basis )
-		? extrachill_analytics_ga_organic_share( $ga_ability, $host, $cur_start, $cur_end )
-		: null;
-	if ( is_wp_error( $organic_share ) ) {
-		$organic_share = null;
-	}
 
 	// Percent slope of (organic) sessions, current vs previous equal window.
 	$slope_pct = null;
@@ -506,6 +521,20 @@ function extrachill_analytics_ga_sessions_for_window( $ga_ability, $host, $start
  * @return float|null|WP_Error Organic share (0..1), null if no sessions, or error.
  */
 function extrachill_analytics_ga_organic_share( $ga_ability, $host, $start, $end ) {
+	$stats = extrachill_analytics_ga_traffic_source_stats( $ga_ability, $host, $start, $end );
+	return is_wp_error( $stats ) ? $stats : $stats['organic_share'];
+}
+
+/**
+ * Read organic sessions and share from one traffic_sources response.
+ *
+ * @param WP_Ability $ga_ability GA ability instance.
+ * @param string     $host       Hostname filter.
+ * @param string     $start      Start date (YYYY-MM-DD).
+ * @param string     $end        End date (YYYY-MM-DD).
+ * @return array|WP_Error Traffic-source totals, or error.
+ */
+function extrachill_analytics_ga_traffic_source_stats( $ga_ability, $host, $start, $end ) {
 	$result = $ga_ability->execute(
 		array(
 			'action'     => 'traffic_sources',
@@ -539,10 +568,18 @@ function extrachill_analytics_ga_organic_share( $ga_ability, $host, $start, $end
 	}
 
 	if ( $total <= 0 ) {
-		return null;
+		return array(
+			'total_sessions'   => 0,
+			'organic_sessions' => 0,
+			'organic_share'    => null,
+		);
 	}
 
-	return $organic / $total;
+	return array(
+		'total_sessions'   => $total,
+		'organic_sessions' => $organic,
+		'organic_share'    => $organic / $total,
+	);
 }
 
 /**
@@ -561,37 +598,8 @@ function extrachill_analytics_ga_organic_share( $ga_ability, $host, $start, $end
  * @return int|WP_Error Organic sessions count, or error.
  */
 function extrachill_analytics_ga_organic_sessions( $ga_ability, $host, $start, $end ) {
-	$result = $ga_ability->execute(
-		array(
-			'action'     => 'traffic_sources',
-			'hostname'   => $host,
-			'start_date' => $start,
-			'end_date'   => $end,
-			'limit'      => 1000,
-		)
-	);
-
-	if ( is_wp_error( $result ) ) {
-		return $result;
-	}
-
-	if ( ! is_array( $result ) || empty( $result['success'] ) ) {
-		return new WP_Error( 'ga_organic_sessions_failed', is_array( $result ) && ! empty( $result['error'] ) ? $result['error'] : 'GA traffic_sources returned no result.' );
-	}
-
-	$organic = 0;
-	foreach ( (array) ( $result['results'] ?? array() ) as $row ) {
-		$sessions = (int) ( $row['sessions'] ?? 0 );
-		$medium   = strtolower( (string) ( $row['sessionMedium'] ?? '' ) );
-		// GA4 organic mediums: "organic" (search) and "organic_social". We count
-		// search organic as the audience-growth signal; treat anything literally
-		// containing "organic" as organic to stay robust to GA naming.
-		if ( false !== strpos( $medium, 'organic' ) ) {
-			$organic += $sessions;
-		}
-	}
-
-	return $organic;
+	$stats = extrachill_analytics_ga_traffic_source_stats( $ga_ability, $host, $start, $end );
+	return is_wp_error( $stats ) ? $stats : $stats['organic_sessions'];
 }
 
 /**

--- a/inc/core/report-result-cache.php
+++ b/inc/core/report-result-cache.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Bounded result caching for the expensive network analytics reports.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'EXTRACHILL_ANALYTICS_REPORT_CACHE_TTL', 5 * MINUTE_IN_SECONDS );
+define( 'EXTRACHILL_ANALYTICS_REPORT_CACHE_STALE_TTL', 10 * MINUTE_IN_SECONDS );
+
+/**
+ * Normalize report inputs so equivalent requests share a cache entry.
+ *
+ * @param mixed $value Input value.
+ * @return mixed Normalized value.
+ */
+function extrachill_analytics_report_cache_normalize( $value ) {
+	if ( ! is_array( $value ) ) {
+		return $value;
+	}
+
+	if ( array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
+		ksort( $value );
+	}
+
+	foreach ( $value as $key => $item ) {
+		$value[ $key ] = extrachill_analytics_report_cache_normalize( $item );
+	}
+
+	return $value;
+}
+
+/**
+ * Build the network-transient key for one normalized report request.
+ *
+ * @param string $report Report identifier.
+ * @param array  $inputs Behavior-affecting normalized inputs.
+ * @return string Cache key.
+ */
+function extrachill_analytics_report_cache_key( $report, $inputs ) {
+	$network_id = function_exists( 'get_current_network_id' ) ? (int) get_current_network_id() : 1;
+	$normalized = extrachill_analytics_report_cache_normalize( $inputs );
+	$digest     = hash( 'sha256', (string) wp_json_encode( $normalized ) );
+
+	return sprintf( 'eca_report_v1_%d_%s_%s', $network_id, sanitize_key( $report ), $digest );
+}
+
+/**
+ * Add the explicit freshness contract to a report result.
+ *
+ * @param array  $result       Report result.
+ * @param int    $generated_at Unix timestamp when the report was computed.
+ * @param string $cache_status miss, hit, or stale.
+ * @return array Result with freshness metadata.
+ */
+function extrachill_analytics_report_cache_stamp( $result, $generated_at, $cache_status ) {
+	$result['freshness'] = array(
+		'as_of'           => isset( $result['as_of'] ) ? (string) $result['as_of'] : gmdate( 'Y-m-d H:i:s', $generated_at ),
+		'generated_at'    => gmdate( 'Y-m-d H:i:s', $generated_at ),
+		'fresh_until'     => gmdate( 'Y-m-d H:i:s', $generated_at + EXTRACHILL_ANALYTICS_REPORT_CACHE_TTL ),
+		'max_age_seconds' => EXTRACHILL_ANALYTICS_REPORT_CACHE_TTL,
+		'cache_status'    => $cache_status,
+		'is_stale'        => 'stale' === $cache_status,
+	);
+
+	return $result;
+}
+
+/**
+ * Read or compute one expensive analytics report.
+ *
+ * Fresh results live for five minutes. Write-side invalidation is deliberately
+ * avoided because pageviews arrive continuously and would prevent warm reads.
+ * The transient is retained for ten minutes so concurrent readers can receive
+ * the prior result while one request refreshes it. Atomic lock behavior is
+ * enabled only with a persistent object cache; without one, WordPress's
+ * request-local cache cannot coordinate workers.
+ *
+ * @param string   $report  Report identifier.
+ * @param array    $inputs  Behavior-affecting normalized inputs.
+ * @param callable $compute Computes and returns the report array.
+ * @return array Report result with freshness metadata.
+ */
+function extrachill_analytics_report_cache_remember( $report, $inputs, $compute ) {
+	$key     = extrachill_analytics_report_cache_key( $report, $inputs );
+	$payload = get_site_transient( $key );
+	$now     = time();
+	$valid   = is_array( $payload )
+		&& isset( $payload['generated_at'], $payload['result'] )
+		&& is_array( $payload['result'] );
+	$age     = $valid ? max( 0, $now - (int) $payload['generated_at'] ) : PHP_INT_MAX;
+
+	if ( $valid && $age <= EXTRACHILL_ANALYTICS_REPORT_CACHE_TTL ) {
+		return extrachill_analytics_report_cache_stamp( $payload['result'], (int) $payload['generated_at'], 'hit' );
+	}
+
+	$can_lock = function_exists( 'wp_using_ext_object_cache' )
+		&& wp_using_ext_object_cache()
+		&& function_exists( 'wp_cache_add' )
+		&& function_exists( 'wp_cache_delete' );
+	$lock_key = $key . '_lock';
+	$locked   = ! $can_lock || wp_cache_add( $lock_key, 1, 'extrachill_analytics_reports', 30 );
+
+	if ( ! $locked && $valid && $age <= EXTRACHILL_ANALYTICS_REPORT_CACHE_STALE_TTL ) {
+		return extrachill_analytics_report_cache_stamp( $payload['result'], (int) $payload['generated_at'], 'stale' );
+	}
+
+	if ( ! $locked ) {
+		// Cold reports currently take up to ~14 seconds. Wait within that existing
+		// cost envelope for the lock owner rather than multiplying the same work.
+		for ( $attempt = 0; $attempt < 60; ++$attempt ) {
+			usleep( 250000 );
+			$payload = get_site_transient( $key );
+			if ( is_array( $payload ) && isset( $payload['generated_at'], $payload['result'] ) && is_array( $payload['result'] ) ) {
+				$age = max( 0, time() - (int) $payload['generated_at'] );
+				if ( $age <= EXTRACHILL_ANALYTICS_REPORT_CACHE_TTL ) {
+					return extrachill_analytics_report_cache_stamp( $payload['result'], (int) $payload['generated_at'], 'hit' );
+				}
+			}
+		}
+	}
+
+	try {
+		$result       = (array) call_user_func( $compute );
+		$generated_at = time();
+		$result       = extrachill_analytics_report_cache_stamp( $result, $generated_at, 'miss' );
+		set_site_transient(
+			$key,
+			array(
+				'generated_at' => $generated_at,
+				'result'       => $result,
+			),
+			EXTRACHILL_ANALYTICS_REPORT_CACHE_STALE_TTL
+		);
+
+		return $result;
+	} finally {
+		if ( $can_lock && $locked ) {
+			wp_cache_delete( $lock_key, 'extrachill_analytics_reports' );
+		}
+	}
+}

--- a/tests/ReportResultCacheTest.php
+++ b/tests/ReportResultCacheTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Tests for bounded analytics report-result caching.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/report-result-cache.php';
+
+/**
+ * Verify cache identity, freshness, warm reads, and stale behavior.
+ */
+final class ReportResultCacheTest extends TestCase {
+	/**
+	 * Reset cache fixtures.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['extrachill_analytics_test_site_transients']  = array();
+		$GLOBALS['extrachill_analytics_test_transient_ttls']   = array();
+		$GLOBALS['extrachill_analytics_test_cache']            = array();
+		$GLOBALS['extrachill_analytics_test_ext_object_cache'] = true;
+	}
+
+	/**
+	 * Equivalent normalized inputs share keys; behavior changes do not.
+	 */
+	public function test_cache_key_normalizes_inputs_and_distinguishes_scope(): void {
+		$first = extrachill_analytics_report_cache_key(
+			'retention_stats',
+			array(
+				'days'    => 28,
+				'blog_id' => 0,
+			)
+		);
+		$same  = extrachill_analytics_report_cache_key(
+			'retention_stats',
+			array(
+				'blog_id' => 0,
+				'days'    => 28,
+			)
+		);
+
+		$this->assertSame( $first, $same );
+		$this->assertNotSame(
+			$first,
+			extrachill_analytics_report_cache_key(
+				'retention_stats',
+				array(
+					'days'    => 28,
+					'blog_id' => 2,
+				)
+			)
+		);
+		$this->assertNotSame(
+			$first,
+			extrachill_analytics_report_cache_key(
+				'retention_stats',
+				array(
+					'days'    => 56,
+					'blog_id' => 0,
+				)
+			)
+		);
+	}
+
+	/**
+	 * A warm read returns the original measurement without recomputation.
+	 */
+	public function test_warm_read_preserves_as_of_and_exposes_freshness(): void {
+		$calls   = 0;
+		$compute = static function () use ( &$calls ) {
+			++$calls;
+			return array(
+				'value' => 42,
+				'as_of' => '2026-08-02 22:00:00',
+			);
+		};
+
+		$cold = extrachill_analytics_report_cache_remember( 'conversion_map', array( 'days' => 28 ), $compute );
+		$warm = extrachill_analytics_report_cache_remember( 'conversion_map', array( 'days' => 28 ), $compute );
+
+		$this->assertSame( 1, $calls );
+		$this->assertSame( 'miss', $cold['freshness']['cache_status'] );
+		$this->assertSame( 'hit', $warm['freshness']['cache_status'] );
+		$this->assertSame( $cold['as_of'], $warm['as_of'] );
+		$this->assertSame( $warm['as_of'], $warm['freshness']['as_of'] );
+		$this->assertSame( 300, $warm['freshness']['max_age_seconds'] );
+
+		$key = extrachill_analytics_report_cache_key( 'conversion_map', array( 'days' => 28 ) );
+		$this->assertSame( 600, $GLOBALS['extrachill_analytics_test_transient_ttls'][ $key ] );
+	}
+
+	/**
+	 * A lock loser receives bounded stale data instead of repeating the query.
+	 */
+	public function test_concurrent_refresh_serves_bounded_stale_result(): void {
+		$key       = extrachill_analytics_report_cache_key( 'surface_growth', array( 'weeks' => 4 ) );
+		$lock_key  = $key . '_lock';
+		$generated = time() - 301;
+		$GLOBALS['extrachill_analytics_test_site_transients'][ $key ] = array(
+			'generated_at' => $generated,
+			'result'       => array(
+				'as_of' => '2026-08-02 21:00:00',
+				'value' => 7,
+			),
+		);
+		wp_cache_add( $lock_key, 1, 'extrachill_analytics_reports', 30 );
+
+		$result = extrachill_analytics_report_cache_remember(
+			'surface_growth',
+			array( 'weeks' => 4 ),
+			static function () {
+				throw new RuntimeException( 'Stale lock loser must not compute.' );
+			}
+		);
+
+		$this->assertSame( 7, $result['value'] );
+		$this->assertSame( 'stale', $result['freshness']['cache_status'] );
+		$this->assertTrue( $result['freshness']['is_stale'] );
+	}
+
+	/**
+	 * Data older than the stale ceiling is recomputed.
+	 */
+	public function test_expired_stale_payload_is_recomputed(): void {
+		$key = extrachill_analytics_report_cache_key( 'retention_stats', array( 'days' => 28 ) );
+		$GLOBALS['extrachill_analytics_test_site_transients'][ $key ] = array(
+			'generated_at' => time() - 601,
+			'result'       => array( 'value' => 1 ),
+		);
+
+		$result = extrachill_analytics_report_cache_remember(
+			'retention_stats',
+			array( 'days' => 28 ),
+			static function () {
+				return array( 'value' => 2 );
+			}
+		);
+
+		$this->assertSame( 2, $result['value'] );
+		$this->assertSame( 'miss', $result['freshness']['cache_status'] );
+	}
+
+	/**
+	 * Each ability includes every behavior-affecting parameter in its cache input.
+	 */
+	public function test_report_wrappers_key_all_behavior_affecting_inputs(): void {
+		$root       = dirname( __DIR__ ) . '/inc/core/abilities/';
+		$surface    = file_get_contents( $root . 'get-surface-growth.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source contract fixture.
+		$retention  = file_get_contents( $root . 'get-retention-stats.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source contract fixture.
+		$conversion = file_get_contents( $root . 'get-conversion-map.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source contract fixture.
+
+		$this->assertStringContainsString( "array( 'weeks' => \$weeks )", $surface );
+		foreach ( array( 'days', 'end_days_ago', 'blog_id', 'cohort_weeks' ) as $input ) {
+			$this->assertStringContainsString( "'{$input}'", $retention );
+		}
+		foreach ( array( 'days', 'session_gap_mins', 'top_articles', 'min_entry_sessions', 'return_observation_days' ) as $input ) {
+			$this->assertStringContainsString( "'{$input}'", $conversion );
+		}
+	}
+}

--- a/tests/SurfaceGrowthRequestTest.php
+++ b/tests/SurfaceGrowthRequestTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Tests for Surface Growth upstream request reuse.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/class-surfacegrowthgaabilityfixture.php';
+require_once dirname( __DIR__ ) . '/inc/core/abilities/get-surface-growth.php';
+
+/**
+ * Ensure current traffic source rows drive both organic count and share.
+ */
+final class SurfaceGrowthRequestTest extends TestCase {
+	/**
+	 * One surface performs two date and two traffic-source reads.
+	 */
+	public function test_current_traffic_sources_result_is_reused_for_share(): void {
+		$ability = new SurfaceGrowthGaAbilityFixture();
+		$result  = extrachill_analytics_surface_demand_growth(
+			array( 'host' => 'extrachill.com' ),
+			$ability,
+			true,
+			7
+		);
+
+		$this->assertCount( 4, $ability->requests );
+		$this->assertSame( array( 'date_stats', 'date_stats', 'traffic_sources', 'traffic_sources' ), array_column( $ability->requests, 'action' ) );
+		$this->assertSame( 40, $result['current_organic'] );
+		$this->assertSame( 20, $result['previous_organic'] );
+		$this->assertSame( 0.4, $result['organic_share'] );
+		$this->assertSame( 100.0, $result['slope_pct'] );
+	}
+
+	/**
+	 * Traffic-source errors preserve the all-session fallback semantics.
+	 */
+	public function test_traffic_source_error_preserves_all_session_fallback(): void {
+		$ability               = new SurfaceGrowthGaAbilityFixture();
+		$ability->fail_traffic = true;
+		$result                = extrachill_analytics_surface_demand_growth(
+			array( 'host' => 'extrachill.com' ),
+			$ability,
+			true,
+			7
+		);
+
+		$this->assertTrue( $result['measured'] );
+		$this->assertSame( 'all_sessions', $result['basis'] );
+		$this->assertSame( 70, $result['current_organic'] );
+		$this->assertSame( 70, $result['previous_organic'] );
+		$this->assertNull( $result['organic_share'] );
+	}
+
+	/**
+	 * A truncated date series remains an explicit coverage gap.
+	 */
+	public function test_truncated_date_series_remains_not_instrumented(): void {
+		$result = extrachill_analytics_surface_demand_growth(
+			array( 'host' => 'extrachill.com' ),
+			new SurfaceGrowthGaAbilityFixture(),
+			true,
+			8
+		);
+
+		$this->assertFalse( $result['measured'] );
+		$this->assertTrue( $result['not_instrumented'] );
+		$this->assertStringContainsString( 'truncated daily series', $result['reason'] );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -178,6 +178,19 @@ if ( ! function_exists( 'wp_cache_incr' ) ) {
 		return $GLOBALS['extrachill_analytics_test_cache'][ $group ][ $key ];
 	}
 }
+if ( ! function_exists( 'wp_cache_delete' ) ) {
+	/**
+	 * Delete a cache fixture.
+	 *
+	 * @param string $key   Cache key.
+	 * @param string $group Cache group.
+	 * @return bool
+	 */
+	function wp_cache_delete( $key, $group = '' ) {
+		unset( $GLOBALS['extrachill_analytics_test_cache'][ $group ][ $key ] );
+		return true;
+	}
+}
 if ( ! function_exists( 'sanitize_key' ) ) {
 	/**
 	 * Stub for sanitize_key().

--- a/tests/class-surfacegrowthgaabilityfixture.php
+++ b/tests/class-surfacegrowthgaabilityfixture.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * GA ability fixture for Surface Growth tests.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+/**
+ * Minimal GA ability fixture that records requests.
+ */
+final class SurfaceGrowthGaAbilityFixture {
+	/**
+	 * Recorded ability requests.
+	 *
+	 * @var array<int,array<string,mixed>>
+	 */
+	public $requests = array();
+
+	/**
+	 * Whether traffic_sources requests should fail.
+	 *
+	 * @var bool
+	 */
+	public $fail_traffic = false;
+
+	/**
+	 * Return deterministic date and source rows.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	public function execute( $input ) {
+		$this->requests[] = $input;
+		if ( 'date_stats' === $input['action'] ) {
+			return array(
+				'success' => true,
+				'results' => array_fill( 0, 7, array( 'sessions' => 10 ) ),
+			);
+		}
+		if ( $this->fail_traffic ) {
+			return new WP_Error( 'ga_failed', 'Traffic sources unavailable.' );
+		}
+
+		$is_current = gmdate( 'Y-m-d', strtotime( '-7 days' ) ) === $input['start_date'];
+		return array(
+			'success' => true,
+			'results' => array(
+				array(
+					'sessions'      => $is_current ? 40 : 20,
+					'sessionMedium' => 'organic',
+				),
+				array(
+					'sessions'      => $is_current ? 60 : 30,
+					'sessionMedium' => '(none)',
+				),
+			),
+		);
+	}
+}

--- a/tests/class-wp-error.php
+++ b/tests/class-wp-error.php
@@ -43,5 +43,14 @@ if ( ! class_exists( 'WP_Error' ) ) {
 			$this->message = $message;
 			$this->data    = $data;
 		}
+
+		/**
+		 * Return the first error message.
+		 *
+		 * @return string Error message.
+		 */
+		public function get_error_message() {
+			return $this->message;
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- cache Surface Growth, Retention, and Conversion report results by normalized behavior-affecting inputs
- expose explicit freshness metadata and suppress concurrent recomputation with a persistent-cache lock plus bounded stale serving
- reuse each current-period Surface Growth `traffic_sources` result for both organic sessions and organic share

## Root Cause
Studio recomputed every report synchronously for every tab, range, and site-scope change. Live 28-day timings measured on 2026-08-02 were GA Sessions 4.23s, Surface Growth 12.26s, Retention 13.88s, and Conversion 10.73s. The first-party `c8c_extrachill_analytics_events` table was approximately 1.05M rows / 492 MB, so Retention and Conversion repeatedly paid their full aggregate/stream-processing costs while Surface Growth repeated sequential upstream GA requests.

## Cache Contract
- Key: `eca_report_v1_{network_id}_{report}_{sha256(wp_json_encode(recursively_key_sorted_normalized_inputs))}`.
- Inputs: Surface Growth keys `weeks`; Retention keys `days`, `end_days_ago`, `blog_id`, and `cohort_weeks`; Conversion keys `days`, `session_gap_mins`, `top_articles`, `min_entry_sessions`, and `return_observation_days`.
- Freshness: results are fresh for 300 seconds and expose `freshness.as_of`, `generated_at`, `fresh_until`, `max_age_seconds`, `cache_status`, and `is_stale`. The report's original measurement `as_of` is preserved.
- Expiry/invalidation: network transients are retained for 600 seconds to permit bounded stale serving. Event-write invalidation is intentionally not used because continuously arriving pageviews would prevent these caches from becoming warm; freshness is bounded by the short TTL instead.
- Stampedes: when Redis/persistent object caching is active, `wp_cache_add()` acquires an atomic 30-second recompute lock. A lock loser receives a still-bounded stale result immediately; on a truly cold collision it polls for up to 15 seconds, matching the existing cold-read cost envelope, before computing as a failure fallback. Without a persistent cache, requests compute normally because request-local locks cannot coordinate workers.

## Surface Growth Requests
Each surface previously made five cold upstream GA calls: current/prior `date_stats`, current/prior `traffic_sources`, and a duplicate current `traffic_sources` call for organic share. It now makes four by deriving current organic sessions and share from the same response.

Across five surfaces:
- cold cache miss: up to 20 GA calls, down from 25
- warm cache hit: 0 GA calls

Fallback-to-all-sessions and truncated-series `not_instrumented` coverage semantics remain unchanged.

## Verification
- `vendor/bin/phpunit`: passed, 400 tests / 1,598 assertions.
- focused PHPCS over changed production and fixture files: 0 errors; 12 pre-existing direct-query warnings in `get-retention-stats.php`.
- `git diff --check`: passed.
- `composer lint:php`: cannot provide a repository-wide clean result because the script scans `vendor/` and fails on third-party dependency source; this existing defect is tracked in #169. Changed production files pass targeted PHPCS.
- deterministic live timing was not run because the managed worktree cannot exercise the new code against production data without modifying the production runtime. Unit evidence proves warm reads skip computation; expected warm runtime is a transient/object-cache lookup under the issue's one-second target.

## Residual Risk
The first request for each unique normalized input still pays the existing full cold computation cost. If Redis is unavailable, cross-worker stampede suppression is unavailable and the five-minute TTL remains the only bound. No schema, index, or rollup changes are included because caching and duplicate-call removal address the repeated-work root cause without production profiling-driven schema evidence.

Closes #223