### PR TITLE
feat: add shared analytics date range runtime

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -30,6 +30,7 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/link-page-analytics
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/event-types.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/events.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/report-result-cache.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/date-range.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/security-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/visitor-classifier.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/search-source-classifier.php';

--- a/inc/core/abilities/get-conversion-map.php
+++ b/inc/core/abilities/get-conversion-map.php
@@ -84,6 +84,14 @@ function extrachill_analytics_register_conversion_map_ability() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
+					'start_date'              => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive UTC window start in Y-m-d format. Must be paired with end_date and takes precedence over days.', 'extrachill-analytics' ),
+					),
+					'end_date'                => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive UTC window end in Y-m-d format. Pageviews and outcomes are strictly capped at this day.', 'extrachill-analytics' ),
+					),
 					'days'                    => array(
 						'type'        => 'integer',
 						'description' => __( 'Number of days to look back for the window. Default 28.', 'extrachill-analytics' ),
@@ -172,16 +180,23 @@ function extrachill_analytics_conversion_surface_map() {
  * exact same per-visitor semantics get-retention-stats documents.
  *
  * @param array $input Input parameters.
- * @return array Conversion map.
+ * @return array|WP_Error Conversion map or date validation error.
  */
 function extrachill_analytics_ability_get_conversion_map( $input ) {
+	$date_range = extrachill_analytics_resolve_date_range( $input );
+	if ( is_wp_error( $date_range ) ) {
+		return $date_range;
+	}
+
 	$normalized = array(
-		'days'                    => isset( $input['days'] ) ? max( 1, (int) $input['days'] ) : 28,
+		'days'                    => $date_range ? $date_range['days'] : ( isset( $input['days'] ) ? max( 1, (int) $input['days'] ) : 28 ),
 		'session_gap_mins'        => isset( $input['session_gap_mins'] ) ? max( 1, (int) $input['session_gap_mins'] ) : 30,
 		'top_articles'            => isset( $input['top_articles'] ) ? max( 1, (int) $input['top_articles'] ) : 25,
 		'min_entry_sessions'      => isset( $input['min_entry_sessions'] ) ? max( 1, (int) $input['min_entry_sessions'] ) : 1,
 		'return_observation_days' => isset( $input['return_observation_days'] ) ? max( 0, (int) $input['return_observation_days'] ) : 7,
 		'author_id'               => isset( $input['author_id'] ) ? max( 0, (int) $input['author_id'] ) : 0,
+		'start_date'              => $date_range ? $date_range['start_date'] : '',
+		'end_date'                => $date_range ? $date_range['end_date'] : '',
 	);
 
 	return extrachill_analytics_report_cache_remember(
@@ -197,7 +212,7 @@ function extrachill_analytics_ability_get_conversion_map( $input ) {
  * Compute an uncached conversion-map report.
  *
  * @param array $input Normalized input parameters.
- * @return array Conversion map.
+ * @return array|WP_Error Conversion map or date validation error.
  */
 function extrachill_analytics_compute_conversion_map( $input ) {
 	global $wpdb;
@@ -208,6 +223,10 @@ function extrachill_analytics_compute_conversion_map( $input ) {
 	$min_entry_sessions      = isset( $input['min_entry_sessions'] ) ? max( 1, (int) $input['min_entry_sessions'] ) : 1;
 	$return_observation_days = isset( $input['return_observation_days'] ) ? max( 0, (int) $input['return_observation_days'] ) : 7;
 	$author_id               = isset( $input['author_id'] ) ? max( 0, (int) $input['author_id'] ) : 0;
+	$date_range              = extrachill_analytics_resolve_date_range( $input );
+	if ( is_wp_error( $date_range ) ) {
+		return $date_range;
+	}
 
 	$gap_secs = $session_gap_mins * 60;
 
@@ -220,9 +239,13 @@ function extrachill_analytics_compute_conversion_map( $input ) {
 
 	$now_ts        = time();
 	$now_utc       = gmdate( 'Y-m-d H:i:s', $now_ts );
-	$since         = gmdate( 'Y-m-d H:i:s', $now_ts - ( $days * DAY_IN_SECONDS ) );
-	$stream_since  = gmdate( 'Y-m-d H:i:s', $now_ts - ( $days * DAY_IN_SECONDS ) - ( $session_gap_mins * MINUTE_IN_SECONDS ) );
-	$mature_before = gmdate( 'Y-m-d H:i:s', $now_ts - ( $return_observation_days * DAY_IN_SECONDS ) );
+	$since         = $date_range ? $date_range['start_at'] : gmdate( 'Y-m-d H:i:s', $now_ts - ( $days * DAY_IN_SECONDS ) );
+	$window_end    = $date_range ? $date_range['end_exclusive'] : $now_utc;
+	$window_end_ts = (int) strtotime( $window_end . ' UTC' );
+	$stream_since  = gmdate( 'Y-m-d H:i:s', strtotime( $since . ' UTC' ) - ( $session_gap_mins * MINUTE_IN_SECONDS ) );
+	$mature_before = gmdate( 'Y-m-d H:i:s', $window_end_ts - ( $return_observation_days * DAY_IN_SECONDS ) );
+	$start_date    = $date_range ? $date_range['start_date'] : gmdate( 'Y-m-d', strtotime( $since ) );
+	$end_date      = $date_range ? $date_range['end_date'] : gmdate( 'Y-m-d', $now_ts );
 
 	// Pull one inactivity-gap of pre-window context plus the in-window stream for
 	// every visitor who touched the entry blog. The buffer prevents a session
@@ -241,6 +264,7 @@ function extrachill_analytics_compute_conversion_map( $input ) {
 			WHERE e.event_type = %s
 				AND e.visitor_id IS NOT NULL AND e.visitor_id != ''
 				AND e.created_at >= %s
+				AND e.created_at < %s
 				AND e.visitor_id IN (
 					SELECT visitor_id FROM (
 						SELECT DISTINCT visitor_id
@@ -248,14 +272,17 @@ function extrachill_analytics_compute_conversion_map( $input ) {
 						WHERE event_type = %s
 							AND visitor_id IS NOT NULL AND visitor_id != ''
 							AND created_at >= %s
+							AND created_at < %s
 							AND blog_id = %d
 					) AS entry_visitors
 				)
 			ORDER BY e.visitor_id ASC, e.created_at ASC, e.id ASC",
 			$event_type,
 			$stream_since,
+			$window_end,
 			$event_type,
 			$stream_since,
+			$window_end,
 			$entry_blog_id
 		)
 	);
@@ -469,7 +496,7 @@ function extrachill_analytics_compute_conversion_map( $input ) {
 		$table,
 		$outcome_types,
 		$since,
-		$now_utc,
+		$window_end,
 		static function ( $page ) use ( &$visitor_users ) {
 			extrachill_analytics_conversion_observe_outcome_identities( $page, $visitor_users );
 		}
@@ -480,7 +507,7 @@ function extrachill_analytics_compute_conversion_map( $input ) {
 		$table,
 		$outcome_types,
 		$since,
-		$now_utc,
+		$window_end,
 		static function ( $page ) use ( $entry_blog_id, $author_id, $journeys_by_visitor, $visitor_to_user, &$outcome_records, &$outcome_coverage ) {
 			extrachill_analytics_conversion_collect_outcome_rows(
 				$page,
@@ -578,12 +605,15 @@ function extrachill_analytics_compute_conversion_map( $input ) {
 			'attribution_semantics' => 'direct_source resolves the outcome event source_url to a published main-site article. visitor_journey attributes an identified outcome occurring after that visitor\'s first eligible mature entry journey, split at the configured pageview-session boundary. Outcome identity is event_data.user_id then stored user_id, with visitor_id stitched to a user only when this window observes exactly one user for that visitor; ambiguous visitors are not merged. Repeated person/outcome rows count once, while later rows may supply attribution missing from an earlier duplicate. The lenses are independent and may both attribute one outcome; do not add them as unique people. Coverage status measured, partial, or not_instrumented must be read with each count.',
 		),
 		'days'                        => $days,
+		'start_date'                  => $start_date,
+		'end_date'                    => $end_date,
 		'session_gap_mins'            => $session_gap_mins,
 		'return_observation_days'     => $return_observation_days,
 		'denominator'                 => 'One first eligible, mature editorial-entry journey per visitor. An eligible entry is a session starting in the reporting window on a published blog-1 post; late entries without the configured return observation period are excluded.',
 		'measured_destination_routes' => 'Eligible collected pageviews on events, community, and artist, including post-backed singular views and route-level homepage, archive, search, auth, and directory views. Entry journeys remain published blog-1 posts only. Historical periods before issue #182 deployment remain singular-only.',
-		'period'                      => gmdate( 'Y-m-d', $now_ts - ( $days * DAY_IN_SECONDS ) ) . ' to ' . gmdate( 'Y-m-d', $now_ts ),
+		'period'                      => $start_date . ' to ' . $end_date,
 		'since'                       => $since,
+		'until'                       => $window_end,
 		'as_of'                       => $now_utc,
 		'note'                        => 'First-party, bot-filtered editorial-to-platform funnel. entry_sessions is a legacy field name: it counts one first eligible, mature entry journey per visitor, not every entry session. Eligible entries start on a published blog-1 post; route views never become editorial entries. Same-session and return reach include eligible collected events/community/artist routes. Newsletter signup, registration, onboarding completion, and artist profile first publication are successful server-side outcomes reported through separate direct-source and visitor-journey lenses. Automatic registration newsletter subscriptions are excluded. Missing source or visitor identity and outcome types absent from the window remain explicit coverage, never an inferred zero. Route-level destination collection is additive from issue #182 onward, so historical periods remain singular-only. Pageviews include one inactivity-gap before the lower boundary; outcomes use two bounded keyset passes ordered by created_at then row ID for ambiguity-safe visitor/user stitching and attribution. Late entries without the configured return observation period and NULL-visitor pageviews (GPC/DNT opt-out) are excluded.',
 	);
@@ -614,10 +644,10 @@ function extrachill_analytics_conversion_outcome_types() {
  * @param string   $table         Trusted analytics events table name.
  * @param string[] $outcome_types Concrete outcome event names.
  * @param string   $since         Inclusive UTC lower bound.
- * @param string   $as_of         Inclusive UTC upper bound.
+ * @param string   $end_exclusive Exclusive UTC upper bound.
  * @param callable $consume       Receives each ordered page.
  */
-function extrachill_analytics_conversion_each_outcome_page( $table, $outcome_types, $since, $as_of, $consume ) {
+function extrachill_analytics_conversion_each_outcome_page( $table, $outcome_types, $since, $end_exclusive, $consume ) {
 	global $wpdb;
 
 	$page_size          = 500;
@@ -629,9 +659,9 @@ function extrachill_analytics_conversion_each_outcome_page( $table, $outcome_typ
 		$where  = array(
 			"event_type IN ({$event_placeholders})",
 			'created_at >= %s',
-			'created_at <= %s',
+			'created_at < %s',
 		);
-		$values = array_merge( array_map( 'sanitize_key', $outcome_types ), array( $since, $as_of ) );
+		$values = array_merge( array_map( 'sanitize_key', $outcome_types ), array( $since, $end_exclusive ) );
 
 		if ( null !== $cursor_time ) {
 			$where[]  = '(created_at > %s OR (created_at = %s AND id > %d))';

--- a/inc/core/abilities/get-retention-stats.php
+++ b/inc/core/abilities/get-retention-stats.php
@@ -42,6 +42,14 @@ function extrachill_analytics_register_retention_stats_ability() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
+					'start_date'   => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive UTC window start in Y-m-d format. Must be paired with end_date and takes precedence over days/end_days_ago.', 'extrachill-analytics' ),
+					),
+					'end_date'     => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive UTC window end in Y-m-d format. Must be paired with start_date.', 'extrachill-analytics' ),
+					),
 					'days'         => array(
 						'type'        => 'integer',
 						'description' => __( 'Number of days the window spans. Default 28.', 'extrachill-analytics' ),
@@ -49,7 +57,7 @@ function extrachill_analytics_register_retention_stats_ability() {
 					),
 					'end_days_ago' => array(
 						'type'        => 'integer',
-						'description' => __( 'How many days ago the window ENDS. 0 (default) means the window ends now. A positive value shifts the whole window into the past, enabling an exact prior-period read (e.g. days=28, end_days_ago=28 reads the 28-day window immediately before the most recent 28 days). Applies to return rate, cross-site return, and session depth; the cohort curve always anchors at now.', 'extrachill-analytics' ),
+						'description' => __( 'How many days ago the window ENDS. 0 (default) means the window ends now. A positive value shifts the whole window into the past, enabling an exact prior-period read (e.g. days=28, end_days_ago=28 reads the 28-day window immediately before the most recent 28 days). Applies to return rate, cross-site return, and session depth; the cohort curve anchors at now for relative reads and at end_date for exact reads.', 'extrachill-analytics' ),
 						'default'     => 0,
 					),
 					'blog_id'      => array(
@@ -86,14 +94,21 @@ function extrachill_analytics_register_retention_stats_ability() {
  * Execute callback for get-retention-stats ability.
  *
  * @param array $input Input parameters.
- * @return array Retention metrics.
+ * @return array|WP_Error Retention metrics or date validation error.
  */
 function extrachill_analytics_ability_get_retention_stats( $input ) {
+	$date_range = extrachill_analytics_resolve_date_range( $input );
+	if ( is_wp_error( $date_range ) ) {
+		return $date_range;
+	}
+
 	$normalized = array(
-		'days'         => isset( $input['days'] ) ? max( 1, (int) $input['days'] ) : 28,
-		'end_days_ago' => isset( $input['end_days_ago'] ) ? max( 0, (int) $input['end_days_ago'] ) : 0,
+		'days'         => $date_range ? $date_range['days'] : ( isset( $input['days'] ) ? max( 1, (int) $input['days'] ) : 28 ),
+		'end_days_ago' => $date_range ? 0 : ( isset( $input['end_days_ago'] ) ? max( 0, (int) $input['end_days_ago'] ) : 0 ),
 		'blog_id'      => isset( $input['blog_id'] ) ? max( 0, (int) $input['blog_id'] ) : 0,
 		'cohort_weeks' => isset( $input['cohort_weeks'] ) ? max( 1, (int) $input['cohort_weeks'] ) : 8,
+		'start_date'   => $date_range ? $date_range['start_date'] : '',
+		'end_date'     => $date_range ? $date_range['end_date'] : '',
 	);
 
 	return extrachill_analytics_report_cache_remember(
@@ -109,7 +124,7 @@ function extrachill_analytics_ability_get_retention_stats( $input ) {
  * Compute an uncached retention report.
  *
  * @param array $input Normalized input parameters.
- * @return array Retention metrics.
+ * @return array|WP_Error Retention metrics or date validation error.
  */
 function extrachill_analytics_compute_retention_stats( $input ) {
 	global $wpdb;
@@ -118,6 +133,10 @@ function extrachill_analytics_compute_retention_stats( $input ) {
 	$end_days_ago = isset( $input['end_days_ago'] ) ? max( 0, (int) $input['end_days_ago'] ) : 0;
 	$blog_id      = isset( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
 	$cohort_weeks = isset( $input['cohort_weeks'] ) ? max( 1, (int) $input['cohort_weeks'] ) : 8;
+	$date_range   = extrachill_analytics_resolve_date_range( $input );
+	if ( is_wp_error( $date_range ) ) {
+		return $date_range;
+	}
 
 	$table      = extrachill_analytics_events_table();
 	$event_type = defined( 'EC_ANALYTICS_EVENT_PAGEVIEW' ) ? EC_ANALYTICS_EVENT_PAGEVIEW : 'pageview';
@@ -125,9 +144,11 @@ function extrachill_analytics_compute_retention_stats( $input ) {
 	// The window ENDS at $end_days_ago days before now (0 = now) and SPANS
 	// $days. Shifting the end into the past yields an exact prior-period read
 	// without any end-date-less proxying.
-	$now_utc    = gmdate( 'Y-m-d H:i:s' );
-	$window_end = gmdate( 'Y-m-d H:i:s', strtotime( "-{$end_days_ago} days" ) );
-	$since      = gmdate( 'Y-m-d H:i:s', strtotime( '-' . ( $days + $end_days_ago ) . ' days' ) );
+	$now_utc    = $date_range ? $date_range['end_exclusive'] : gmdate( 'Y-m-d H:i:s' );
+	$window_end = $date_range ? $date_range['end_exclusive'] : gmdate( 'Y-m-d H:i:s', (int) strtotime( "-{$end_days_ago} days" ) );
+	$since      = $date_range ? $date_range['start_at'] : gmdate( 'Y-m-d H:i:s', (int) strtotime( '-' . ( $days + $end_days_ago ) . ' days' ) );
+	$start_date = $date_range ? $date_range['start_date'] : gmdate( 'Y-m-d', (int) strtotime( $since ) );
+	$end_date   = $date_range ? $date_range['end_date'] : gmdate( 'Y-m-d', (int) strtotime( $window_end ) );
 
 	// Common WHERE: pageviews, in window, with a non-NULL visitor_id (opted-out
 	// rows are excluded from per-visitor metrics), optional blog filter. An
@@ -136,7 +157,7 @@ function extrachill_analytics_compute_retention_stats( $input ) {
 	$base_where  = array( 'event_type = %s', "visitor_id IS NOT NULL AND visitor_id != ''", 'created_at >= %s' );
 	$base_values = array( $event_type, $since );
 
-	if ( $end_days_ago > 0 ) {
+	if ( $date_range || $end_days_ago > 0 ) {
 		$base_where[]  = 'created_at < %s';
 		$base_values[] = $window_end;
 	}
@@ -174,7 +195,7 @@ function extrachill_analytics_compute_retention_stats( $input ) {
 	// available history (within the requested blog scope). W1 and W2 are the
 	// first and second complete ISO weeks after that acquisition week.
 	// ---------------------------------------------------------------------
-	$cohort_since = gmdate( 'Y-m-d H:i:s', strtotime( "-{$cohort_weeks} weeks" ) );
+	$cohort_since = gmdate( 'Y-m-d H:i:s', (int) strtotime( "-{$cohort_weeks} weeks", (int) strtotime( $now_utc ) ) );
 
 	$cohort_where  = array( 'event_type = %s', "visitor_id IS NOT NULL AND visitor_id != ''", 'created_at < %s' );
 	$cohort_values = array( $event_type, $now_utc );
@@ -244,7 +265,7 @@ function extrachill_analytics_compute_retention_stats( $input ) {
 	// ---------------------------------------------------------------------
 	$xsite_where  = array( 'event_type = %s', "visitor_id IS NOT NULL AND visitor_id != ''", 'created_at >= %s' );
 	$xsite_values = array( $event_type, $since );
-	if ( $end_days_ago > 0 ) {
+	if ( $date_range || $end_days_ago > 0 ) {
 		$xsite_where[]  = 'created_at < %s';
 		$xsite_values[] = $window_end;
 	}
@@ -303,7 +324,7 @@ function extrachill_analytics_compute_retention_stats( $input ) {
 	// ---------------------------------------------------------------------
 	$ref_where  = array( 'event_type = %s', 'created_at >= %s', "JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.referrer_host')) IS NOT NULL" );
 	$ref_values = array( $event_type, $since );
-	if ( $end_days_ago > 0 ) {
+	if ( $date_range || $end_days_ago > 0 ) {
 		$ref_where[]  = 'created_at < %s';
 		$ref_values[] = $window_end;
 	}
@@ -339,7 +360,7 @@ function extrachill_analytics_compute_retention_stats( $input ) {
 	// they must not be silently presented as whole-platform route coverage.
 	$coverage_where  = array( 'event_type = %s', 'created_at >= %s' );
 	$coverage_values = array( $event_type, $since );
-	if ( $end_days_ago > 0 ) {
+	if ( $date_range || $end_days_ago > 0 ) {
 		$coverage_where[]  = 'created_at < %s';
 		$coverage_values[] = $window_end;
 	}
@@ -397,8 +418,10 @@ function extrachill_analytics_compute_retention_stats( $input ) {
 		),
 		'days'                => $days,
 		'end_days_ago'        => $end_days_ago,
+		'start_date'          => $start_date,
+		'end_date'            => $end_date,
 		'blog_id'             => $blog_id,
-		'period'              => gmdate( 'Y-m-d', strtotime( $since ) ) . ' to ' . gmdate( 'Y-m-d', strtotime( $window_end ) ),
+		'period'              => $start_date . ' to ' . $end_date,
 		'since'               => $since,
 		'until'               => $window_end,
 		'as_of'               => $now_utc,

--- a/inc/core/abilities/get-surface-growth.php
+++ b/inc/core/abilities/get-surface-growth.php
@@ -68,7 +68,15 @@ function extrachill_analytics_register_surface_growth_ability() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'weeks' => array(
+					'start_date' => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive UTC window start in Y-m-d format. Must be paired with end_date and takes precedence over weeks.', 'extrachill-analytics' ),
+					),
+					'end_date'   => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive UTC window end in Y-m-d format. The comparison is the immediately preceding equal-length window.', 'extrachill-analytics' ),
+					),
+					'weeks'      => array(
 						'type'        => 'integer',
 						'description' => __( 'Number of weeks the growth window spans. Default 4. The demand slope compares this window against the immediately-preceding window of equal length.', 'extrachill-analytics' ),
 						'default'     => 4,
@@ -157,16 +165,27 @@ function extrachill_analytics_surface_growth_map() {
  * Execute callback for get-surface-growth ability.
  *
  * @param array $input Input parameters.
- * @return array Cross-surface growth read.
+ * @return array|WP_Error Cross-surface growth read or date validation error.
  */
 function extrachill_analytics_ability_get_surface_growth( $input ) {
-	$weeks = isset( $input['weeks'] ) ? max( 1, (int) $input['weeks'] ) : 4;
+	$date_range = extrachill_analytics_resolve_date_range( $input );
+	if ( is_wp_error( $date_range ) ) {
+		return $date_range;
+	}
+
+	$weeks      = isset( $input['weeks'] ) ? max( 1, (int) $input['weeks'] ) : 4;
+	$normalized = $date_range
+		? array(
+			'start_date' => $date_range['start_date'],
+			'end_date'   => $date_range['end_date'],
+		)
+		: array( 'weeks' => $weeks );
 
 	return extrachill_analytics_report_cache_remember(
 		'surface_growth',
-		array( 'weeks' => $weeks ),
-		static function () use ( $weeks ) {
-			return extrachill_analytics_compute_surface_growth( array( 'weeks' => $weeks ) );
+		$normalized,
+		static function () use ( $normalized ) {
+			return extrachill_analytics_compute_surface_growth( $normalized );
 		}
 	);
 }
@@ -175,17 +194,24 @@ function extrachill_analytics_ability_get_surface_growth( $input ) {
  * Compute an uncached surface-growth report.
  *
  * @param array $input Normalized input parameters.
- * @return array Cross-surface growth read.
+ * @return array|WP_Error Cross-surface growth read or date validation error.
  */
 function extrachill_analytics_compute_surface_growth( $input ) {
-	$weeks = isset( $input['weeks'] ) ? max( 1, (int) $input['weeks'] ) : 4;
-	$days  = $weeks * 7;
+	$date_range = extrachill_analytics_resolve_date_range( $input );
+	if ( is_wp_error( $date_range ) ) {
+		return $date_range;
+	}
+	$weeks      = isset( $input['weeks'] ) ? max( 1, (int) $input['weeks'] ) : 4;
+	$days       = $date_range ? $date_range['days'] : $weeks * 7;
+	$weeks      = $days / 7;
 
 	$now_utc      = gmdate( 'Y-m-d H:i:s' );
-	$window_start = gmdate( 'Y-m-d H:i:s', (int) strtotime( "-{$days} days" ) );
+	$window_start = $date_range ? $date_range['start_at'] : gmdate( 'Y-m-d H:i:s', (int) strtotime( "-{$days} days" ) );
+	$window_end   = $date_range ? $date_range['end_exclusive'] : $now_utc;
 	// Prior equal-length window, used for both the supply % (prior_total is
 	// everything before the window) and the demand slope (previous period).
-	$prior_start = gmdate( 'Y-m-d H:i:s', (int) strtotime( "-{$days} days", (int) strtotime( $window_start ) ) );
+	$prior_window = $date_range ? extrachill_analytics_previous_date_range( $date_range ) : null;
+	$prior_start  = $prior_window ? $prior_window['start_at'] : gmdate( 'Y-m-d H:i:s', (int) strtotime( "-{$days} days", (int) strtotime( $window_start ) ) );
 
 	// Resolve the GA ability once. Its absence is a demand coverage gap, not a
 	// fatal: every surface's demand figure degrades to not_instrumented.
@@ -197,8 +223,8 @@ function extrachill_analytics_compute_surface_growth( $input ) {
 	$surfaces = array();
 
 	foreach ( extrachill_analytics_surface_growth_map() as $key => $surface ) {
-		$supply = extrachill_analytics_surface_supply_growth( $surface, $window_start, $days );
-		$demand = extrachill_analytics_surface_demand_growth( $surface, $ga_ability, $ga_available, $days );
+		$supply = extrachill_analytics_surface_supply_growth( $surface, $window_start, $days, $window_end );
+		$demand = extrachill_analytics_surface_demand_growth( $surface, $ga_ability, $ga_available, $days, $date_range, $prior_window );
 
 		$surfaces[ $key ] = array(
 			'surface'             => $key,
@@ -223,9 +249,11 @@ function extrachill_analytics_compute_surface_growth( $input ) {
 		'fastest_growing' => extrachill_analytics_fastest_growing( $surfaces ),
 		'weeks'           => $weeks,
 		'days'            => $days,
+		'start_date'      => $date_range ? $date_range['start_date'] : gmdate( 'Y-m-d', strtotime( $window_start ) ),
+		'end_date'        => $date_range ? $date_range['end_date'] : gmdate( 'Y-m-d', strtotime( $window_end ) ),
 		'window'          => array(
 			'start' => $window_start,
-			'end'   => $now_utc,
+			'end'   => $window_end,
 		),
 		'prior_window'    => array(
 			'start' => $prior_start,
@@ -249,9 +277,10 @@ function extrachill_analytics_compute_surface_growth( $input ) {
  * @param array  $surface      Surface definition.
  * @param string $window_start UTC lower bound of the window (Y-m-d H:i:s).
  * @param int    $days         Window length in days.
+ * @param string $window_end   Exclusive UTC upper bound.
  * @return array Supply growth figure, or a not_instrumented marker.
  */
-function extrachill_analytics_surface_supply_growth( $surface, $window_start, $days ) {
+function extrachill_analytics_surface_supply_growth( $surface, $window_start, $days, $window_end = '' ) {
 	global $wpdb;
 
 	$blog_id   = (int) $surface['blog_id'];
@@ -261,10 +290,9 @@ function extrachill_analytics_surface_supply_growth( $surface, $window_start, $d
 		return extrachill_analytics_not_instrumented( 'Surface has no countable blog/post type.' );
 	}
 
-	// post_date is stored in the site's local timezone, but the window bound is
-	// UTC. Convert the bound to the blog's local time so the COUNT(*) compares
-	// like with like. We switch into the blog only to read its timezone + table
-	// prefix; the query itself is a single aggregate.
+	// Published posts carry post_date_gmt, so compare directly against the UTC
+	// report bounds. This avoids applying today's numeric site offset to a
+	// historical window that may cross a daylight-saving transition.
 	$prefix = $wpdb->get_blog_prefix( $blog_id );
 	$table  = $prefix . 'posts';
 
@@ -276,34 +304,38 @@ function extrachill_analytics_surface_supply_growth( $surface, $window_start, $d
 		return extrachill_analytics_not_instrumented( 'Posts table for this surface is not available.' );
 	}
 
-	// Express the UTC window bound in the blog's local time for post_date
-	// comparison. get_post_time/Date helpers need blog context, so resolve the
-	// offset from the blog's gmt_offset option directly to avoid a switch.
-	$gmt_offset   = (float) get_blog_option( $blog_id, 'gmt_offset', 0 );
-	$offset_secs  = (int) round( $gmt_offset * HOUR_IN_SECONDS );
-	$window_local = gmdate( 'Y-m-d H:i:s', strtotime( $window_start ) + $offset_secs );
-
 	// $table is an internal, trusted blog-prefix table name from
 	// $wpdb->get_blog_prefix() — never user input — and cannot be passed as a
 	// prepare() placeholder. Values are placeholdered. Direct aggregate reads
 	// are intentional (no cache layer for these cross-surface counts).
 	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	// New items inside the window.
-	$new_count = (int) $wpdb->get_var(
-		$wpdb->prepare(
-			"SELECT COUNT(*) FROM {$table} WHERE post_type = %s AND post_status = 'publish' AND post_date >= %s",
-			$post_type,
-			$window_local
-		)
-	);
+	if ( '' !== $window_end ) {
+		$new_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table} WHERE post_type = %s AND post_status = 'publish' AND post_date_gmt >= %s AND post_date_gmt < %s",
+				$post_type,
+				$window_start,
+				$window_end
+			)
+		);
+	} else {
+		$new_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table} WHERE post_type = %s AND post_status = 'publish' AND post_date_gmt >= %s",
+				$post_type,
+				$window_start
+			)
+		);
+	}
 
 	// Prior total: everything published before the window. Basis for the
 	// percent-growth figure (new_in_window / prior_total).
 	$prior_total = (int) $wpdb->get_var(
 		$wpdb->prepare(
-			"SELECT COUNT(*) FROM {$table} WHERE post_type = %s AND post_status = 'publish' AND post_date < %s",
+			"SELECT COUNT(*) FROM {$table} WHERE post_type = %s AND post_status = 'publish' AND post_date_gmt < %s",
 			$post_type,
-			$window_local
+			$window_start
 		)
 	);
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -346,9 +378,11 @@ function extrachill_analytics_surface_supply_growth( $surface, $window_start, $d
  * @param WP_Ability|null $ga_ability   Resolved GA ability (or null).
  * @param bool            $ga_available Whether the GA ability resolved.
  * @param int             $days         Window length in days.
+ * @param array|null      $date_range   Exact current window, or null for relative mode.
+ * @param array|null      $prior_window Exact previous window, or null for relative mode.
  * @return array Demand growth figure, or a not_instrumented marker.
  */
-function extrachill_analytics_surface_demand_growth( $surface, $ga_ability, $ga_available, $days ) {
+function extrachill_analytics_surface_demand_growth( $surface, $ga_ability, $ga_available, $days, $date_range = null, $prior_window = null ) {
 	if ( ! $ga_available ) {
 		return extrachill_analytics_not_instrumented( 'Google Analytics ability (datamachine/google-analytics) is not available on this install.' );
 	}
@@ -358,10 +392,10 @@ function extrachill_analytics_surface_demand_growth( $surface, $ga_ability, $ga_
 	// Window boundaries as GA-style YYYY-MM-DD dates. GA date_stats excludes
 	// "today" (defaults to yesterday) so we mirror that: the current window ends
 	// yesterday; the previous window is the equal-length span before it.
-	$cur_end    = gmdate( 'Y-m-d', (int) strtotime( '-1 day' ) );
-	$cur_start  = gmdate( 'Y-m-d', (int) strtotime( "-{$days} days" ) );
-	$prev_end   = gmdate( 'Y-m-d', (int) strtotime( '-' . ( $days + 1 ) . ' days' ) );
-	$prev_start = gmdate( 'Y-m-d', (int) strtotime( '-' . ( $days * 2 ) . ' days' ) );
+	$cur_end    = $date_range ? $date_range['end_date'] : gmdate( 'Y-m-d', (int) strtotime( '-1 day' ) );
+	$cur_start  = $date_range ? $date_range['start_date'] : gmdate( 'Y-m-d', (int) strtotime( "-{$days} days" ) );
+	$prev_end   = $prior_window ? $prior_window['end_date'] : gmdate( 'Y-m-d', (int) strtotime( '-' . ( $days + 1 ) . ' days' ) );
+	$prev_start = $prior_window ? $prior_window['start_date'] : gmdate( 'Y-m-d', (int) strtotime( '-' . ( $days * 2 ) . ' days' ) );
 
 	// The window is $days long; date_stats returns one row per day, so the
 	// expected series length is $days. Pass it through so the helper can both

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -348,6 +348,9 @@ add_action( 'template_redirect', 'extrachill_analytics_prime_visitor_cookie' );
  */
 const EXTRACHILL_ANALYTICS_CHART_HANDLE = 'extrachill-analytics-chart';
 
+/** Shared on-demand analytics date-range script and style handle. */
+const EXTRACHILL_ANALYTICS_DATE_RANGE_HANDLE = 'extrachill-analytics-date-range';
+
 /**
  * Register (do NOT enqueue) the shared Chart.js v4 script handle.
  *
@@ -394,6 +397,50 @@ add_action( 'wp_enqueue_scripts', 'extrachill_analytics_register_chart_asset', 5
 add_action( 'admin_enqueue_scripts', 'extrachill_analytics_register_chart_asset', 5 );
 
 /**
+ * Register, but do not enqueue, the shared analytics date-range runtime.
+ *
+ * Consumers declare the handle as a dependency. The bundled Flatpickr runtime
+ * exposes `window.ExtraChillAnalyticsDateRange.create()` for plain JavaScript or
+ * framework wrappers, while the matching style handle owns Flatpickr's base and
+ * analytics theme CSS.
+ *
+ * @return bool True when the built runtime is available.
+ */
+function extrachill_analytics_register_date_range_asset() {
+	if (
+		wp_script_is( EXTRACHILL_ANALYTICS_DATE_RANGE_HANDLE, 'registered' )
+		&& wp_style_is( EXTRACHILL_ANALYTICS_DATE_RANGE_HANDLE, 'registered' )
+	) {
+		return true;
+	}
+
+	$asset_file = EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'build/date-range.asset.php';
+	$style_file = EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'build/date-range.css';
+	if ( ! file_exists( $asset_file ) || ! file_exists( $style_file ) ) {
+		return false;
+	}
+
+	$asset = require $asset_file;
+	wp_register_script(
+		EXTRACHILL_ANALYTICS_DATE_RANGE_HANDLE,
+		EXTRACHILL_ANALYTICS_PLUGIN_URL . 'build/date-range.js',
+		isset( $asset['dependencies'] ) ? $asset['dependencies'] : array(),
+		isset( $asset['version'] ) ? $asset['version'] : EXTRACHILL_ANALYTICS_VERSION,
+		true
+	);
+	wp_register_style(
+		EXTRACHILL_ANALYTICS_DATE_RANGE_HANDLE,
+		EXTRACHILL_ANALYTICS_PLUGIN_URL . 'build/date-range.css',
+		array(),
+		isset( $asset['version'] ) ? $asset['version'] : EXTRACHILL_ANALYTICS_VERSION
+	);
+
+	return true;
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_analytics_register_date_range_asset', 5 );
+add_action( 'admin_enqueue_scripts', 'extrachill_analytics_register_date_range_asset', 5 );
+
+/**
  * Enqueue view tracking on eligible public routes.
  */
 function extrachill_analytics_enqueue_view_tracking() {
@@ -401,7 +448,7 @@ function extrachill_analytics_enqueue_view_tracking() {
 		return;
 	}
 
-	$post_id = is_singular() ? get_the_ID() : 0;
+	$post_id = is_singular() ? (int) get_the_ID() : 0;
 	// Existing custom-domain singular views remain anonymous and post-backed;
 	// route-level collection is first-party only.
 	if ( $post_id <= 0 && ! extrachill_analytics_request_host_is_first_party() ) {
@@ -432,7 +479,7 @@ function extrachill_analytics_enqueue_view_tracking() {
 		'extrachill-view-tracking',
 		EXTRACHILL_ANALYTICS_PLUGIN_URL . 'assets/js/view-tracking.js',
 		array(),
-		filemtime( $js_path ),
+		(string) filemtime( $js_path ),
 		array(
 			'strategy'  => 'defer',
 			'in_footer' => true,
@@ -502,7 +549,7 @@ function extrachill_analytics_enqueue_outbound_tracking() {
 		'extrachill-outbound-tracking',
 		EXTRACHILL_ANALYTICS_PLUGIN_URL . 'assets/js/outbound-tracking.js',
 		array(),
-		filemtime( $js_path ),
+		(string) filemtime( $js_path ),
 		array(
 			'strategy'  => 'defer',
 			'in_footer' => true,

--- a/inc/core/date-range.php
+++ b/inc/core/date-range.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Shared analytics date-window validation.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/** Maximum inclusive analytics date range. */
+const EXTRACHILL_ANALYTICS_MAX_DATE_RANGE_DAYS = 364;
+
+/**
+ * Validate a canonical UTC calendar date.
+ *
+ * @param mixed $date Candidate date.
+ * @return bool Whether the date is valid Y-m-d.
+ */
+function extrachill_analytics_is_valid_date( $date ) {
+	if ( ! is_string( $date ) || ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
+		return false;
+	}
+
+	return checkdate( (int) $matches[2], (int) $matches[3], (int) $matches[1] );
+}
+
+/**
+ * Resolve optional inclusive dates to exact UTC boundaries.
+ *
+ * Empty dates indicate that the caller should preserve its legacy relative
+ * window. Exact windows are represented as [start_at, end_exclusive), avoiding
+ * fractional-second and end-of-day ambiguity in SQL.
+ *
+ * @param array $input Ability input.
+ * @param int   $maximum_days Maximum inclusive range length.
+ * @return array|WP_Error|null Exact window, validation error, or null.
+ */
+function extrachill_analytics_resolve_date_range( $input, $maximum_days = EXTRACHILL_ANALYTICS_MAX_DATE_RANGE_DAYS ) {
+	$start_date = isset( $input['start_date'] ) ? trim( (string) $input['start_date'] ) : '';
+	$end_date   = isset( $input['end_date'] ) ? trim( (string) $input['end_date'] ) : '';
+
+	if ( '' === $start_date && '' === $end_date ) {
+		return null;
+	}
+
+	if (
+		'' === $start_date
+		|| '' === $end_date
+		|| ! extrachill_analytics_is_valid_date( $start_date )
+		|| ! extrachill_analytics_is_valid_date( $end_date )
+		|| $start_date > $end_date
+	) {
+		return new WP_Error(
+			'invalid_analytics_date_range',
+			__( 'start_date and end_date must be valid Y-m-d dates, with start_date on or before end_date.', 'extrachill-analytics' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$start_ts = gmmktime( 0, 0, 0, (int) substr( $start_date, 5, 2 ), (int) substr( $start_date, 8, 2 ), (int) substr( $start_date, 0, 4 ) );
+	$end_ts   = gmmktime( 0, 0, 0, (int) substr( $end_date, 5, 2 ), (int) substr( $end_date, 8, 2 ), (int) substr( $end_date, 0, 4 ) );
+	$days     = (int) ( ( $end_ts - $start_ts ) / DAY_IN_SECONDS ) + 1;
+
+	if ( $days > max( 1, (int) $maximum_days ) ) {
+		return new WP_Error(
+			'analytics_date_range_too_large',
+			sprintf(
+				/* translators: %d: Maximum inclusive date range in days. */
+				__( 'The selected analytics date range cannot exceed %d days.', 'extrachill-analytics' ),
+				(int) $maximum_days
+			),
+			array( 'status' => 400 )
+		);
+	}
+
+	return array(
+		'start_date'    => $start_date,
+		'end_date'      => $end_date,
+		'start_at'      => $start_date . ' 00:00:00',
+		'end_exclusive' => gmdate( 'Y-m-d H:i:s', $end_ts + DAY_IN_SECONDS ),
+		'days'          => $days,
+	);
+}
+
+/**
+ * Build the immediately preceding inclusive window of equal length.
+ *
+ * @param array $window Exact window from extrachill_analytics_resolve_date_range().
+ * @return array Previous date window.
+ */
+function extrachill_analytics_previous_date_range( $window ) {
+	$start_ts = (int) strtotime( $window['start_at'] . ' UTC' );
+	$days     = (int) $window['days'];
+
+	return array(
+		'start_date'    => gmdate( 'Y-m-d', $start_ts - ( $days * DAY_IN_SECONDS ) ),
+		'end_date'      => gmdate( 'Y-m-d', $start_ts - DAY_IN_SECONDS ),
+		'start_at'      => gmdate( 'Y-m-d H:i:s', $start_ts - ( $days * DAY_IN_SECONDS ) ),
+		'end_exclusive' => $window['start_at'],
+		'days'          => $days,
+	);
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"start": "wp-scripts start",
 		"lint:js": "wp-scripts lint-js",
 		"lint:css": "wp-scripts lint-style",
+		"test:js": "wp-scripts test-unit-js",
 		"format": "wp-scripts format"
 	},
 	"author": "Chris Huber <hello@chubes.net>",
@@ -21,6 +22,7 @@
 		"@wordpress/element": "^6.0.0",
 		"@wordpress/i18n": "^5.0.0",
 		"chart.js": "^4.4.0",
+		"flatpickr": "^4.6.13",
 		"wp-native-client": "^0.0.1"
 	},
 	"private": true

--- a/src/date-range.css
+++ b/src/date-range.css
@@ -1,0 +1,30 @@
+.flatpickr-calendar {
+	font-family: inherit;
+	border: 1px solid var(--extrachill-border-color, #c3c4c7);
+	box-shadow: 0 8px 24px rgb(0 0 0 / 16%);
+}
+
+.flatpickr-months .flatpickr-prev-month:focus-visible,
+.flatpickr-months .flatpickr-next-month:focus-visible {
+	outline: 2px solid var(--extrachill-accent-color, #2271b1);
+	outline-offset: -2px;
+}
+
+.flatpickr-day.selected,
+.flatpickr-day.startRange,
+.flatpickr-day.endRange,
+.flatpickr-day.selected:hover,
+.flatpickr-day.startRange:hover,
+.flatpickr-day.endRange:hover {
+	color: #fff;
+	background: var(--extrachill-accent-color, #2271b1);
+	border-color: var(--extrachill-accent-color, #2271b1);
+}
+
+.flatpickr-day.inRange {
+	background: color-mix(in srgb, var(--extrachill-accent-color, #2271b1) 15%, transparent);
+	border-color: transparent;
+	box-shadow:
+		-5px 0 0 color-mix(in srgb, var(--extrachill-accent-color, #2271b1) 15%, transparent),
+		5px 0 0 color-mix(in srgb, var(--extrachill-accent-color, #2271b1) 15%, transparent);
+}

--- a/src/date-range.js
+++ b/src/date-range.js
@@ -1,0 +1,236 @@
+/**
+ * Framework-neutral analytics date-range runtime.
+ *
+ * Public API:
+ * window.ExtraChillAnalyticsDateRange.create(input, options)
+ *
+ * `options.startDate` / `endDate` and all delivered values are canonical UTC
+ * calendar dates (Y-m-d). The returned controller supports getRange, setRange,
+ * setPreset({ days, endDate? }), clear, reset, and destroy.
+ */
+
+/**
+ * External dependencies
+ */
+import flatpickr from 'flatpickr';
+import 'flatpickr/dist/flatpickr.css';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './date-range.css';
+
+const DEFAULT_MAX_DAYS = 364;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseDate( value ) {
+	if ( ! DATE_PATTERN.test( value || '' ) ) {
+		return null;
+	}
+
+	const [ year, month, day ] = value.split( '-' ).map( Number );
+	const date = new Date( Date.UTC( year, month - 1, day ) );
+	return date.getUTCFullYear() === year &&
+		date.getUTCMonth() === month - 1 &&
+		date.getUTCDate() === day
+		? date
+		: null;
+}
+
+function formatDate( date ) {
+	return [
+		date.getFullYear(),
+		String( date.getMonth() + 1 ).padStart( 2, '0' ),
+		String( date.getDate() ).padStart( 2, '0' ),
+	].join( '-' );
+}
+
+function rangeDays( startDate, endDate ) {
+	return (
+		Math.round(
+			( parseDate( endDate ) - parseDate( startDate ) ) / 86400000
+		) + 1
+	);
+}
+
+function validateRange( startDate, endDate, maxDays ) {
+	if ( ! parseDate( startDate ) || ! parseDate( endDate ) ) {
+		throw new TypeError(
+			'Date ranges require valid Y-m-d start and end values.'
+		);
+	}
+
+	const days = rangeDays( startDate, endDate );
+	if ( days < 1 || days > maxDays ) {
+		throw new RangeError( `Date ranges must span 1 to ${ maxDays } days.` );
+	}
+}
+
+function makeNavigationAccessible( instance, controls ) {
+	controls.forEach( ( { element, handler } ) =>
+		element.removeEventListener( 'keydown', handler )
+	);
+	controls.length = 0;
+
+	[
+		[
+			instance.prevMonthNav,
+			__( 'Previous month', 'extrachill-analytics' ),
+		],
+		[ instance.nextMonthNav, __( 'Next month', 'extrachill-analytics' ) ],
+	].forEach( ( [ element, label ] ) => {
+		element.setAttribute( 'role', 'button' );
+		element.setAttribute( 'tabindex', '0' );
+		element.setAttribute( 'aria-label', label );
+		const handler = ( event ) => {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
+				event.preventDefault();
+				element.click();
+			}
+		};
+		element.addEventListener( 'keydown', handler );
+		controls.push( { element, handler } );
+	} );
+}
+
+function create( input, options = {} ) {
+	if ( ! ( input instanceof window.HTMLInputElement ) ) {
+		throw new TypeError( 'Date range input must be an HTMLInputElement.' );
+	}
+
+	const maxDays = Math.min(
+		DEFAULT_MAX_DAYS,
+		Math.max( 1, Number( options.maxDays ) || DEFAULT_MAX_DAYS )
+	);
+	const initial =
+		options.startDate || options.endDate
+			? { startDate: options.startDate, endDate: options.endDate }
+			: null;
+	if ( initial ) {
+		validateRange( initial.startDate, initial.endDate, maxDays );
+	}
+
+	let current = initial ? { ...initial } : null;
+	let destroyed = false;
+	const controls = [];
+	const reportError = options.onError || ( () => {} );
+	const picker = flatpickr( input, {
+		mode: 'range',
+		dateFormat: 'Y-m-d',
+		allowInput: false,
+		defaultDate: initial
+			? [ initial.startDate, initial.endDate ]
+			: undefined,
+		onReady( _dates, _value, instance ) {
+			makeNavigationAccessible( instance, controls );
+		},
+		onMonthChange( _dates, _value, instance ) {
+			makeNavigationAccessible( instance, controls );
+		},
+		onYearChange( _dates, _value, instance ) {
+			makeNavigationAccessible( instance, controls );
+		},
+		onChange( dates, _value, instance ) {
+			if ( dates.length === 0 ) {
+				current = null;
+				options.onChange?.( null );
+				return;
+			}
+			if ( dates.length !== 2 ) {
+				return;
+			}
+
+			const range = {
+				startDate: formatDate( dates[ 0 ] ),
+				endDate: formatDate( dates[ 1 ] ),
+			};
+			try {
+				validateRange( range.startDate, range.endDate, maxDays );
+				current = range;
+				options.onChange?.( { ...range } );
+			} catch ( error ) {
+				instance.clear( false );
+				current = null;
+				reportError( error );
+			}
+		},
+	} );
+
+	function assertActive() {
+		if ( destroyed ) {
+			throw new Error( 'Date range controller has been destroyed.' );
+		}
+	}
+
+	function setRange( startDate, endDate, trigger = true ) {
+		assertActive();
+		validateRange( startDate, endDate, maxDays );
+		current = { startDate, endDate };
+		picker.setDate( [ startDate, endDate ], false );
+		if ( trigger ) {
+			options.onChange?.( { ...current } );
+		}
+	}
+
+	return {
+		picker,
+		getRange: () => ( current ? { ...current } : null ),
+		setRange,
+		setPreset( preset ) {
+			assertActive();
+			const days = Math.max( 1, Number( preset?.days ) || 0 );
+			if ( days > maxDays ) {
+				throw new RangeError(
+					`Date ranges must span 1 to ${ maxDays } days.`
+				);
+			}
+			const end = parseDate(
+				preset?.endDate || new Date().toISOString().slice( 0, 10 )
+			);
+			if ( ! end ) {
+				throw new TypeError(
+					'Preset endDate must be a valid Y-m-d value.'
+				);
+			}
+			const start = new Date( end );
+			start.setUTCDate( start.getUTCDate() - days + 1 );
+			setRange(
+				start.toISOString().slice( 0, 10 ),
+				end.toISOString().slice( 0, 10 )
+			);
+		},
+		clear() {
+			assertActive();
+			picker.clear();
+		},
+		reset() {
+			assertActive();
+			if ( initial ) {
+				setRange( initial.startDate, initial.endDate );
+			} else {
+				picker.clear();
+			}
+		},
+		destroy() {
+			if ( destroyed ) {
+				return;
+			}
+			controls.forEach( ( { element, handler } ) =>
+				element.removeEventListener( 'keydown', handler )
+			);
+			controls.length = 0;
+			destroyed = true;
+			picker.destroy();
+		},
+	};
+}
+
+const ExtraChillAnalyticsDateRange = { create, maxDays: DEFAULT_MAX_DAYS };
+window.ExtraChillAnalyticsDateRange = ExtraChillAnalyticsDateRange;
+
+export default ExtraChillAnalyticsDateRange;

--- a/src/date-range.test.js
+++ b/src/date-range.test.js
@@ -1,0 +1,135 @@
+/* global beforeEach, describe, expect, it, jest */
+
+const mockFlatpickr = jest.fn();
+
+jest.mock( 'flatpickr', () => ( {
+	__esModule: true,
+	default: ( input, options ) => mockFlatpickr( input, options ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( { __: ( text ) => text } ), {
+	virtual: true,
+} );
+
+/**
+ * Internal dependencies
+ */
+import DateRange from './date-range';
+
+describe( 'shared analytics date range', () => {
+	let input;
+	let instance;
+	let config;
+
+	beforeEach( () => {
+		document.body.innerHTML = '<input id="range">';
+		input = document.querySelector( '#range' );
+		mockFlatpickr.mockReset();
+		mockFlatpickr.mockImplementation( ( _input, options ) => {
+			config = options;
+			instance = {
+				prevMonthNav: document.createElement( 'span' ),
+				nextMonthNav: document.createElement( 'span' ),
+				setDate: jest.fn(),
+				clear: jest.fn( ( trigger = true ) => {
+					if ( trigger ) {
+						config.onChange( [], '', instance );
+					}
+				} ),
+				destroy: jest.fn(),
+			};
+			options.onReady( [], '', instance );
+			return instance;
+		} );
+	} );
+
+	it( 'hydrates canonical dates and emits complete ranges only', () => {
+		const onChange = jest.fn();
+		const controller = DateRange.create( input, {
+			startDate: '2026-07-01',
+			endDate: '2026-07-28',
+			onChange,
+		} );
+
+		expect( config.defaultDate ).toEqual( [ '2026-07-01', '2026-07-28' ] );
+		config.onChange( [ new Date( 2026, 6, 2 ) ], '', instance );
+		expect( onChange ).not.toHaveBeenCalled();
+		config.onChange(
+			[ new Date( 2026, 6, 2 ), new Date( 2026, 6, 8 ) ],
+			'',
+			instance
+		);
+		expect( onChange ).toHaveBeenCalledWith( {
+			startDate: '2026-07-02',
+			endDate: '2026-07-08',
+		} );
+		expect( controller.getRange() ).toEqual( {
+			startDate: '2026-07-02',
+			endDate: '2026-07-08',
+		} );
+	} );
+
+	it( 'supports keyboard navigation and removes handlers on destroy', () => {
+		const controller = DateRange.create( input );
+		const click = jest.fn();
+		instance.prevMonthNav.addEventListener( 'click', click );
+
+		expect( instance.prevMonthNav.getAttribute( 'role' ) ).toBe( 'button' );
+		expect( instance.prevMonthNav.getAttribute( 'aria-label' ) ).toBe(
+			'Previous month'
+		);
+		instance.prevMonthNav.dispatchEvent(
+			new window.KeyboardEvent( 'keydown', { key: 'Enter' } )
+		);
+		expect( click ).toHaveBeenCalledTimes( 1 );
+
+		controller.destroy();
+		instance.prevMonthNav.dispatchEvent(
+			new window.KeyboardEvent( 'keydown', { key: 'Enter' } )
+		);
+		expect( click ).toHaveBeenCalledTimes( 1 );
+		expect( instance.destroy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'clears, resets, and applies bounded presets', () => {
+		const onChange = jest.fn();
+		const controller = DateRange.create( input, {
+			startDate: '2026-07-01',
+			endDate: '2026-07-28',
+			onChange,
+			maxDays: 30,
+		} );
+
+		controller.clear();
+		expect( onChange ).toHaveBeenLastCalledWith( null );
+		controller.reset();
+		expect( instance.setDate ).toHaveBeenLastCalledWith(
+			[ '2026-07-01', '2026-07-28' ],
+			false
+		);
+		controller.setPreset( { days: 7, endDate: '2026-08-04' } );
+		expect( onChange ).toHaveBeenLastCalledWith( {
+			startDate: '2026-07-29',
+			endDate: '2026-08-04',
+		} );
+		expect( () =>
+			controller.setPreset( { days: 31, endDate: '2026-08-04' } )
+		).toThrow( RangeError );
+	} );
+
+	it( 'rejects oversized picker selections without delivering a change', () => {
+		const onChange = jest.fn();
+		const onError = jest.fn();
+		DateRange.create( input, { maxDays: 7, onChange, onError } );
+
+		config.onChange(
+			[ new Date( 2026, 6, 1 ), new Date( 2026, 6, 8 ) ],
+			'',
+			instance
+		);
+
+		expect( onChange ).not.toHaveBeenCalled();
+		expect( onError.mock.calls[ 0 ][ 0 ] ).toBeInstanceOf( RangeError );
+		expect( instance.clear ).toHaveBeenCalledWith( false );
+	} );
+} );

--- a/tests/ConversionMapOutcomesTest.php
+++ b/tests/ConversionMapOutcomesTest.php
@@ -242,6 +242,7 @@ final class ConversionMapOutcomesTest extends TestCase {
 		$this->assertSame( 501, end( $consumed ) );
 		$this->assertCount( 2, $db->prepared_queries );
 		$this->assertStringContainsString( 'ORDER BY created_at ASC, id ASC', $db->prepared_queries[0]['query'] );
+		$this->assertStringContainsString( 'created_at < %s', $db->prepared_queries[0]['query'] );
 		$this->assertStringContainsString( 'id > %d', $db->prepared_queries[1]['query'] );
 		$this->assertSame( 500, end( $db->prepared_queries[1]['args'] ) );
 	}

--- a/tests/DateRangeAssetTest.php
+++ b/tests/DateRangeAssetTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Tests for the shared date-range asset ownership contract.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/** Verify registration remains lazy and network-consumable. */
+final class DateRangeAssetTest extends TestCase {
+	/** Both frontend and admin hooks register without unconditional enqueueing. */
+	public function test_asset_is_registered_on_demand_for_both_request_surfaces(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source fixture.
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/assets.php' );
+
+		$this->assertNotFalse( $source );
+		$this->assertStringContainsString( "const EXTRACHILL_ANALYTICS_DATE_RANGE_HANDLE = 'extrachill-analytics-date-range';", $source );
+		$this->assertStringContainsString( "add_action( 'wp_enqueue_scripts', 'extrachill_analytics_register_date_range_asset', 5 );", $source );
+		$this->assertStringContainsString( "add_action( 'admin_enqueue_scripts', 'extrachill_analytics_register_date_range_asset', 5 );", $source );
+		$this->assertStringContainsString( 'wp_register_script(', $source );
+		$this->assertStringContainsString( 'wp_register_style(', $source );
+		$this->assertStringNotContainsString( "wp_enqueue_script(\n\t\tEXTRACHILL_ANALYTICS_DATE_RANGE_HANDLE", $source );
+	}
+}

--- a/tests/DateRangeContractTest.php
+++ b/tests/DateRangeContractTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Tests for shared inclusive analytics date windows.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/** Verify validation, boundaries, and per-report contracts. */
+final class DateRangeContractTest extends TestCase {
+	/** Exact ranges expose an exclusive UTC SQL boundary. */
+	public function test_resolves_inclusive_dates_to_utc_boundaries(): void {
+		$window = extrachill_analytics_resolve_date_range(
+			array(
+				'start_date' => '2026-02-27',
+				'end_date'   => '2026-03-02',
+			)
+		);
+
+		$this->assertIsArray( $window );
+		$this->assertSame( 4, $window['days'] );
+		$this->assertSame( '2026-02-27 00:00:00', $window['start_at'] );
+		$this->assertSame( '2026-03-03 00:00:00', $window['end_exclusive'] );
+	}
+
+	/** The comparison window is adjacent and exactly equal in length. */
+	public function test_previous_window_is_immediately_adjacent(): void {
+		$window   = extrachill_analytics_resolve_date_range(
+			array(
+				'start_date' => '2026-07-08',
+				'end_date'   => '2026-07-14',
+			)
+		);
+		$previous = extrachill_analytics_previous_date_range( $window );
+
+		$this->assertSame( '2026-07-01', $previous['start_date'] );
+		$this->assertSame( '2026-07-07', $previous['end_date'] );
+		$this->assertSame( $window['start_at'], $previous['end_exclusive'] );
+	}
+
+	/** Invalid, partial, reversed, and oversized selections fail before caching. */
+	public function test_rejects_invalid_and_oversized_ranges(): void {
+		$this->assertTrue( is_wp_error( extrachill_analytics_resolve_date_range( array( 'start_date' => '2026-01-01' ) ) ) );
+		$this->assertTrue(
+			is_wp_error(
+				extrachill_analytics_resolve_date_range(
+					array(
+						'start_date' => '2026-02-30',
+						'end_date'   => '2026-03-01',
+					)
+				)
+			)
+		);
+		$this->assertTrue(
+			is_wp_error(
+				extrachill_analytics_resolve_date_range(
+					array(
+						'start_date' => '2026-03-02',
+						'end_date'   => '2026-03-01',
+					)
+				)
+			)
+		);
+		$this->assertTrue(
+			is_wp_error(
+				extrachill_analytics_resolve_date_range(
+					array(
+						'start_date' => '2025-01-01',
+						'end_date'   => '2026-01-01',
+					)
+				)
+			)
+		);
+	}
+
+	/** Each report preserves its honest historical cutoff semantics. */
+	public function test_report_sources_use_canonical_exact_bounds(): void {
+		$retention  = $this->source( 'get-retention-stats.php' );
+		$growth     = $this->source( 'get-surface-growth.php' );
+		$conversion = $this->source( 'get-conversion-map.php' );
+
+		$this->assertStringContainsString( '$date_range[\'end_exclusive\']', $retention );
+		$this->assertStringContainsString( 'strtotime( "-{$cohort_weeks} weeks", strtotime( $now_utc ) )', $retention );
+		$this->assertStringContainsString( 'extrachill_analytics_previous_date_range( $date_range )', $growth );
+		$this->assertStringContainsString( 'post_date_gmt >= %s AND post_date_gmt < %s', $growth );
+		$this->assertStringNotContainsString( 'get_blog_option( $blog_id, \'gmt_offset\'', $growth );
+		$this->assertStringContainsString( "'created_at < %s'", $conversion );
+		$this->assertStringContainsString( 'AND e.created_at < %s', $conversion );
+		$this->assertStringContainsString( '$window_end_ts - ( $return_observation_days * DAY_IN_SECONDS )', $conversion );
+	}
+
+	/**
+	 * Read one report source fixture.
+	 *
+	 * @param string $file Ability filename.
+	 * @return string Source.
+	 */
+	private function source( $file ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source fixture.
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/abilities/' . $file );
+		$this->assertNotFalse( $source );
+		return $source;
+	}
+}

--- a/tests/ReportResultCacheTest.php
+++ b/tests/ReportResultCacheTest.php
@@ -65,6 +65,26 @@ final class ReportResultCacheTest extends TestCase {
 		);
 	}
 
+	/** Canonical selected windows remain part of report identity. */
+	public function test_cache_key_distinguishes_exact_date_windows(): void {
+		$first = extrachill_analytics_report_cache_key(
+			'surface_growth',
+			array(
+				'start_date' => '2026-07-01',
+				'end_date'   => '2026-07-28',
+			)
+		);
+		$next  = extrachill_analytics_report_cache_key(
+			'surface_growth',
+			array(
+				'start_date' => '2026-07-02',
+				'end_date'   => '2026-07-29',
+			)
+		);
+
+		$this->assertNotSame( $first, $next );
+	}
+
 	/**
 	 * A warm read returns the original measurement without recomputation.
 	 */

--- a/tests/SurfaceGrowthRequestTest.php
+++ b/tests/SurfaceGrowthRequestTest.php
@@ -69,4 +69,30 @@ final class SurfaceGrowthRequestTest extends TestCase {
 		$this->assertTrue( $result['not_instrumented'] );
 		$this->assertStringContainsString( 'truncated daily series', $result['reason'] );
 	}
+
+	/** Exact ranges pass the selected and preceding windows through unchanged. */
+	public function test_exact_range_uses_equal_preceding_ga_window(): void {
+		$ability = new SurfaceGrowthGaAbilityFixture();
+		$current = extrachill_analytics_resolve_date_range(
+			array(
+				'start_date' => '2026-07-08',
+				'end_date'   => '2026-07-14',
+			)
+		);
+		$prior   = extrachill_analytics_previous_date_range( $current );
+
+		extrachill_analytics_surface_demand_growth(
+			array( 'host' => 'extrachill.com' ),
+			$ability,
+			true,
+			7,
+			$current,
+			$prior
+		);
+
+		$this->assertSame( '2026-07-08', $ability->requests[0]['start_date'] );
+		$this->assertSame( '2026-07-14', $ability->requests[0]['end_date'] );
+		$this->assertSame( '2026-07-01', $ability->requests[1]['start_date'] );
+		$this->assertSame( '2026-07-07', $ability->requests[1]['end_date'] );
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -946,3 +946,4 @@ require_once dirname( __DIR__ ) . '/inc/core/php-error-log.php';
 require_once dirname( __DIR__ ) . '/inc/core/abilities/get-php-error-summary.php';
 require_once dirname( __DIR__ ) . '/inc/core/security-classifier.php';
 require_once dirname( __DIR__ ) . '/inc/core/retention-cohorts.php';
+require_once dirname( __DIR__ ) . '/inc/core/date-range.php';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,14 @@
  *
  * Extends @wordpress/scripts defaults for React admin app.
  */
+/**
+ * WordPress dependencies
+ */
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+
+/**
+ * External dependencies
+ */
 const path = require( 'path' );
 
 module.exports = {
@@ -14,6 +21,9 @@ module.exports = {
 		// `extrachill-analytics-chart` handle and externalized by consumers.
 		// See extrachill-analytics#93 and src/chart.js.
 		chart: './src/chart.js',
+		// Shared framework-neutral Flatpickr range runtime. Consumers declare the
+		// `extrachill-analytics-date-range` WordPress script/style dependency.
+		'date-range': './src/date-range.js',
 	},
 	output: {
 		...defaultConfig.output,


### PR DESCRIPTION
## Summary
- Own Flatpickr in the network-activated Analytics plugin and register lazy frontend/admin `extrachill-analytics-date-range` script and style handles, following the existing shared Chart.js ownership direction.
- Expose the framework-neutral `window.ExtraChillAnalyticsDateRange.create(input, options)` API with canonical `Y-m-d` values, complete-range-only delivery, keyboard-accessible month navigation, clear/reset, presets, bounded ranges, and idempotent cleanup.
- Add validated inclusive `start_date` / `end_date` support to Retention, Surface Growth, and Conversion Map while preserving existing relative callers and report-specific measurement semantics.

## Ownership And Runtime Contract
Extra Chill Analytics is network-activated and already owns shared analytics visualization infrastructure. Bundling Flatpickr here gives Studio, Artist Analytics, and future analytics consumers one on-demand runtime without coupling them to Data Machine Events or a UI framework.

Consumers declare both Analytics-owned handles and call:

```js
const controller = window.ExtraChillAnalyticsDateRange.create(input, {
    startDate: '2026-07-01',
    endDate: '2026-07-28',
    maxDays: 364,
    onChange(range) {},
});
```

The controller exposes `getRange()`, `setRange()`, `setPreset()`, `clear()`, `reset()`, `destroy()`, and the underlying `picker`. Values are canonical UTC calendar dates. `onChange` receives only complete ranges or `null` for an intentional clear. The shared maximum is 364 days; consumers may configure a lower maximum.

## Report Date Semantics
- **Retention:** exact dates bound rolling metrics as `[start_date 00:00:00, day-after-end_date 00:00:00)` UTC. Historical cohort acquisition, W1/W2 activity, censoring, and maturity are observed only through the selected end cutoff. Relative `days` / `end_days_ago` behavior remains unchanged and cohorts remain anchored to now for relative reads.
- **Surface Growth:** exact dates use the selected inclusive window and the immediately preceding equal-length inclusive comparison window. GA requests receive those dates unchanged. Supply reads `post_date_gmt` with an exclusive UTC upper bound, avoiding DST-offset reconstruction. Existing `weeks` callers retain the current rolling supply window and GA-through-yesterday behavior.
- **Conversion Map:** exact dates retain the one-session-gap lower context buffer but strictly cap pageviews and successful outcomes at the day after `end_date`. Entry maturity is measured against that same selected cutoff, preserving equal return-observation opportunity. Existing `days` callers retain their rolling-now window.

Each exact report includes canonical `start_date` / `end_date` output. Canonical selected windows participate in report cache identity; exact dates take precedence over legacy relative inputs.

## Compatibility
- Existing `days`, `end_days_ago`, and `weeks` callers continue to work without input changes.
- No assets are enqueued network-wide; consumers opt in through WordPress dependencies.
- No Studio or Artist Platform consumer code is changed in this PR.
- No Data Machine Events dependency or cross-layer runtime coupling is introduced.

## Verification
- `composer test` (409 tests, 1642 assertions)
- `npm run test:js -- --runInBand` (4 tests)
- `npm run build`
- Scoped WordPress ESLint and stylelint for the new runtime
- Scoped PHPCS for changed contracts and tests
- Homeboy changed-file lint, including PHPStan level 7, ESLint, and PHPCS (passed with no new findings)
- Homeboy PR architecture audit (no introduced findings)
- Homeboy production build and ZIP structure validation (passed; date-range JS/CSS/RTL/asset metadata packaged)
- PHP syntax checks for all changed PHP files
- `git diff --check`

## Follow-Up
Studio Network and Artist Analytics should each add their own placement/state wrappers and declare the shared Analytics script/style handles in separate consumer PRs.

Closes #231