### PR TITLE
Support exact link-page analytics dates

### DIFF
--- a/inc/core/abilities/get-link-page-analytics.php
+++ b/inc/core/abilities/get-link-page-analytics.php
@@ -8,6 +8,7 @@
  * @package ExtraChill\Analytics
  * @since 0.8.0
  */
+
 declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
@@ -33,6 +34,14 @@ function extrachill_analytics_register_get_link_page_analytics_ability(): void {
 						'type'        => 'integer',
 						'description' => __( 'Number of days to query. Defaults to 30.', 'extrachill-analytics' ),
 						'default'     => 30,
+					),
+					'start_date'   => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive start date in Y-m-d format. Requires end_date.', 'extrachill-analytics' ),
+					),
+					'end_date'     => array(
+						'type'        => 'string',
+						'description' => __( 'Inclusive end date in Y-m-d format. Requires start_date.', 'extrachill-analytics' ),
 					),
 				),
 				'required'   => array( 'link_page_id' ),
@@ -74,6 +83,11 @@ function extrachill_analytics_register_get_link_page_analytics_ability(): void {
 function extrachill_analytics_ability_get_link_page_analytics( array $input ) {
 	$link_page_id = isset( $input['link_page_id'] ) ? (int) $input['link_page_id'] : 0;
 	$date_range   = isset( $input['date_range'] ) ? (int) $input['date_range'] : 30;
+	$date_window  = extrachill_analytics_resolve_date_range( $input, 90 );
+
+	if ( is_wp_error( $date_window ) ) {
+		return $date_window;
+	}
 
 	if ( $link_page_id <= 0 ) {
 		return new \WP_Error(
@@ -111,8 +125,12 @@ function extrachill_analytics_ability_get_link_page_analytics( array $input ) {
 		);
 	}
 
-	/** @var array|WP_Error|null $result */
-	$result = apply_filters( 'extrachill_get_link_page_analytics', null, $link_page_id, $date_range );
+	/**
+	 * Analytics provider result.
+	 *
+	 * @var array|WP_Error|null $result
+	 */
+	$result = apply_filters( 'extrachill_get_link_page_analytics', null, $link_page_id, $date_range, $date_window );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;

--- a/inc/core/link-page-analytics.php
+++ b/inc/core/link-page-analytics.php
@@ -43,7 +43,7 @@ add_action( 'extrachill_link_click_recorded', 'extrachill_analytics_handle_link_
 /*
  * ECA read provider for the extrachill_get_link_page_analytics filter.
  */
-add_filter( 'extrachill_get_link_page_analytics', 'extrachill_analytics_provide_link_page_analytics', 20, 3 );
+add_filter( 'extrachill_get_link_page_analytics', 'extrachill_analytics_provide_link_page_analytics', 20, 4 );
 
 /**
  * Supplies link-page analytics data for the extrachill_get_link_page_analytics
@@ -55,12 +55,17 @@ add_filter( 'extrachill_get_link_page_analytics', 'extrachill_analytics_provide_
  *   chart_data{labels[],datasets[{label,data[]}]}
  *   top_links[{text,identifier,clicks}]
  *
- * @param mixed $data         Prior filter value (unused).
- * @param int   $link_page_id Link page post ID.
- * @param int   $date_range   Number of days to include (1-90).
+ * The optional fourth argument preserves the numeric third argument used by the
+ * extrachill-api and artist-platform consumers while allowing this provider's
+ * ability to pass a canonical exact window.
+ *
+ * @param mixed      $data         Prior filter value (unused).
+ * @param int        $link_page_id Link page post ID.
+ * @param int        $date_range   Number of days to include (1-90).
+ * @param array|null $date_window  Canonical exact inclusive date window.
  * @return array|WP_Error
  */
-function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id, $date_range ) {
+function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id, $date_range, $date_window = null ) {
 	global $wpdb;
 
 	$link_page_id = absint( $link_page_id );
@@ -68,13 +73,18 @@ function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id,
 		return new WP_Error( 'invalid_link_page', 'Invalid or missing link page ID.', array( 'status' => 400 ) );
 	}
 
-	$range = absint( $date_range );
-	$range = $range ? $range : 30;
-	$range = max( 1, min( 90, $range ) );
-
-	$today       = current_time( 'Y-m-d' );
-	$start_stamp = strtotime( $today . ' -' . ( $range - 1 ) . ' days' );
-	$start_date  = gmdate( 'Y-m-d', $start_stamp );
+	if ( is_array( $date_window ) ) {
+		$range      = (int) $date_window['days'];
+		$start_date = $date_window['start_date'];
+		$end_date   = $date_window['end_date'];
+	} else {
+		$range       = absint( $date_range );
+		$range       = $range ? $range : 30;
+		$range       = max( 1, min( 90, $range ) );
+		$end_date    = current_time( 'Y-m-d' );
+		$start_stamp = strtotime( $end_date . ' -' . ( $range - 1 ) . ' days' );
+		$start_date  = gmdate( 'Y-m-d', (int) $start_stamp );
+	}
 
 	$views_table  = extrachill_analytics_link_page_views_table();
 	$clicks_table = extrachill_analytics_link_page_clicks_table();
@@ -84,7 +94,7 @@ function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id,
 			"SELECT stat_date, view_count FROM {$views_table} WHERE link_page_id = %d AND stat_date BETWEEN %s AND %s ORDER BY stat_date ASC", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $views_table is a code-defined table name; all values bound via prepare().
 			$link_page_id,
 			$start_date,
-			$today
+			$end_date
 		)
 	);
 
@@ -93,7 +103,7 @@ function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id,
 			"SELECT stat_date, SUM(click_count) AS click_count FROM {$clicks_table} WHERE link_page_id = %d AND stat_date BETWEEN %s AND %s GROUP BY stat_date ORDER BY stat_date ASC", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $clicks_table is a code-defined table name; all values bound via prepare().
 			$link_page_id,
 			$start_date,
-			$today
+			$end_date
 		)
 	);
 
@@ -102,7 +112,7 @@ function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id,
 			"SELECT link_url, link_text, SUM(click_count) AS total_clicks FROM {$clicks_table} WHERE link_page_id = %d AND stat_date BETWEEN %s AND %s GROUP BY link_url, link_text ORDER BY total_clicks DESC LIMIT 20", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $clicks_table is a code-defined table name; all values bound via prepare().
 			$link_page_id,
 			$start_date,
-			$today
+			$end_date
 		)
 	);
 
@@ -122,7 +132,7 @@ function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id,
 	$click_series = array();
 
 	for ( $i = 0; $i < $range; $i++ ) {
-		$date           = gmdate( 'Y-m-d', strtotime( $start_date . ' +' . $i . ' days' ) );
+		$date           = gmdate( 'Y-m-d', (int) strtotime( $start_date . ' +' . $i . ' days' ) );
 		$labels[]       = $date;
 		$view_series[]  = isset( $view_map[ $date ] ) ? $view_map[ $date ] : 0;
 		$click_series[] = isset( $click_map[ $date ] ) ? $click_map[ $date ] : 0;
@@ -143,6 +153,9 @@ function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id,
 	);
 
 	return array(
+		'start_date' => $start_date,
+		'end_date'   => $end_date,
+		'days'       => $range,
 		'summary'    => array(
 			'total_views'  => $total_views,
 			'total_clicks' => $total_clicks,

--- a/inc/core/link-page-analytics.php
+++ b/inc/core/link-page-analytics.php
@@ -43,7 +43,7 @@ add_action( 'extrachill_link_click_recorded', 'extrachill_analytics_handle_link_
 /*
  * ECA read provider for the extrachill_get_link_page_analytics filter.
  */
-add_filter( 'extrachill_get_link_page_analytics', 'extrachill_analytics_provide_link_page_analytics', 20, 4 );
+add_filter( 'extrachill_get_link_page_analytics', 'extrachill_analytics_provide_link_page_analytics', 20, 5 );
 
 /**
  * Supplies link-page analytics data for the extrachill_get_link_page_analytics
@@ -55,17 +55,19 @@ add_filter( 'extrachill_get_link_page_analytics', 'extrachill_analytics_provide_
  *   chart_data{labels[],datasets[{label,data[]}]}
  *   top_links[{text,identifier,clicks}]
  *
- * The optional fourth argument preserves the numeric third argument used by the
- * extrachill-api and artist-platform consumers while allowing this provider's
- * ability to pass a canonical exact window.
+ * The optional exact-window arguments preserve the numeric third argument used
+ * by existing consumers. The Analytics ability passes a canonical window as
+ * argument four; external consumers may pass raw start/end strings as arguments
+ * four and five for validation by this owning provider.
  *
- * @param mixed      $data         Prior filter value (unused).
- * @param int        $link_page_id Link page post ID.
- * @param int        $date_range   Number of days to include (1-90).
- * @param array|null $date_window  Canonical exact inclusive date window.
+ * @param mixed             $data         Prior filter value (unused).
+ * @param int               $link_page_id Link page post ID.
+ * @param int               $date_range   Number of days to include (1-90).
+ * @param array|string|null $date_window Canonical window or raw start date.
+ * @param string|null       $end_date_input Raw inclusive end date.
  * @return array|WP_Error
  */
-function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id, $date_range, $date_window = null ) {
+function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id, $date_range, $date_window = null, $end_date_input = null ) {
 	global $wpdb;
 
 	$link_page_id = absint( $link_page_id );
@@ -77,6 +79,20 @@ function extrachill_analytics_provide_link_page_analytics( $data, $link_page_id,
 		$range      = (int) $date_window['days'];
 		$start_date = $date_window['start_date'];
 		$end_date   = $date_window['end_date'];
+	} elseif ( is_string( $date_window ) || is_string( $end_date_input ) ) {
+		$resolved_window = extrachill_analytics_resolve_date_range(
+			array(
+				'start_date' => is_string( $date_window ) ? $date_window : '',
+				'end_date'   => is_string( $end_date_input ) ? $end_date_input : '',
+			),
+			90
+		);
+		if ( is_wp_error( $resolved_window ) ) {
+			return $resolved_window;
+		}
+		$range      = (int) $resolved_window['days'];
+		$start_date = $resolved_window['start_date'];
+		$end_date   = $resolved_window['end_date'];
 	} else {
 		$range       = absint( $date_range );
 		$range       = $range ? $range : 30;

--- a/tests/LinkPageAnalyticsDateRangeTest.php
+++ b/tests/LinkPageAnalyticsDateRangeTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Tests for exact link-page analytics date windows.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/database/link-page-analytics-db.php';
+require_once dirname( __DIR__ ) . '/inc/core/link-page-analytics.php';
+
+/** Verify validation, SQL bounds, compatibility, and response metadata. */
+final class LinkPageAnalyticsDateRangeTest extends TestCase {
+	/** Install deterministic database and site-calendar fixtures. */
+	protected function setUp(): void {
+		$GLOBALS['extrachill_analytics_test_current_time'] = gmmktime( 12, 0, 0, 3, 10, 2026 );
+		$GLOBALS['wpdb']                                   = new class() {
+			/**
+			 * Database table prefix.
+			 *
+			 * @var string
+			 */
+			public $prefix = 'wp_4_';
+
+			/**
+			 * Executed SELECT statements.
+			 *
+			 * @var string[]
+			 */
+			public $queries = array();
+
+			/**
+			 * Substitute integer and string placeholders for query assertions.
+			 *
+			 * @param string $query SQL query.
+			 * @param mixed  ...$args Prepared values.
+			 * @return string Prepared fixture query.
+			 */
+			public function prepare( $query, ...$args ) {
+				foreach ( $args as $arg ) {
+					$replacement = is_int( $arg ) ? (string) $arg : "'" . (string) $arg . "'";
+					$query       = preg_replace( '/%[ds]/', $replacement, $query, 1 );
+				}
+				return $query;
+			}
+
+			/**
+			 * Return fixtures for views, daily clicks, and top links in query order.
+			 *
+			 * @param string $query SQL query.
+			 * @return array<object> Aggregate row fixtures.
+			 */
+			public function get_results( $query ) {
+				$this->queries[] = $query;
+				$index           = count( $this->queries );
+
+				if ( 1 === $index ) {
+					return array(
+						(object) array(
+							'stat_date'  => '2026-03-08',
+							'view_count' => '2',
+						),
+						(object) array(
+							'stat_date'  => '2026-03-10',
+							'view_count' => '5',
+						),
+					);
+				}
+				if ( 2 === $index ) {
+					return array(
+						(object) array(
+							'stat_date'   => '2026-03-08',
+							'click_count' => '1',
+						),
+						(object) array(
+							'stat_date'   => '2026-03-10',
+							'click_count' => '3',
+						),
+					);
+				}
+				return array(
+					(object) array(
+						'link_url'     => 'https://example.com',
+						'link_text'    => 'Example',
+						'total_clicks' => '4',
+					),
+				);
+			}
+		};
+	}
+
+	/** Exact dates override the numeric range across every query and chart bucket. */
+	public function test_exact_window_controls_queries_and_response(): void {
+		$window = extrachill_analytics_resolve_date_range(
+			array(
+				'start_date' => '2026-03-08',
+				'end_date'   => '2026-03-10',
+			),
+			90
+		);
+
+		$result = extrachill_analytics_provide_link_page_analytics( null, 42, 90, $window );
+
+		$this->assertSame( '2026-03-08', $result['start_date'] );
+		$this->assertSame( '2026-03-10', $result['end_date'] );
+		$this->assertSame( 3, $result['days'] );
+		$this->assertSame( array( '2026-03-08', '2026-03-09', '2026-03-10' ), $result['chart_data']['labels'] );
+		$this->assertSame( array( 2, 0, 5 ), $result['chart_data']['datasets'][0]['data'] );
+		$this->assertSame( array( 1, 0, 3 ), $result['chart_data']['datasets'][1]['data'] );
+		$this->assertSame(
+			array(
+				'total_views'  => 7,
+				'total_clicks' => 4,
+			),
+			$result['summary']
+		);
+		$this->assertSame( 4, $result['top_links'][0]['clicks'] );
+
+		$this->assertCount( 3, $GLOBALS['wpdb']->queries );
+		foreach ( $GLOBALS['wpdb']->queries as $query ) {
+			$this->assertStringContainsString( "stat_date BETWEEN '2026-03-08' AND '2026-03-10'", $query );
+		}
+	}
+
+	/** Numeric callers retain their inclusive relative site-calendar window. */
+	public function test_legacy_numeric_range_remains_supported(): void {
+		$result = extrachill_analytics_provide_link_page_analytics( null, 42, 2 );
+
+		$this->assertSame( '2026-03-09', $result['start_date'] );
+		$this->assertSame( '2026-03-10', $result['end_date'] );
+		$this->assertSame( 2, $result['days'] );
+		$this->assertSame( array( '2026-03-09', '2026-03-10' ), $result['chart_data']['labels'] );
+	}
+
+	/** The ability exposes paired dates and uses the shared 90-day validator. */
+	public function test_ability_date_contract_uses_shared_validation(): void {
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/abilities/get-link-page-analytics.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source fixture.
+
+		$this->assertStringContainsString( "'start_date'", $source );
+		$this->assertStringContainsString( "'end_date'", $source );
+		$this->assertStringContainsString( 'extrachill_analytics_resolve_date_range( $input, 90 )', $source );
+		$this->assertStringContainsString( '$date_range, $date_window', $source );
+
+		$partial = extrachill_analytics_resolve_date_range( array( 'start_date' => '2026-01-01' ), 90 );
+		$large   = extrachill_analytics_resolve_date_range(
+			array(
+				'start_date' => '2026-01-01',
+				'end_date'   => '2026-04-01',
+			),
+			90
+		);
+
+		$this->assertSame( 'invalid_analytics_date_range', $partial->code );
+		$this->assertSame( 'analytics_date_range_too_large', $large->code );
+	}
+}

--- a/tests/LinkPageAnalyticsDateRangeTest.php
+++ b/tests/LinkPageAnalyticsDateRangeTest.php
@@ -123,6 +123,18 @@ final class LinkPageAnalyticsDateRangeTest extends TestCase {
 		}
 	}
 
+	/** External consumers may pass raw paired dates to the owning provider. */
+	public function test_raw_exact_pair_is_validated_by_provider(): void {
+		$result = extrachill_analytics_provide_link_page_analytics( null, 42, 90, '2026-03-08', '2026-03-10' );
+
+		$this->assertSame( '2026-03-08', $result['start_date'] );
+		$this->assertSame( '2026-03-10', $result['end_date'] );
+		$this->assertSame( 3, $result['days'] );
+
+		$partial = extrachill_analytics_provide_link_page_analytics( null, 42, 90, '2026-03-08', '' );
+		$this->assertSame( 'invalid_analytics_date_range', $partial->code );
+	}
+
 	/** Numeric callers retain their inclusive relative site-calendar window. */
 	public function test_legacy_numeric_range_remains_supported(): void {
 		$result = extrachill_analytics_provide_link_page_analytics( null, 42, 2 );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -74,6 +74,31 @@ if ( ! function_exists( '__' ) ) {
 		return $text;
 	}
 }
+if ( ! function_exists( 'absint' ) ) {
+	/**
+	 * Return a non-negative integer fixture.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @return int Non-negative integer.
+	 */
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+if ( ! function_exists( 'current_time' ) ) {
+	/**
+	 * Return a site-calendar time fixture.
+	 *
+	 * @param string $format Date format.
+	 * @return string Formatted date.
+	 */
+	function current_time( $format ) {
+		$timestamp = isset( $GLOBALS['extrachill_analytics_test_current_time'] )
+			? (int) $GLOBALS['extrachill_analytics_test_current_time']
+			: time();
+		return gmdate( $format, $timestamp );
+	}
+}
 if ( ! function_exists( 'wp_json_encode' ) ) {
 	/**
 	 * Encode a fixture value as JSON.


### PR DESCRIPTION
## Summary
- accept paired `start_date` / `end_date` inputs through the link-page analytics ability and validate them with the shared 90-day resolver
- apply exact inclusive site-calendar bounds to views, clicks, top links, and zero-filled chart labels, returning canonical `start_date`, `end_date`, and `days`
- preserve legacy numeric callers by retaining `date_range` as the filter's third argument and adding the resolved exact window as an optional fourth argument

## Rationale and semantics
Artist Analytics needs the Analytics-owned provider to expose the same canonical date contract as the shared picker. Exact dates now take precedence over `date_range`; partial, invalid, reversed, and over-90-day pairs return the shared resolver errors. Daily aggregate rows remain site-calendar buckets, so date-only SQL uses inclusive `BETWEEN` bounds without UTC-offset conversion.

The filter seam remains compatible with the deployed `extrachill-api` and `extrachill-artist-platform` consumers, which both pass the numeric range as the third argument. The provider's fourth argument defaults to `null`, preserving their existing relative-window behavior. This report remains uncached, so no cache-key or invalidation behavior changes.

## Evidence
- `vendor/bin/phpunit tests/LinkPageAnalyticsDateRangeTest.php` (3 tests, 22 assertions)
- `vendor/bin/phpunit` (412 tests, 1664 assertions)
- changed-file WordPress PHPCS (no errors; existing direct-query warnings only)
- `homeboy review lint extrachill-analytics --path /var/lib/datamachine/workspace/extrachill-analytics@issue-236-link-page-dates --changed-since origin/main --placement local --summary` (PHPCS, ESLint, and PHPStan pass with zero findings)
- changed-file `php -l` and `git diff --check` pass
- tracked full-repository PHPCS was also run; it continues to report pre-existing baseline findings outside this change, while release-range PHPCS is clean

Closes #236