### PR TITLE
fix: prepare analytics schema before frontend writes

### DIFF
--- a/extrachill-analytics.php
+++ b/extrachill-analytics.php
@@ -25,6 +25,9 @@ require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/php-error-log-db.ph
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/mediavine-revenue-db.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/class-extrachill-analytics-revenue-store.php';
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/link-page-analytics-db.php';
+require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/database/network-schema.php';
+
+register_activation_hook( __FILE__, 'extrachill_analytics_activate' );
 
 // Core functionality (network-wide).
 require_once EXTRACHILL_ANALYTICS_PLUGIN_DIR . 'inc/core/event-types.php';

--- a/inc/core/events.php
+++ b/inc/core/events.php
@@ -32,6 +32,11 @@ function extrachill_track_analytics_event( $event_type, $event_data = array(), $
 		return false;
 	}
 
+	if ( ! extrachill_analytics_events_ensure_ready() ) {
+		error_log( 'extrachill_track_analytics_event failed: analytics events schema is not ready.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- intentional write-failure log without request data.
+		return false;
+	}
+
 	$table_name = extrachill_analytics_events_table();
 
 	// Server-side stitching: when the caller didn't supply a valid visitor id

--- a/inc/database/events-db.php
+++ b/inc/database/events-db.php
@@ -22,14 +22,16 @@ function extrachill_analytics_events_create_table() {
 	$current_db_version = get_site_option( EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION_OPTION );
 
 	if ( EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION === $current_db_version ) {
-		return;
+		return true;
 	}
 
 	global $wpdb;
 	$charset_collate = $wpdb->get_charset_collate();
 	$table_name      = $wpdb->base_prefix . 'extrachill_analytics_events';
 
-	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	if ( ! function_exists( 'dbDelta' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	}
 
 	$sql = "CREATE TABLE {$table_name} (
 		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -49,12 +51,48 @@ function extrachill_analytics_events_create_table() {
 		KEY visitor_created (visitor_id, created_at)
 	) {$charset_collate};";
 
+	$wpdb->last_error = '';
 	dbDelta( $sql );
 
+	if ( '' !== $wpdb->last_error ) {
+		return false;
+	}
+
 	update_site_option( EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION_OPTION, EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION );
+	return true;
 }
 
-add_action( 'admin_init', 'extrachill_analytics_events_create_table' );
+/**
+ * Check the cheap network option that marks the events schema ready.
+ *
+ * @return bool Whether the current events schema has been installed.
+ */
+function extrachill_analytics_events_schema_is_ready() {
+	return EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION === get_site_option( EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION_OPTION );
+}
+
+/**
+ * Ensure the events table is ready before the first write in this request.
+ *
+ * @return bool Whether writes may proceed.
+ */
+function extrachill_analytics_events_ensure_ready() {
+	static $ready = false;
+
+	if ( $ready || extrachill_analytics_events_schema_is_ready() ) {
+		$ready = true;
+		return true;
+	}
+
+	if ( function_exists( 'extrachill_analytics_install_network_schema' ) ) {
+		extrachill_analytics_install_network_schema();
+	} else {
+		extrachill_analytics_events_create_table();
+	}
+
+	$ready = extrachill_analytics_events_schema_is_ready();
+	return $ready;
+}
 
 /**
  * Get the analytics events table name.

--- a/inc/database/mediavine-revenue-db.php
+++ b/inc/database/mediavine-revenue-db.php
@@ -35,14 +35,16 @@ function extrachill_analytics_revenue_create_table() {
 	$current_db_version = get_site_option( EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION_OPTION );
 
 	if ( EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION === $current_db_version ) {
-		return;
+		return true;
 	}
 
 	global $wpdb;
 	$charset_collate = $wpdb->get_charset_collate();
 	$table_name      = extrachill_analytics_revenue_table();
 
-	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	if ( ! function_exists( 'dbDelta' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	}
 
 	// One row per (blog_id, slug, period_label, import_batch). period_label is the
 	// canonical time bucket ("2026-05" for a monthly export, "all-time" for the
@@ -88,12 +90,16 @@ function extrachill_analytics_revenue_create_table() {
 		KEY import_batch_idx (import_batch)
 	) {$charset_collate};";
 
+	$wpdb->last_error = '';
 	dbDelta( $sql );
 
-	update_site_option( EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION_OPTION, EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION );
-}
+	if ( '' !== $wpdb->last_error ) {
+		return false;
+	}
 
-add_action( 'admin_init', 'extrachill_analytics_revenue_create_table' );
+	update_site_option( EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION_OPTION, EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION );
+	return true;
+}
 
 /**
  * Get the Mediavine revenue table name.

--- a/inc/database/network-schema.php
+++ b/inc/database/network-schema.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Network Database Schema Lifecycle
+ *
+ * @package ExtraChill\Analytics
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'EXTRACHILL_ANALYTICS_SCHEMA_LOCK_OPTION', 'extrachill_analytics_schema_migration_lock' );
+define( 'EXTRACHILL_ANALYTICS_SCHEMA_LOCK_TTL', 300 );
+
+/**
+ * Check whether every network-scoped analytics table is current.
+ *
+ * @return bool Whether all network schemas are ready.
+ */
+function extrachill_analytics_network_schema_is_ready() {
+	return EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION === get_site_option( EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION_OPTION )
+		&& EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION === get_site_option( EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION )
+		&& EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION === get_site_option( EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION_OPTION );
+}
+
+/**
+ * Atomically claim the network schema migration, recovering abandoned locks.
+ *
+ * @return bool Whether this request owns the migration lock.
+ */
+function extrachill_analytics_claim_schema_lock() {
+	$now = time();
+
+	if ( add_site_option( EXTRACHILL_ANALYTICS_SCHEMA_LOCK_OPTION, $now ) ) {
+		return true;
+	}
+
+	$locked_at = (int) get_site_option( EXTRACHILL_ANALYTICS_SCHEMA_LOCK_OPTION, 0 );
+	if ( $locked_at > $now - EXTRACHILL_ANALYTICS_SCHEMA_LOCK_TTL ) {
+		return false;
+	}
+
+	delete_site_option( EXTRACHILL_ANALYTICS_SCHEMA_LOCK_OPTION );
+	return add_site_option( EXTRACHILL_ANALYTICS_SCHEMA_LOCK_OPTION, $now );
+}
+
+/**
+ * Install or upgrade all network-scoped analytics tables.
+ *
+ * Version checks make the normal request path cheap. The atomic network option
+ * serializes dbDelta calls when multiple frontend requests arrive during an
+ * upgrade or immediately after a restore.
+ *
+ * @return bool Whether every network schema is ready.
+ */
+function extrachill_analytics_install_network_schema() {
+	if ( extrachill_analytics_network_schema_is_ready() ) {
+		return true;
+	}
+
+	if ( ! extrachill_analytics_claim_schema_lock() ) {
+		return extrachill_analytics_network_schema_is_ready();
+	}
+
+	try {
+		extrachill_analytics_events_create_table();
+		extrachill_analytics_php_error_create_table();
+		extrachill_analytics_revenue_create_table();
+	} finally {
+		delete_site_option( EXTRACHILL_ANALYTICS_SCHEMA_LOCK_OPTION );
+	}
+
+	return extrachill_analytics_network_schema_is_ready();
+}
+
+/**
+ * Install the network schema during explicit plugin activation.
+ *
+ * @param bool $network_wide Whether WordPress activated the plugin network-wide.
+ */
+function extrachill_analytics_activate( $network_wide = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+	extrachill_analytics_install_network_schema();
+}
+
+add_action( 'plugins_loaded', 'extrachill_analytics_install_network_schema' );

--- a/inc/database/php-error-log-db.php
+++ b/inc/database/php-error-log-db.php
@@ -24,14 +24,16 @@ function extrachill_analytics_php_error_create_table() {
 	$current_db_version = get_site_option( EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION );
 
 	if ( EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION === $current_db_version ) {
-		return;
+		return true;
 	}
 
 	global $wpdb;
 	$charset_collate = $wpdb->get_charset_collate();
 	$table_name      = $wpdb->base_prefix . 'extrachill_analytics_php_errors';
 
-	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	if ( ! function_exists( 'dbDelta' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	}
 
 	$sql = "CREATE TABLE {$table_name} (
 		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -50,12 +52,16 @@ function extrachill_analytics_php_error_create_table() {
 		KEY snapshot_day_idx (snapshot_day)
 	) {$charset_collate};";
 
+	$wpdb->last_error = '';
 	dbDelta( $sql );
 
-	update_site_option( EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION, EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION );
-}
+	if ( '' !== $wpdb->last_error ) {
+		return false;
+	}
 
-add_action( 'admin_init', 'extrachill_analytics_php_error_create_table' );
+	update_site_option( EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION, EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION );
+	return true;
+}
 
 /**
  * Get the PHP error daily counts table name.

--- a/tests/SchemaReadinessTest.php
+++ b/tests/SchemaReadinessTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Network schema lifecycle coverage.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/schema-readiness-fixtures.php';
+
+/**
+ * Verify activation, upgrades, and the public-write readiness guard.
+ */
+final class SchemaReadinessTest extends TestCase {
+	/**
+	 * Install a minimal database fixture.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['extrachill_analytics_test_site_options'] = array();
+		$GLOBALS['extrachill_analytics_test_dbdelta']      = array();
+		$GLOBALS['extrachill_analytics_test_migrations']   = array();
+		$GLOBALS['wpdb']                                   = new class() {
+			/**
+			 * Network table prefix.
+			 *
+			 * @var string
+			 */
+			public $base_prefix = 'wp_';
+
+			/**
+			 * Site table prefix.
+			 *
+			 * @var string
+			 */
+			public $prefix = 'wp_';
+
+			/**
+			 * Last database error.
+			 *
+			 * @var string
+			 */
+			public $last_error = '';
+
+			/**
+			 * Return a deterministic charset clause.
+			 *
+			 * @return string Charset clause.
+			 */
+			public function get_charset_collate() {
+				return 'DEFAULT CHARACTER SET utf8mb4';
+			}
+		};
+	}
+
+	/**
+	 * Fresh network activation creates every table without an admin request.
+	 */
+	public function test_fresh_activation_prepares_frontend_event_write_without_admin_init(): void {
+		extrachill_analytics_activate( true );
+
+		$this->assertTrue( extrachill_analytics_network_schema_is_ready() );
+		$this->assertSame( array( 'events', 'php-errors' ), $GLOBALS['extrachill_analytics_test_migrations'] );
+		$this->assertCount( 1, $GLOBALS['extrachill_analytics_test_dbdelta'] );
+		$this->assertSame(
+			EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION,
+			get_site_option( EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION_OPTION )
+		);
+		$this->assertArrayNotHasKey( EXTRACHILL_ANALYTICS_SCHEMA_LOCK_OPTION, $GLOBALS['extrachill_analytics_test_site_options'] );
+	}
+
+	/**
+	 * Current schemas avoid dbDelta during lifecycle and write readiness checks.
+	 */
+	public function test_current_schema_short_circuits_without_migration(): void {
+		$GLOBALS['extrachill_analytics_test_site_options'] = array(
+			EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION_OPTION  => EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION,
+			EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION => EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION,
+			EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION_OPTION => EXTRACHILL_ANALYTICS_REVENUE_DB_VERSION,
+		);
+
+		$this->assertTrue( extrachill_analytics_install_network_schema() );
+		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_migrations'] );
+		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_dbdelta'] );
+	}
+
+	/**
+	 * A concurrent migration blocks duplicate schema work and event writes.
+	 */
+	public function test_active_migration_lock_prevents_concurrent_dbdelta(): void {
+		$GLOBALS['extrachill_analytics_test_site_options'][ EXTRACHILL_ANALYTICS_SCHEMA_LOCK_OPTION ] = time();
+
+		$this->assertFalse( extrachill_analytics_install_network_schema() );
+		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_migrations'] );
+		$this->assertSame( array(), $GLOBALS['extrachill_analytics_test_dbdelta'] );
+	}
+
+	/**
+	 * The public writer checks readiness before resolving or inserting its table.
+	 */
+	public function test_public_write_guard_precedes_insert(): void {
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/core/events.php' );
+		$guard  = strpos( $source, 'extrachill_analytics_events_ensure_ready()' );
+		$table  = strpos( $source, '$table_name = extrachill_analytics_events_table()' );
+		$insert = strpos( $source, '$wpdb->insert(' );
+
+		$this->assertNotFalse( $guard );
+		$this->assertNotFalse( $table );
+		$this->assertNotFalse( $insert );
+		$this->assertLessThan( $table, $guard );
+		$this->assertLessThan( $insert, $guard );
+	}
+
+	/**
+	 * The real events migration remains version-gated and admin-independent.
+	 */
+	public function test_events_migration_contract_is_idempotent_and_not_admin_gated(): void {
+		$source = file_get_contents( dirname( __DIR__ ) . '/inc/database/events-db.php' );
+
+		$this->assertStringContainsString( 'EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION === $current_db_version', $source );
+		$this->assertStringContainsString( 'function extrachill_analytics_events_ensure_ready()', $source );
+		$this->assertStringNotContainsString( "add_action( 'admin_init'", $source );
+	}
+}

--- a/tests/schema-readiness-fixtures.php
+++ b/tests/schema-readiness-fixtures.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Schema readiness lifecycle fixtures.
+ *
+ * @package ExtraChill\Analytics
+ */
+
+if ( ! defined( 'EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION' ) ) {
+	define( 'EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION', '1.2' );
+	define( 'EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION_OPTION', 'extrachill_analytics_events_db_version' );
+}
+if ( ! defined( 'EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION' ) ) {
+	define( 'EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION', '1.0' );
+	define( 'EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION', 'extrachill_analytics_php_error_db_version' );
+}
+if ( ! function_exists( 'extrachill_analytics_events_create_table' ) ) {
+	/**
+	 * Record the events migration fixture.
+	 *
+	 * @return bool True.
+	 */
+	function extrachill_analytics_events_create_table() {
+		$GLOBALS['extrachill_analytics_test_migrations'][] = 'events';
+		update_site_option( EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION_OPTION, EXTRACHILL_ANALYTICS_EVENTS_DB_VERSION );
+		return true;
+	}
+}
+if ( ! function_exists( 'extrachill_analytics_php_error_create_table' ) ) {
+	/**
+	 * Record the PHP error migration fixture.
+	 *
+	 * @return bool True.
+	 */
+	function extrachill_analytics_php_error_create_table() {
+		$GLOBALS['extrachill_analytics_test_migrations'][] = 'php-errors';
+		update_site_option( EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION_OPTION, EXTRACHILL_ANALYTICS_PHP_ERROR_DB_VERSION );
+		return true;
+	}
+}
+if ( ! function_exists( 'dbDelta' ) ) {
+	/**
+	 * Record a schema reconciliation fixture.
+	 *
+	 * @param string $sql Schema definition.
+	 * @return array Empty dbDelta result.
+	 */
+	function dbDelta( $sql ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid -- Mirrors the WordPress core API.
+		$GLOBALS['extrachill_analytics_test_dbdelta'][] = $sql;
+		return array();
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/database/mediavine-revenue-db.php';
+require_once dirname( __DIR__ ) . '/inc/database/network-schema.php';


### PR DESCRIPTION
## Summary
- install and upgrade all network-scoped analytics tables during plugin activation and `plugins_loaded`, independent of wp-admin traffic
- serialize stale schema migrations with an atomic network-option lock and only mark versions current after successful `dbDelta()` calls
- guard the first event write in each request with a cheap version readiness check, migrating when stale and avoiding writes while another migration owns the lock
- add lifecycle coverage for fresh activation without `admin_init`, already-current schemas, concurrent migration contention, and public-write guard ordering

## Lifecycle behavior
Fresh activation synchronously prepares the events, PHP error, and Mediavine revenue tables. Existing installations run the same idempotent installer on `plugins_loaded`; current schema versions short-circuit from cached network options without invoking `dbDelta()`. Event persistence performs a once-per-request readiness check as defense in depth before resolving or inserting into the network events table.

## Verification
- `composer test` (418 tests, 1,687 assertions)
- `vendor/bin/phpunit --filter SchemaReadinessTest` (5 tests, 19 assertions)
- changed-file PHPCS with WordPress standards and zero errors
- `php -l` on all modified production PHP files

Closes #238